### PR TITLE
Add 'skip_cleanup=true' to Travis script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script: ./.travis-build.sh
 deploy:
   provider: script
   script: ./.travis-publish.sh
+  skip_cleanup: true
   on:
     all_branches: true
     condition: $TRAVIS_BRANCH =~ ^(master|develop)$


### PR DESCRIPTION
This prevents build artifacts from being removed before the deploy
script runs.