### PR TITLE
Update README and change Central properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,13 +36,13 @@ ext {
   androidMinimumSDKVersion = 21
   androidTargetSDKVersion = 28
 
-  if (!project.hasProperty("nexusUsername")) {
-    logger.warn("No nexusUsername property specified: Using an empty value")
-    nexusUsername = ""
+  if (!project.hasProperty("mavenCentralUsername")) {
+    logger.warn("No mavenCentralUsername property specified: Using an empty value")
+    mavenCentralUsername = ""
   }
-  if (!project.hasProperty("nexusPassword")) {
-    logger.warn("No nexusPassword property specified: Using an empty value")
-    nexusPassword = ""
+  if (!project.hasProperty("mavenCentralPassword")) {
+    logger.warn("No mavenCentralPassword property specified: Using an empty value")
+    mavenCentralPassword = ""
   }
 
   if (!project.hasProperty("org.librarysimplified.nexus.publish")) {
@@ -357,8 +357,8 @@ Automatic-Module-Name: ${POM_AUTOMATIC_MODULE_NAME}
           def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
           url = version.endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl
           credentials(PasswordCredentials) {
-            username nexusUsername
-            password nexusPassword
+            username mavenCentralUsername
+            password mavenCentralPassword
           }
         }
       }


### PR DESCRIPTION
This adds release instructions to the README.md file, and changes
the existing nexusUsername and nexusPassword properties to use less
confusing mavenCentralUsername and mavenCentralPassword names.

**What's this do?**
Updates documentation.

**Why are we doing this? (w/ JIRA link if applicable)**
Because we have insufficient documentation.

**How should this be tested? / Do these changes have associated tests?**
Not applicable.

**Dependencies for merging? Releasing to production?**
Not applicable.

**Has the application documentation been updated for these changes?**
Yes.

**Did someone actually run this code to verify it works?**
Not applicable.