### PR TITLE
SIMPLY-2567: Don't activate leanback mode if the screen reader is enabled.

### DIFF
--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/ReaderActivity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/ReaderActivity.kt
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.util.concurrent.Executors
 
-
 /**
  * The main reader activity for reading an EPUB using Readium 2.
  */


### PR DESCRIPTION
This changes the behavior of the new reader to show a persistent toolbar
and system navigation if the screen reader (TalkBack) is enabled.
Previously, leanback mode would activate automatically putting the
reader into a fullscreen view. This can make it hard for users to
navigate when using accessibility services.