### PR TITLE
SIMPLY-2564: login prompt displays a login-button that covers up the EULA checkbox/instructions inside the prompt's modal.

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentLoginDialog.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentLoginDialog.kt
@@ -79,6 +79,7 @@ class CatalogFragmentLoginDialog : DialogFragment() {
   private lateinit var uiThread: UIThreadServiceType
   private lateinit var userName: EditText
   private lateinit var userNameLabel: TextView
+  private lateinit var lockFormOverlay: View
   private val parametersId = PARAMETERS_ID
   private var accountEventSubscription: Disposable? = null
 
@@ -88,14 +89,10 @@ class CatalogFragmentLoginDialog : DialogFragment() {
 
     val services = Services.serviceDirectory()
 
-    this.profilesController =
-      services.requireService(ProfilesControllerType::class.java)
-    this.uiThread =
-      services.requireService(UIThreadServiceType::class.java)
-    this.documents =
-      services.requireService(DocumentStoreType::class.java)
-    this.screenSize =
-      services.requireService(ScreenSizeInformationType::class.java)
+    this.profilesController = services.requireService(ProfilesControllerType::class.java)
+    this.uiThread = services.requireService(UIThreadServiceType::class.java)
+    this.documents = services.requireService(DocumentStoreType::class.java)
+    this.screenSize = services.requireService(ScreenSizeInformationType::class.java)
   }
 
   override fun onCreateView(
@@ -106,25 +103,17 @@ class CatalogFragmentLoginDialog : DialogFragment() {
     val layout =
       inflater.inflate(R.layout.login_dialog, container, false)
 
-    this.action =
-      layout.findViewById(R.id.loginButton)
-    this.eula =
-      layout.findViewById(R.id.loginEULA)
-    this.password =
-      layout.findViewById(R.id.loginPassword)
-    this.passwordLabel =
-      layout.findViewById(R.id.loginPasswordLabel)
-    this.progress =
-      layout.findViewById(R.id.loginProgressBar)
-    this.progressText =
-      layout.findViewById(R.id.loginProgressText)
-    this.userName =
-      layout.findViewById(R.id.loginUserName)
-    this.userNameLabel =
-      layout.findViewById(R.id.loginUserNameLabel)
+    this.action = layout.findViewById(R.id.loginButton)
+    this.eula = layout.findViewById(R.id.loginEULA)
+    this.password = layout.findViewById(R.id.loginPassword)
+    this.passwordLabel = layout.findViewById(R.id.loginPasswordLabel)
+    this.progress = layout.findViewById(R.id.loginProgressBar)
+    this.progressText = layout.findViewById(R.id.loginProgressText)
+    this.userName = layout.findViewById(R.id.loginUserName)
+    this.userNameLabel = layout.findViewById(R.id.loginUserNameLabel)
+    this.lockFormOverlay = layout.findViewById(R.id.lockFormOverlay)
 
-    this.fieldListener =
-      OnTextChangeListener(this::onFieldChanged)
+    this.fieldListener = OnTextChangeListener(this::onFieldChanged)
 
     this.action.isEnabled = false
     this.progress.visibility = View.INVISIBLE
@@ -135,9 +124,8 @@ class CatalogFragmentLoginDialog : DialogFragment() {
   override fun onStart() {
     super.onStart()
 
-    this.dialogModel =
-      ViewModelProviders.of(this.requireActivity())
-        .get(CatalogLoginViewModel::class.java)
+    this.dialogModel = ViewModelProviders.of(this.requireActivity())
+      .get(CatalogLoginViewModel::class.java)
 
     this.resizeDialog()
 
@@ -148,8 +136,7 @@ class CatalogFragmentLoginDialog : DialogFragment() {
 
     try {
       this.account =
-        this.profilesController.profileCurrent()
-          .account(this.parameters.accountId)
+        this.profilesController.profileCurrent().account(this.parameters.accountId)
     } catch (e: AccountsDatabaseNonexistentException) {
       this.dismiss()
       return
@@ -209,7 +196,7 @@ class CatalogFragmentLoginDialog : DialogFragment() {
           )
           window.setLayout(
             (this.screenSize.widthPixels * 0.8).toInt(),
-            (this.screenSize.heightPixels * 0.4).toInt())
+            (this.screenSize.heightPixels * 0.475).toInt())
         } else {
           this.logger.debug(
             "screen landscape ({}x{})",
@@ -317,12 +304,14 @@ class CatalogFragmentLoginDialog : DialogFragment() {
   }
 
   private fun unlockForm() {
+    this.lockFormOverlay.visibility = View.GONE
     this.userName.isEnabled = true
     this.action.isEnabled = true
     this.password.isEnabled = true
   }
 
   private fun lockForm() {
+    this.lockFormOverlay.visibility = View.VISIBLE
     this.userName.isEnabled = false
     this.action.isEnabled = false
     this.password.isEnabled = false

--- a/simplified-ui-catalog/src/main/res/layout/login_dialog.xml
+++ b/simplified-ui-catalog/src/main/res/layout/login_dialog.xml
@@ -79,32 +79,6 @@
       </TableRow>
     </TableLayout>
 
-    <TextView
-      android:id="@+id/loginProgressText"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      android:ellipsize="end"
-      android:gravity="center_horizontal"
-      android:maxLines="1"
-      android:text="@string/catalogPlaceholder"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/loginTable"
-      app:layout_constraintVertical_bias="1.0" />
-
-    <ProgressBar
-      android:id="@+id/loginProgressBar"
-      style="?android:attr/progressBarStyleHorizontal"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="16dp"
-      android:layout_marginBottom="16dp"
-      android:indeterminate="true"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/loginProgressText" />
-
     <CheckBox
       android:id="@+id/loginEULA"
       android:layout_width="0dp"
@@ -136,6 +110,32 @@
       android:background="@color/lock_form_overlay"
       android:visibility="gone"
       app:layout_constraintTop_toBottomOf="@id/loginTitle" />
+
+    <TextView
+        android:id="@+id/loginProgressText"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:ellipsize="end"
+        android:gravity="center_horizontal"
+        android:maxLines="1"
+        android:text="@string/catalogPlaceholder"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/loginTable"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <ProgressBar
+        android:id="@+id/loginProgressBar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:indeterminate="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/loginProgressText" />
 
   </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/simplified-ui-catalog/src/main/res/layout/login_dialog.xml
+++ b/simplified-ui-catalog/src/main/res/layout/login_dialog.xml
@@ -3,12 +3,14 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="wrap_content">
 
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="32dp">
+    android:layout_marginStart="32dp"
+    android:layout_marginTop="32dp"
+    android:layout_marginEnd="32dp">
 
     <TextView
       android:id="@+id/loginTitle"
@@ -77,6 +79,32 @@
       </TableRow>
     </TableLayout>
 
+    <TextView
+      android:id="@+id/loginProgressText"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="16dp"
+      android:ellipsize="end"
+      android:gravity="center_horizontal"
+      android:maxLines="1"
+      android:text="@string/catalogPlaceholder"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/loginTable"
+      app:layout_constraintVertical_bias="1.0" />
+
+    <ProgressBar
+      android:id="@+id/loginProgressBar"
+      style="?android:attr/progressBarStyleHorizontal"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="16dp"
+      android:layout_marginBottom="16dp"
+      android:indeterminate="true"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/loginProgressText" />
+
     <CheckBox
       android:id="@+id/loginEULA"
       android:layout_width="0dp"
@@ -88,45 +116,26 @@
       android:text="@string/loginEULA"
       app:layout_constraintEnd_toEndOf="@id/loginTable"
       app:layout_constraintStart_toStartOf="@id/loginTable"
-      app:layout_constraintTop_toBottomOf="@id/loginTable" />
-
-    <TextView
-      android:id="@+id/loginProgressText"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      android:ellipsize="end"
-      android:maxLines="1"
-      android:text="@string/catalogPlaceholder"
-      app:layout_constraintBottom_toTopOf="@id/loginProgressBar"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/loginEULA"
-      app:layout_constraintVertical_bias="1.0" />
-
-    <ProgressBar
-      android:id="@+id/loginProgressBar"
-      style="?android:attr/progressBarStyleHorizontal"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="16dp"
-      android:layout_marginBottom="16dp"
-      android:indeterminate="true"
-      app:layout_constraintBottom_toTopOf="@id/loginButton"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
+      app:layout_constraintTop_toBottomOf="@id/loginProgressBar" />
 
     <Button
       android:id="@+id/loginButton"
-      android:layout_width="80dp"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_margin="16dp"
       android:layout_marginBottom="16dp"
       android:text="@string/loginLogin"
-      app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent" />
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/loginEULA" />
+
+    <View
+      android:id="@+id/lockFormOverlay"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="@color/lock_form_overlay"
+      android:visibility="gone"
+      app:layout_constraintTop_toBottomOf="@id/loginTitle" />
 
   </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>
-

--- a/simplified-ui-theme/src/main/res/values/styles.xml
+++ b/simplified-ui-theme/src/main/res/values/styles.xml
@@ -196,7 +196,10 @@
   <color name="simplified_material_blue_grey_primary">#607d8b</color>
   <color name="simplified_material_blue_grey_primary_light">#8eacbb</color>
   <color name="simplified_material_blue_grey_primary_dark">#34515e</color>
-  
+
+  <!-- Login screen lock form overlay -->
+  <color name="lock_form_overlay">#b3ffffff</color>
+
   <!-- Predefined themes -->
   <!-- Automatically generated, see styles.sh -->
   <style name="SimplifiedTheme_NoActionBar_Red" parent="SimplifiedTheme.NoActionBar.Base">


### PR DESCRIPTION
**What's this do?**
This cleans up the login dialog a bit by adding a semi transparent background while loading, improving the login button accessibility by widening the  login button, and properly hiding/showing the loading progress.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2564: Login prompt displays a login-button that covers up the EULA checkbox/instructions inside the prompt's modal.](https://jira.nypl.org/browse/SIMPLY-2564)

**How should this be tested? / Do these changes have associated tests?**
Simply attempt top login to a library

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 