### PR TITLE
SIMPLY-2627: Remove global 'Accept-Encoding: identity' header.

### DIFF
--- a/simplified-documents/src/main/java/org/nypl/simplified/documents/synced/SyncedDocument.java
+++ b/simplified-documents/src/main/java/org/nypl/simplified/documents/synced/SyncedDocument.java
@@ -122,7 +122,6 @@ public final class SyncedDocument extends SyncedDocumentAbstract
   @Override protected void documentOnReceipt(
     final int status,
     final InputStream data,
-    final long length,
     final String type,
     final File output)
     throws IOException

--- a/simplified-documents/src/main/java/org/nypl/simplified/documents/synced/SyncedDocumentAbstract.java
+++ b/simplified-documents/src/main/java/org/nypl/simplified/documents/synced/SyncedDocumentAbstract.java
@@ -103,7 +103,6 @@ public abstract class SyncedDocumentAbstract implements SyncedDocumentType
   protected abstract void documentOnReceipt(
     int status,
     InputStream data,
-    long length,
     String type,
     File output)
     throws IOException;
@@ -216,7 +215,7 @@ public abstract class SyncedDocumentAbstract implements SyncedDocumentType
   {
     final String type = this.getContentType(e.getResponseHeaders());
     this.documentOnReceipt(
-      e.getStatus(), e.getData(), e.getContentLength(), type, this.current_tmp);
+      e.getStatus(), e.getData(), type, this.current_tmp);
     this.saveResults(u);
   }
 
@@ -243,7 +242,6 @@ public abstract class SyncedDocumentAbstract implements SyncedDocumentType
     this.documentOnReceipt(
       e.getStatus(),
       e.getValue(),
-      e.getContentLength(),
       type,
       this.current_tmp);
 

--- a/simplified-downloader-core/src/main/java/org/nypl/simplified/downloader/core/DownloaderHTTP.java
+++ b/simplified-downloader-core/src/main/java/org/nypl/simplified/downloader/core/DownloaderHTTP.java
@@ -223,7 +223,7 @@ public final class DownloaderHTTP implements DownloaderType
             this.log.debug("download cancelled");
             this.listener.onDownloadCancelled(this);
           } else {
-            if (this.total != expected) {
+            if (this.total < expected) {
               this.log.error(
                 "received {} bytes but expected {}",
                 Long.valueOf(this.total),

--- a/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTP.java
+++ b/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTP.java
@@ -150,7 +150,6 @@ public final class HTTP implements HTTPType
         conn.setRequestProperty("Range", "bytes=" + offset + "-");
       }
       conn.setRequestProperty("User-Agent", this.user_agent);
-      conn.setRequestProperty("Accept-Encoding", "identity");
 
       if (content_type_opt.isSome()) {
         conn.setRequestProperty("Content-Type", ((Some<String>) content_type_opt).get());
@@ -248,7 +247,6 @@ public final class HTTP implements HTTPType
       conn.setRequestProperty("User-Agent", this.user_agent);
       conn.setReadTimeout(
         (int) TimeUnit.MILLISECONDS.convert(60L, TimeUnit.SECONDS));
-      conn.setRequestProperty("Accept-Encoding", "identity");
 
       if (auth_opt.isSome()) {
         final Some<HTTPAuthType> some = (Some<HTTPAuthType>) auth_opt;


### PR DESCRIPTION
**What's this do?**
This change allows the default HttpURLConnection to accept gzip
encoded responses.

**Why are we doing this? (w/ JIRA link if applicable)**
This will help us reduce bandwidth used and increase the speed of larger requests.

- https://github.com/NYPL-Simplified/library_registry/pull/163
- https://jira.nypl.org/browse/SIMPLY-2627

**How should this be tested? / Do these changes have associated tests?**
Make sure books can still be downloaded.

**Dependencies for merging? Releasing to production?**
None

**Did someone actually run this code to verify it works?**
Yes, me.