### PR TITLE
Refresh books/holds views when switching tabs

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedArguments.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedArguments.kt
@@ -24,6 +24,12 @@ sealed class CatalogFeedArguments : Serializable {
   abstract val isSearchResults: Boolean
 
   /**
+   * `true` if the feed is a locally generated feed (such as the My Books or Holds view).
+   */
+
+  abstract val isLocallyGenerated: Boolean
+
+  /**
    * Arguments that specify a remote feed. Note that feeds consisting of books bundled into the
    * application are still considered to be "remote" because they consist of data that is effectively
    * external to the application.
@@ -33,7 +39,9 @@ sealed class CatalogFeedArguments : Serializable {
     override val title: String,
     val feedURI: URI,
     override val isSearchResults: Boolean
-  ) : CatalogFeedArguments()
+  ) : CatalogFeedArguments() {
+    override val isLocallyGenerated: Boolean = false
+  }
 
   /**
    * Arguments that specify whatever is the default remote feed for the account that is current
@@ -44,6 +52,7 @@ sealed class CatalogFeedArguments : Serializable {
     override val title: String
   ) : CatalogFeedArguments() {
     override val isSearchResults: Boolean = false
+    override val isLocallyGenerated: Boolean = false
   }
 
   /**
@@ -57,5 +66,6 @@ sealed class CatalogFeedArguments : Serializable {
     val selection: FeedBooksSelection
   ) : CatalogFeedArguments() {
     override val isSearchResults: Boolean = false
+    override val isLocallyGenerated: Boolean = true
   }
 }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
@@ -292,6 +292,14 @@ class CatalogFragmentFeed : Fragment() {
     this.accountSubscription =
       this.profilesController.accountEvents()
         .subscribe(this::onAccountEvent)
+
+    /*
+     * Refresh the feed if it is locally generated.
+     */
+
+    if (this.parameters.isLocallyGenerated) {
+      this.feedModel.reloadFeed(this.parameters)
+    }
   }
 
   private fun onAccountEvent(event: AccountEvent) {
@@ -304,12 +312,10 @@ class CatalogFragmentFeed : Fragment() {
     return when (event) {
       is AccountEventCreation.AccountEventCreationSucceeded,
       is AccountEventDeletion.AccountEventDeletionSucceeded -> {
-        when (this.parameters) {
-          is CatalogFeedArguments.CatalogFeedArgumentsRemoteAccountDefault,
-          is CatalogFeedArguments.CatalogFeedArgumentsRemote -> {
-          }
-          is CatalogFeedArguments.CatalogFeedArgumentsLocalBooks ->
-            this.feedModel.reloadFeed(this.parameters)
+        if (this.parameters.isLocallyGenerated) {
+          this.feedModel.reloadFeed(this.parameters)
+        } else {
+          // No reload necessary
         }
       }
       else -> {


### PR DESCRIPTION
**What's this do?**
This refreshes locally generated feeds when the user switches tabs.
In practice, this actually just means refreshing the feed model when
a given feed fragment is started (if the feed is locally generated).

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2666

**How should this be tested? / Do these changes have associated tests?**
Borrow a book in any collection. Switch to the My Books view and check that the book is present in the list.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m 