### PR TITLE
Use different heap settings for Travis CI

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,10 +1,21 @@
 #!/bin/sh
 
 #------------------------------------------------------------------------
+# Configure some Gradle settings that work better in CI containers
+
+cat <<EOF
+
+org.gradle.daemon=true
+org.gradle.configureondemand=true
+org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError
+
+EOF >> gradle.properties
+
+#------------------------------------------------------------------------
 # Execute the build
 
 ./gradlew clean test assemble \
   -Porg.librarysimplified.keyAlias=nypl \
   -Porg.librarysimplified.keyPassword=${NYPL_SIGNING_KEY_PASSWORD} \
-  -Porg.librarysimplified.storePassword=${NYPL_SIGNING_STORE_PASSWORD} \
-  -Porg.gradle.parallel=false
+  -Porg.librarysimplified.storePassword=${NYPL_SIGNING_STORE_PASSWORD}
+

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -8,5 +8,6 @@ exec ./gradlew clean test assemble \
   -Porg.librarysimplified.keyPassword=${NYPL_SIGNING_KEY_PASSWORD} \
   -Porg.librarysimplified.storePassword=${NYPL_SIGNING_STORE_PASSWORD} \
   -Porg.gradle.configureondemand=true \
-  -Porg.gradle.jvmargs="-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError"
+  -Porg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError" \
+  -Porg.gradle.parallel=false
 

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,21 +1,12 @@
 #!/bin/sh
 
 #------------------------------------------------------------------------
-# Configure some Gradle settings that work better in CI containers
-
-cat <<EOF
-
-org.gradle.daemon=true
-org.gradle.configureondemand=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError
-
-EOF >> gradle.properties
-
-#------------------------------------------------------------------------
 # Execute the build
 
 ./gradlew clean test assemble \
   -Porg.librarysimplified.keyAlias=nypl \
   -Porg.librarysimplified.keyPassword=${NYPL_SIGNING_KEY_PASSWORD} \
-  -Porg.librarysimplified.storePassword=${NYPL_SIGNING_STORE_PASSWORD}
+  -Porg.librarysimplified.storePassword=${NYPL_SIGNING_STORE_PASSWORD} \
+  -Porg.gradle.configureondemand=true \
+  -Porg.gradle.jvmargs="-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError"
 

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -7,7 +7,5 @@ exec ./gradlew clean test assemble \
   -Porg.librarysimplified.keyAlias=nypl \
   -Porg.librarysimplified.keyPassword=${NYPL_SIGNING_KEY_PASSWORD} \
   -Porg.librarysimplified.storePassword=${NYPL_SIGNING_STORE_PASSWORD} \
-  -Porg.gradle.configureondemand=true \
-  -Porg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError" \
   -Porg.gradle.parallel=false
 

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -3,7 +3,7 @@
 #------------------------------------------------------------------------
 # Execute the build
 
-./gradlew clean test assemble \
+exec ./gradlew clean test assemble \
   -Porg.librarysimplified.keyAlias=nypl \
   -Porg.librarysimplified.keyPassword=${NYPL_SIGNING_KEY_PASSWORD} \
   -Porg.librarysimplified.storePassword=${NYPL_SIGNING_STORE_PASSWORD} \

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,3 @@ VERSION_NAME=5.0.0-SNAPSHOT
 android.useAndroidX=true
 android.enableJetifier=true
 
-org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
**What's this do?**

This configures Gradle to use a different set of heap settings. These
settings have reduced build times on two similarly structured projects
to ~25% of their original times.

**Why are we doing this? (w/ JIRA link if applicable)**

Shorter builds times are preferable to longer ones!

**How should this be tested? / Do these changes have associated tests?**

No tests needed. If the Travis CI build passes, then this works.

**Dependencies for merging? Releasing to production?**

No dependencies.

**Has the application documentation been updated for these changes?**

No documentation changes required.

**Did someone actually run this code to verify it works?**

Travis CI will run the changes if this PR is merged.