### PR TITLE
Show an error details button in account settings

### DIFF
--- a/simplified-ui-settings/src/main/res/layout/settings_account.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_account.xml
@@ -62,20 +62,32 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/settingsLoginProgress" />
 
-      <Button
-        android:id="@+id/settingsLoginButton"
+      <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:text="@string/settingsLogin"
-        android:enabled="false"
+        android:layout_margin="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/settingsLoginProgressText" />
+        app:layout_constraintTop_toBottomOf="@id/settingsLoginProgressText">
+
+        <Button
+          android:id="@+id/settingsLoginButtonErrorDetails"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginRight="16dp"
+          android:text="@string/errorDetailsTitle"
+          android:layout_weight="1"
+          android:enabled="true" />
+
+        <Button
+          android:id="@+id/settingsLoginButton"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:text="@string/settingsLogin"
+          android:layout_weight="1"
+          android:enabled="false" />
+      </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
**What's this do?**
This makes the necessary changes to show an "error details" button
when an account login/logout fails in the settings screen.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2665

**How should this be tested? / Do these changes have associated tests?**
Go to the settings screen for any account, and enter a username/password that you know to be wrong. When the server reports a login error, an error details button should be visible next to the "login" button. This button will take you to the standard error report page.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m 