### PR TITLE
SIMPLY-2529: Fixed the aspect ratio of catalog images.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ subprojects {
 ext.libraries = [
   androidAsync               : "com.koushikdutta.async:androidasync:2.2.1",
   androidXAppCompat          : "androidx.appcompat:appcompat:1.0.2",
+  androidXCardView           : "androidx.cardview:cardview:1.0.0",
   androidXConstraintLayout   : "androidx.constraintlayout:constraintlayout:1.1.3",
   androidXCore               : "androidx.core:core:1.1.0",
   androidXFragmentTesting    : "androidx.fragment:fragment-testing:1.1.0",

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverGenerator.java
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverGenerator.java
@@ -1,10 +1,6 @@
 package org.nypl.simplified.books.covers;
 
 import android.graphics.Bitmap;
-import android.graphics.Bitmap.Config;
-import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.Paint;
 
 import com.io7m.jnull.NullCheck;
 
@@ -67,8 +63,8 @@ public final class BookCoverGenerator implements BookCoverGeneratorType
 
   @Override public Bitmap generateImage(
     final URI u,
-    final int width,
-    final int height)
+    int width,
+    int height)
     throws IOException
   {
     try {
@@ -81,19 +77,20 @@ public final class BookCoverGenerator implements BookCoverGeneratorType
       final String author_maybe = params.get("author");
       final String author = author_maybe == null ? "" : NullCheck.notNull(author_maybe);
 
+      if (width == 0) {
+        width = (int) Math.round(height * .75);
+      }
+      if (height == 0) {
+        height = (int) Math.round(width / .75);
+      }
+
       final TenPrintInputBuilderType ib = TenPrintInput.newBuilder();
       ib.setAuthor(author);
       ib.setTitle(title);
       ib.setCoverHeight(height);
       final TenPrintInput i = ib.build();
       final Bitmap cover = this.generator.generate(i);
-      final Bitmap container = Bitmap.createBitmap(width, height, Config.RGB_565);
-      final Canvas c = new Canvas(container);
-      final Paint white = new Paint();
-      white.setColor(Color.WHITE);
-      c.drawRect(0.0F, 0.0F, (float) width, (float) height, white);
-      c.drawBitmap(cover, (float) ((width - cover.getWidth()) / 2), 0.0F, null);
-      return NullCheck.notNull(container);
+      return NullCheck.notNull(cover);
     } catch (final Throwable e) {
       LOG.error("error generating image for {}: ", u, e);
       throw new IOException(e);

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
@@ -36,16 +36,15 @@ class BookCoverProvider private constructor(
   private fun generateCoverURI(entry: FeedEntry.FeedEntryOPDS): URI {
     val feedEntry = entry.feedEntry
     val title = feedEntry.title
-    val author: String
     val authors = feedEntry.authors
-    if (authors.isEmpty()) {
-      author = ""
-    } else {
-      author = authors[0]
-    }
+    val author = authors.firstOrNull() ?: ""
     return this.coverGenerator.generateURIForTitleAuthor(title, author)
   }
 
+  /**
+   * @param width Use 0 as desired dimension to resize keeping aspect ratio.
+   * @param height Use 0 as desired dimension to resize keeping aspect ratio.
+   */
   private fun doLoad(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProviderType.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProviderType.kt
@@ -31,9 +31,8 @@ interface BookCoverProviderType {
    *
    * @param entry The feed entry
    * @param imageView The image view
-   * @param width The width
-   * @param height The height
-   * @param badges A function that will be consulted for badge images
+   * @param width Use 0 as desired dimension to resize keeping aspect ratio.
+   * @param height Use 0 as desired dimension to resize keeping aspect ratio.
    */
 
   fun loadThumbnailInto(
@@ -51,9 +50,8 @@ interface BookCoverProviderType {
    *
    * @param entry The feed entry
    * @param imageView The image view
-   * @param width The width
-   * @param height The height
-   * @param badges A function that will be consulted for badge images
+   * @param width Use 0 as desired dimension to resize keeping aspect ratio.
+   * @param height Use 0 as desired dimension to resize keeping aspect ratio.
    */
 
   fun loadCoverInto(

--- a/simplified-books-covers/src/main/res/drawable/cover_error.xml
+++ b/simplified-books-covers/src/main/res/drawable/cover_error.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
   <item>
-    <color android:color="#CFCFCF" />
+    <shape android:shape="rectangle">
+      <solid android:color="#CFCFCF" />
+      <size
+        android:width="@dimen/cover_thumbnail_width"
+        android:height="@dimen/cover_thumbnail_height" />
+    </shape>
   </item>
   <item
     android:width="32dp"

--- a/simplified-books-covers/src/main/res/drawable/cover_loading.xml
+++ b/simplified-books-covers/src/main/res/drawable/cover_loading.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
   <item>
-    <color android:color="#CFCFCF" />
+    <shape android:shape="rectangle">
+      <solid android:color="#CFCFCF" />
+      <size
+        android:width="@dimen/cover_thumbnail_width"
+        android:height="@dimen/cover_thumbnail_height" />
+    </shape>
   </item>
   <item
     android:width="32dp"

--- a/simplified-books-covers/src/main/res/values/dimens.xml
+++ b/simplified-books-covers/src/main/res/values/dimens.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <dimen name="cover_corner_radius">2dp</dimen>
+  <dimen name="cover_thumbnail_height">120dp</dimen>
+  <dimen name="cover_thumbnail_width">90dp</dimen>
+  <dimen name="cover_detail_height">160dp</dimen>
+  <dimen name="cover_detail_width">120dp</dimen>
+</resources>

--- a/simplified-ui-catalog/build.gradle
+++ b/simplified-ui-catalog/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   implementation project(":simplified-ui-toolbar")
 
   implementation libraries.androidXAppCompat
+  implementation libraries.androidXCardView
   implementation libraries.androidXConstraintLayout
   implementation libraries.androidXLifecycle
   implementation libraries.androidXPaging

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -35,7 +35,6 @@ import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.controller.api.BooksControllerType
 import org.nypl.simplified.books.covers.BookCoverProviderType
 import org.nypl.simplified.feeds.api.FeedEntry
-import org.nypl.simplified.futures.FluentFutureExtensions.map
 import org.nypl.simplified.navigation.api.NavigationControllers
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSAvailabilityHeld
@@ -91,7 +90,6 @@ class CatalogFragmentBookDetail : Fragment() {
   private lateinit var buttons: LinearLayout
   private lateinit var configurationService: CatalogConfigurationServiceType
   private lateinit var cover: ImageView
-  private lateinit var coverProgress: ProgressBar
   private lateinit var covers: BookCoverProviderType
   private lateinit var debugStatus: TextView
   private lateinit var format: TextView
@@ -187,9 +185,7 @@ class CatalogFragmentBookDetail : Fragment() {
       inflater.inflate(R.layout.book_detail, container, false)
 
     this.cover =
-      layout.findViewById(R.id.bookDetailCover)
-    this.coverProgress =
-      layout.findViewById(R.id.bookDetailCoverProgress)
+      layout.findViewById(R.id.bookDetailCoverImage)
     this.title =
       layout.findViewById(R.id.bookDetailTitle)
     this.format =
@@ -246,29 +242,11 @@ class CatalogFragmentBookDetail : Fragment() {
   override fun onStart() {
     super.onStart()
 
-    val shortAnimationDuration =
-      this.requireContext().resources.getInteger(android.R.integer.config_shortAnimTime)
-
-    this.cover.visibility = View.INVISIBLE
-    this.coverProgress.visibility = View.VISIBLE
-
+    val targetHeight =
+      resources.getDimensionPixelSize(R.dimen.cover_detail_height)
     this.covers.loadCoverInto(
-      this.parameters.feedEntry,
-      this.cover,
-      this.cover.layoutParams.width,
-      this.cover.layoutParams.height
-    ).map {
-      this.uiThread.runOnUIThread {
-        this.coverProgress.visibility = View.INVISIBLE
-
-        this.cover.visibility = View.VISIBLE
-        this.cover.alpha = 0.0f
-        this.cover.animate()
-          .alpha(1f)
-          .setDuration(shortAnimationDuration.toLong())
-          .setListener(null)
-      }
-    }
+      this.parameters.feedEntry, this.cover, 0, targetHeight
+    )
 
     /*
      * Retrieve the current status of the book, or synthesize a status value based on the

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogLaneItemViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogLaneItemViewHolder.kt
@@ -12,30 +12,25 @@ import org.nypl.simplified.feeds.api.FeedEntry
  * @see CatalogLaneItemViewHolder
  */
 class CatalogLaneItemViewHolder(
-  private val parent: View,
+  private val view: View,
   private val coverLoader: BookCoverProviderType,
   private val onBookSelected: (FeedEntry.FeedEntryOPDS) -> Unit
-) : RecyclerView.ViewHolder(parent) {
+) : RecyclerView.ViewHolder(view) {
 
-  private val imageView = parent as ImageView
-  private val imageWidth =
-    parent.resources.getDimensionPixelSize(R.dimen.catalogFeedCoversWidth)
-  private val imageHeight =
-    parent.resources.getDimensionPixelSize(R.dimen.catalogFeedCoversHeight)
+  private val imageView = view.findViewById<ImageView>(R.id.coverImage)
+  private val targetHeight =
+    view.resources.getDimensionPixelSize(org.nypl.simplified.books.covers.R.dimen.cover_thumbnail_height)
 
   fun bindTo(entry: FeedEntry.FeedEntryOPDS) {
-    imageView.contentDescription =
-      CatalogBookAccessibilityStrings.coverDescription(parent.resources, entry)
+    view.contentDescription =
+      CatalogBookAccessibilityStrings.coverDescription(view.resources, entry)
 
-    imageView.setOnClickListener {
+    view.setOnClickListener {
       onBookSelected.invoke(entry)
     }
 
     coverLoader.loadThumbnailInto(
-      entry = entry,
-      imageView = imageView,
-      width = imageWidth,
-      height = imageHeight
+      entry, imageView, 0, targetHeight
     )
   }
 }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -202,12 +202,12 @@ class CatalogPagedViewHolder(
     this.idleAuthor.text = item.feedEntry.authorsCommaSeparated
     this.errorTitle.text = item.feedEntry.title
 
+    val targetHeight =
+      parent.resources.getDimensionPixelSize(R.dimen.cover_thumbnail_height)
+    val targetWidth = 0
     this.thumbnailLoading =
       this.bookCovers.loadThumbnailInto(
-        item,
-        this.idleCover,
-        this.idleCover.layoutParams.width,
-        this.idleCover.layoutParams.height
+        item, this.idleCover, targetWidth, targetHeight
       ).map {
         this.uiThread.runOnUIThread {
           this.setVisibilityIfNecessary(this.idleProgress, View.INVISIBLE)

--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -13,28 +13,30 @@
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp">
+      android:layout_marginBottom="16dp"
+      android:clipChildren="false"
+      android:clipToPadding="false">
 
-      <ImageView
+      <androidx.cardview.widget.CardView
         android:id="@+id/bookDetailCover"
-        android:layout_width="120dp"
-        android:layout_height="160dp"
-        android:layout_marginStart="16dp"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/cover_thumbnail_height"
         android:layout_marginTop="16dp"
-        android:contentDescription="@string/catalogBookCoverDescription"
-        android:src="@drawable/cover"
+        android:layout_marginStart="16dp"
+        app:cardCornerRadius="@dimen/cover_corner_radius"
+        app:cardElevation="2dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
 
-      <ProgressBar
-        android:id="@+id/bookDetailCoverProgress"
-        style="?android:attr/progressBarStyle"
-        android:layout_width="32dp"
-        android:layout_height="32dp"
-        app:layout_constraintBottom_toBottomOf="@id/bookDetailCover"
-        app:layout_constraintEnd_toEndOf="@id/bookDetailCover"
-        app:layout_constraintStart_toStartOf="@id/bookDetailCover"
-        app:layout_constraintTop_toTopOf="@id/bookDetailCover" />
+        <ImageView
+          android:id="@+id/bookDetailCoverImage"
+          android:layout_width="wrap_content"
+          android:layout_height="match_parent"
+          android:adjustViewBounds="true"
+          android:contentDescription="@null"
+          android:scaleType="fitXY"
+          app:srcCompat="@drawable/cover_loading" />
+      </androidx.cardview.widget.CardView>
 
       <TextView
         android:id="@+id/bookDetailTitle"
@@ -79,7 +81,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/bookDetailCover"
         app:layout_constraintTop_toBottomOf="@id/bookDetailFormat" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <View

--- a/simplified-ui-catalog/src/main/res/layout/feed_lane.xml
+++ b/simplified-ui-catalog/src/main/res/layout/feed_lane.xml
@@ -2,13 +2,18 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
+  android:clipChildren="false"
+  android:clipToPadding="false"
   android:orientation="vertical">
 
   <TextView
     android:id="@+id/feedLaneTitle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="16dp"
+    android:layout_marginLeft="16dp"
+    android:layout_marginTop="16dp"
+    android:layout_marginRight="16dp"
+    android:layout_marginBottom="8dp"
     android:ellipsize="end"
     android:maxLines="1"
     android:text="@string/catalogPlaceholder"
@@ -19,8 +24,9 @@
   <androidx.recyclerview.widget.RecyclerView
     android:id="@+id/feedLaneCoversScroll"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/catalogFeedCoversHeight"
+    android:layout_height="wrap_content"
+    android:clipChildren="false"
     android:clipToPadding="false"
-    android:paddingStart="@dimen/catalogFeedCoversEndSpace"
-    android:paddingEnd="@dimen/catalogFeedCoversEndSpace" />
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp" />
 </LinearLayout>

--- a/simplified-ui-catalog/src/main/res/layout/feed_lane_item.xml
+++ b/simplified-ui-catalog/src/main/res/layout/feed_lane_item.xml
@@ -1,8 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="@dimen/catalogFeedCoversWidth"
-  android:layout_height="@dimen/catalogFeedCoversHeight"
-  android:contentDescription="@null"
-  android:scaleType="fitXY"
-  app:srcCompat="@drawable/cover_loading" />
+  android:layout_width="wrap_content"
+  android:layout_height="wrap_content"
+  android:clipChildren="false"
+  android:clipToPadding="false"
+  android:orientation="vertical">
+
+  <androidx.cardview.widget.CardView
+    android:layout_width="wrap_content"
+    android:layout_height="@dimen/cover_thumbnail_height"
+    app:cardCornerRadius="@dimen/cover_corner_radius"
+    app:cardElevation="2dp">
+
+    <ImageView
+      android:id="@+id/coverImage"
+      android:layout_width="wrap_content"
+      android:layout_height="match_parent"
+      android:adjustViewBounds="true"
+      android:contentDescription="@null"
+      android:scaleType="fitXY"
+      app:srcCompat="@drawable/cover_loading" />
+  </androidx.cardview.widget.CardView>
+</LinearLayout>

--- a/simplified-ui-catalog/src/main/res/layout/feed_with_groups.xml
+++ b/simplified-ui-catalog/src/main/res/layout/feed_with_groups.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/feedWithGroups"
@@ -14,9 +13,10 @@
     android:id="@+id/feedWithGroupsList"
     android:layout_width="0dp"
     android:layout_height="0dp"
+    android:clipChildren="false"
+    android:clipToPadding="false"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@id/feedWithGroupsHeader" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-ui-catalog/src/main/res/values/dimensions.xml
+++ b/simplified-ui-catalog/src/main/res/values/dimensions.xml
@@ -3,15 +3,10 @@
 <resources>
   <dimen name="catalogBookDetailStatusHeight">64dp</dimen>
   <dimen name="catalogBookDetailButtonsHeight">64dp</dimen>
-  <dimen name="catalogFeedCoversHeight">96dp</dimen>
-  <dimen name="catalogFeedCoversWidth">80dp</dimen>
-  <dimen name="catalogFeedCoversEndSpace">16dp</dimen>
   <dimen name="catalogFeedCoversSpace">8dp</dimen>
-
   <dimen name="catalogFeedCellImageWidth">80dp</dimen>
   <dimen name="catalogFeedCellHeight">128dp</dimen>
   <dimen name="catalogFeedCellButtonsHeight">32dp</dimen>
-
   <dimen name="catalogFacetTabStroke">1dp</dimen>
   <dimen name="catalogFacetTabCornerRadius">3dp</dimen>
   <dimen name="catalogFacetTabPaddingLeft">32dp</dimen>


### PR DESCRIPTION
Previously, catalog images were stretched or squished to fit in a fixed
size image view. This change updates the images to have a fixed height
with a variable width. This means covers will maintain their aspect
ratio. As a result, covers appear much sharper and more readable.

### Screens

- [covers-before](https://user-images.githubusercontent.com/107117/73719817-5d914000-46d5-11ea-895f-9d83127b91c1.png)
- [covers-after](https://user-images.githubusercontent.com/107117/73719818-5d914000-46d5-11ea-92b6-81f05f5aab4c.png)
