### PR TITLE
Enable "Related books..." feeds

### DIFF
--- a/simplified-tests-sandbox/src/main/java/org/nypl/simplified/tests/sandbox/BookDetailActivity.kt
+++ b/simplified-tests-sandbox/src/main/java/org/nypl/simplified/tests/sandbox/BookDetailActivity.kt
@@ -30,11 +30,13 @@ import org.nypl.simplified.tests.MockBooksController
 import org.nypl.simplified.tests.MockDocumentStore
 import org.nypl.simplified.tests.MockProfilesController
 import org.nypl.simplified.tests.MutableServiceDirectory
+import org.nypl.simplified.ui.catalog.CatalogFeedArguments
 import org.nypl.simplified.ui.catalog.CatalogFragmentBookDetail
 import org.nypl.simplified.ui.catalog.CatalogFragmentBookDetailParameters
 import org.nypl.simplified.ui.screen.ScreenSizeInformation
 import org.nypl.simplified.ui.screen.ScreenSizeInformationType
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
+import java.net.URI
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -272,7 +274,12 @@ class BookDetailActivity : AppCompatActivity(), ServiceDirectoryProviderType {
       CatalogFragmentBookDetail.create(
         CatalogFragmentBookDetailParameters(
           accountId = profiles.profileAccountCurrent().id,
-          feedEntry = feedEntry
+          feedEntry = feedEntry,
+          feedArguments = CatalogFeedArguments.CatalogFeedArgumentsRemote(
+            title = "Some books",
+            feedURI = URI.create("urn:fake"),
+            isSearchResults = false
+          )
         ))
 
     this.registry.update(

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetailParameters.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetailParameters.kt
@@ -21,7 +21,13 @@ data class CatalogFragmentBookDetailParameters(
    * The OPDS feed entry.
    */
 
-  val feedEntry: FeedEntry.FeedEntryOPDS
+  val feedEntry: FeedEntry.FeedEntryOPDS,
+
+  /**
+   * The parameters of the feed that lead to this book detail page.
+   */
+
+  val feedArguments: CatalogFeedArguments
 
 ) : Serializable {
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
@@ -330,7 +330,7 @@ class CatalogFragmentFeed : Fragment() {
 
   private fun onBookSelected(opdsEntry: FeedEntry.FeedEntryOPDS) {
     this.findNavigationController()
-      .openBookDetail(opdsEntry)
+      .openBookDetail(this.parameters, opdsEntry)
   }
 
   private fun onFeedSelected(title: String, uri: URI) {

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogNavigationControllerType.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogNavigationControllerType.kt
@@ -18,7 +18,10 @@ interface CatalogNavigationControllerType : NavigationControllerType {
    * The catalog wants to open a book detail page.
    */
 
-  fun openBookDetail(entry: FeedEntryOPDS)
+  fun openBookDetail(
+    feedArguments: CatalogFeedArguments,
+    entry: FeedEntryOPDS
+  )
 
   /**
    * A catalog screen wants to open the error page.

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
@@ -221,11 +221,15 @@ class TabbedNavigationController private constructor(
     return this.navigator.stackSize(this.navigator.currentTab())
   }
 
-  override fun openBookDetail(entry: FeedEntry.FeedEntryOPDS) {
+  override fun openBookDetail(
+    feedArguments: CatalogFeedArguments,
+    entry: FeedEntry.FeedEntryOPDS
+  ) {
     val parameters =
       CatalogFragmentBookDetailParameters(
         accountId = this.profilesController.profileAccountCurrent().id,
-        feedEntry = entry
+        feedEntry = entry,
+        feedArguments = feedArguments
       )
 
     this.navigator.addFragment(


### PR DESCRIPTION
**What's this do?**
This adds the missing code necessary to show and use Related Books
feeds in book detail views.

**Why are we doing this? (w/ JIRA link if applicable)**
Fixes: https://jira.nypl.org/browse/SIMPLY-2565

**How should this be tested? / Do these changes have associated tests?**
Navigate to the book detail view of any book in the catalog that you know has related books in the collection. Observe that the "Related books..." section in the detail view is no longer greyed-out. Click the text to go to the related books feed.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m 