### PR TITLE
SIMPLY-2648: Show the problem report message when a book borrow fails.

### DIFF
--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountUnresolvableProviderException.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountUnresolvableProviderException.kt
@@ -6,4 +6,4 @@ import java.lang.Exception
  * An unresolvable provider was specified when trying to create an account.
  */
 
-class AccountUnresolvableProviderException : Exception()
+class AccountUnresolvableProviderException(message: String?) : Exception(message)

--- a/simplified-app-vanilla-with-profiles/src/main/res/xml/network_security_config.xml
+++ b/simplified-app-vanilla-with-profiles/src/main/res/xml/network_security_config.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">qa.circulation.librarysimplified.org</domain>
+  </domain-config>
   <debug-overrides>
     <trust-anchors>
       <certificates src="user"/>

--- a/simplified-app-vanilla/src/main/res/xml/network_security_config.xml
+++ b/simplified-app-vanilla/src/main/res/xml/network_security_config.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">qa.circulation.librarysimplified.org</domain>
+  </domain-config>
   <debug-overrides>
     <trust-anchors>
       <certificates src="user"/>

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountCreateTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountCreateTask.kt
@@ -118,7 +118,7 @@ class ProfileAccountCreateTask(
           this.taskRecorder.currentStepFailed(
             message = message.toString(),
             errorValue = AccountProviderResolutionFailed(resolution.errors()))
-          throw AccountUnresolvableProviderException()
+          throw AccountUnresolvableProviderException(message.toString())
         }
       }
     } catch (e: Exception) {

--- a/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTPProblemReport.java
+++ b/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTPProblemReport.java
@@ -107,6 +107,9 @@ public final class HTTPProblemReport implements Serializable
       if ("http://librarysimplified.org/terms/problem/loan-limit-reached".equals(type_value)) {
         return ProblemType.LoanLimitReached;
       }
+      if ("http://librarysimplified.org/terms/problem/hold-limit-reached".equals(type_value)) {
+        return ProblemType.HoldLimitReached;
+      }
     }
     return ProblemType.Unknown;
   }
@@ -125,35 +128,16 @@ public final class HTTPProblemReport implements Serializable
     return ProblemStatus.Unknown;
   }
 
-  /**
-   * Problem type enum.
-   */
   public enum ProblemType implements Serializable
   {
-    /**
-     * Loan limit reached problem.
-     */
     LoanLimitReached,
-    /**
-     * Unknown problem.
-     */
+    HoldLimitReached,
     Unknown
   }
 
-
-  /**
-   *
-   */
   public enum ProblemStatus implements Serializable
   {
-
-    /**
-     * Unauthorized problem
-     */
     Unauthorized,
-    /**
-     * Unknown problem.
-     */
     Unknown
   }
 }

--- a/simplified-main/src/main/res/values/stringsBookBorrow.xml
+++ b/simplified-main/src/main/res/values/stringsBookBorrow.xml
@@ -11,7 +11,7 @@
   <string name="borrowBookDatabaseCreateOrUpdate">Setting up book database entry…</string>
   <string name="borrowBookDatabaseFailed">Failed to update book database.</string>
   <string name="borrowBookDatabaseUpdated">Book database entry updated successfully.</string>
-  <string name="borrowBookFeedLoadingFailed">Failed to load a feed from the server (%1$s).</string>
+  <string name="borrowBookFeedLoadingFailed">Failed to load feed: %1$s</string>
   <string name="borrowBookFetchingCover">Fetching book cover…</string>
   <string name="borrowBookFulfill">Fulfilling loan…</string>
   <string name="borrowBookFulfillACSM">Fulfilling a book via an ACSM file…</string>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -49,6 +49,7 @@ import org.nypl.simplified.presentableerror.api.PresentableErrorType
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.nypl.simplified.taskrecorder.api.TaskStepResolution
+import org.nypl.simplified.taskrecorder.api.TaskStepResolution.TaskStepFailed
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.nypl.simplified.ui.screen.ScreenSizeInformationType
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
@@ -103,6 +104,7 @@ class CatalogFragmentBookDetail : Fragment() {
   private lateinit var screenSize: ScreenSizeInformationType
   private lateinit var status: ViewGroup
   private lateinit var statusFailed: ViewGroup
+  private lateinit var statusFailedText: TextView
   private lateinit var statusIdle: ViewGroup
   private lateinit var statusIdleText: TextView
   private lateinit var statusInProgress: ViewGroup
@@ -225,6 +227,8 @@ class CatalogFragmentBookDetail : Fragment() {
 
     this.statusFailed =
       this.status.findViewById(R.id.bookDetailStatusFailed)
+    this.statusFailedText =
+      this.status.findViewById(R.id.failedText)
 
     this.statusIdle.visibility = View.VISIBLE
     this.statusInProgress.visibility = View.INVISIBLE
@@ -527,6 +531,10 @@ class CatalogFragmentBookDetail : Fragment() {
     this.statusInProgress.visibility = View.INVISIBLE
     this.statusIdle.visibility = View.INVISIBLE
     this.statusFailed.visibility = View.VISIBLE
+
+    // Get the problem report message, if any.
+    this.statusFailedText.text =
+      bookStatus.problemReport?.problemDetail ?: getString(R.string.catalogOperationFailed)
   }
 
   @UiThread
@@ -831,6 +839,7 @@ class CatalogFragmentBookDetail : Fragment() {
     this.statusInProgress.visibility = View.INVISIBLE
     this.statusIdle.visibility = View.INVISIBLE
     this.statusFailed.visibility = View.VISIBLE
+    this.statusFailedText.text = getString(R.string.catalogOperationFailed)
   }
 
   @UiThread
@@ -857,6 +866,10 @@ class CatalogFragmentBookDetail : Fragment() {
     this.statusInProgress.visibility = View.INVISIBLE
     this.statusIdle.visibility = View.INVISIBLE
     this.statusFailed.visibility = View.VISIBLE
+
+    // Get the problem report message, if any.
+    this.statusFailedText.text =
+      bookStatus.problemReport?.problemDetail ?: getString(R.string.catalogOperationFailed)
   }
 
   @UiThread

--- a/simplified-ui-catalog/src/main/res/layout/book_detail_status.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail_status.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
   android:id="@+id/bookDetailStatus"
   android:layout_width="match_parent"
-  android:layout_height="@dimen/catalogBookDetailStatusHeight">
+  android:layout_height="@dimen/catalogBookDetailStatusHeight"
+  android:background="?attr/simplifiedColorPrimary">
 
   <include layout="@layout/book_detail_status_idle" />
-
   <include layout="@layout/book_detail_status_failed" />
-
   <include layout="@layout/book_detail_status_in_progress" />
 </FrameLayout>

--- a/simplified-ui-catalog/src/main/res/layout/book_detail_status_failed.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail_status_failed.xml
@@ -1,24 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/bookDetailStatusFailed"
-  android:background="?attr/simplifiedColorPrimary"
-  android:layout_width="match_parent"
-  android:layout_height="@dimen/catalogBookDetailStatusHeight">
+  tools:background="?attr/simplifiedColorPrimary"
+  tools:layout_height="@dimen/catalogBookDetailStatusHeight"
+  tools:layout_width="match_parent"
+  tools:parentTag="android.widget.FrameLayout">
 
   <TextView
     android:id="@+id/failedText"
-    android:layout_width="0dp"
-    android:layout_height="0dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="16dp"
+    android:ellipsize="end"
     android:gravity="center"
-    android:maxLines="1"
-    android:text="@string/catalogOperationFailed"
-    android:textAlignment="center"
+    android:maxLines="2"
     android:textColor="#fff"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+    tools:text="@string/catalogPlaceholder" />
+</merge>

--- a/simplified-ui-catalog/src/main/res/layout/book_detail_status_failed.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail_status_failed.xml
@@ -10,10 +10,12 @@
     android:id="@+id/failedText"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="16dp"
+    android:layout_marginStart="16dp"
+    android:layout_marginEnd="16dp"
     android:ellipsize="end"
     android:gravity="center"
     android:maxLines="2"
+    android:textAlignment="center"
     android:textColor="#fff"
     tools:text="@string/catalogPlaceholder" />
 </FrameLayout>

--- a/simplified-ui-catalog/src/main/res/layout/book_detail_status_failed.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail_status_failed.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/bookDetailStatusFailed"
-  tools:background="?attr/simplifiedColorPrimary"
-  tools:layout_height="@dimen/catalogBookDetailStatusHeight"
-  tools:layout_width="match_parent"
-  tools:parentTag="android.widget.FrameLayout">
+  android:layout_width="match_parent"
+  android:layout_height="@dimen/catalogBookDetailStatusHeight"
+  tools:background="?attr/simplifiedColorPrimary">
 
   <TextView
     android:id="@+id/failedText"
@@ -17,4 +16,4 @@
     android:maxLines="2"
     android:textColor="#fff"
     tools:text="@string/catalogPlaceholder" />
-</merge>
+</FrameLayout>

--- a/simplified-ui-catalog/src/main/res/layout/book_detail_status_idle.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail_status_idle.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/bookDetailStatusIdle"
-  tools:background="?attr/simplifiedColorPrimary"
-  tools:layout_height="@dimen/catalogBookDetailStatusHeight"
-  tools:layout_width="match_parent"
-  tools:parentTag="android.widget.FrameLayout">
+  android:layout_width="match_parent"
+  android:layout_height="@dimen/catalogBookDetailStatusHeight"
+  tools:background="?attr/simplifiedColorPrimary">
 
   <TextView
     android:id="@+id/idleText"
@@ -17,4 +16,4 @@
     android:maxLines="2"
     android:textColor="#fff"
     tools:text="@string/catalogPlaceholder" />
-</merge>
+</FrameLayout>

--- a/simplified-ui-catalog/src/main/res/layout/book_detail_status_idle.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail_status_idle.xml
@@ -10,10 +10,12 @@
     android:id="@+id/idleText"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="16dp"
+    android:layout_marginStart="16dp"
+    android:layout_marginEnd="16dp"
     android:ellipsize="end"
     android:gravity="center"
     android:maxLines="2"
+    android:textAlignment="center"
     android:textColor="#fff"
     tools:text="@string/catalogPlaceholder" />
 </FrameLayout>

--- a/simplified-ui-catalog/src/main/res/layout/book_detail_status_idle.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail_status_idle.xml
@@ -1,25 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/bookDetailStatusIdle"
-  android:layout_width="match_parent"
-  android:layout_height="@dimen/catalogBookDetailStatusHeight"
-  android:background="?attr/simplifiedColorPrimary">
+  tools:background="?attr/simplifiedColorPrimary"
+  tools:layout_height="@dimen/catalogBookDetailStatusHeight"
+  tools:layout_width="match_parent"
+  tools:parentTag="android.widget.FrameLayout">
 
   <TextView
     android:id="@+id/idleText"
-    android:layout_width="0dp"
-    android:layout_height="0dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:layout_margin="16dp"
     android:ellipsize="end"
-    android:gravity="center_horizontal|center_vertical"
-    android:maxLines="1"
-    android:text="@string/catalogPlaceholder"
+    android:gravity="center"
+    android:maxLines="2"
     android:textColor="#fff"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+    tools:text="@string/catalogPlaceholder" />
+</merge>

--- a/simplified-ui-catalog/src/main/res/layout/book_detail_status_in_progress.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail_status_in_progress.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/bookDetailStatusInProgress"
-  android:background="?attr/simplifiedColorPrimary"
   android:layout_width="match_parent"
-  android:layout_height="@dimen/catalogBookDetailStatusHeight">
+  android:layout_height="@dimen/catalogBookDetailStatusHeight"
+  tools:background="?attr/simplifiedColorPrimary">
 
   <TextView
     android:id="@+id/inProgressText"
@@ -14,11 +14,11 @@
     android:layout_marginStart="32dp"
     android:maxLength="4"
     android:maxLines="1"
-    android:text="@string/catalogPlaceholder"
     android:textColor="#fff"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+    app:layout_constraintTop_toTopOf="parent"
+    tools:text="@string/catalogPlaceholder" />
 
   <ProgressBar
     android:id="@+id/inProgressBar"
@@ -32,5 +32,4 @@
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toEndOf="@id/inProgressText"
     app:layout_constraintTop_toTopOf="parent" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageFragment.kt
+++ b/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageFragment.kt
@@ -1,11 +1,14 @@
 package org.nypl.simplified.ui.errorpage
 
+import android.graphics.Typeface
 import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.StyleSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.TableLayout
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -45,10 +48,8 @@ class ErrorPageFragment : Fragment() {
     }
   }
 
-  private lateinit var errorAttributesTable: TableLayout
-  private lateinit var errorAttributesTitle: TextView
+  private lateinit var errorDetails: TextView
   private lateinit var errorStepsList: RecyclerView
-  private lateinit var errorTitle: TextView
   private lateinit var listener: ErrorPageListenerType
   private lateinit var parameters: ErrorPageParameters<PresentableErrorType>
   private lateinit var sendButton: Button
@@ -79,12 +80,8 @@ class ErrorPageFragment : Fragment() {
     val viewRoot =
       inflater.inflate(R.layout.error_page, container, false)
 
-    this.errorTitle =
-      viewRoot.findViewById(R.id.errorTitle)
-    this.errorAttributesTitle =
-      viewRoot.findViewById(R.id.errorDetailsTitle)
-    this.errorAttributesTable =
-      viewRoot.findViewById(R.id.errorDetailsTable)
+    this.errorDetails =
+      viewRoot.findViewById(R.id.errorDetails)
     this.errorStepsList =
       viewRoot.findViewById(R.id.errorSteps)
     this.sendButton =
@@ -95,25 +92,24 @@ class ErrorPageFragment : Fragment() {
         as ErrorPageParameters<PresentableErrorType>
 
     if (parameters.attributes.isEmpty()) {
-      this.errorAttributesTable.visibility = View.GONE
-      this.errorAttributesTitle.visibility = View.GONE
+      this.errorDetails.visibility = View.GONE
     } else {
-      this.errorAttributesTable.removeAllViews()
+      this.errorDetails.text = ""
 
-      for (key in parameters.attributes.keys) {
-        val value =
-          parameters.attributes[key]
-        val tableRow =
-          inflater.inflate(R.layout.error_attribute_row, this.errorAttributesTable, false)
-        val tableCell0 =
-          tableRow.findViewById<TextView>(R.id.errorAttributeKey)
-        val tableCell1 =
-          tableRow.findViewById<TextView>(R.id.errorAttributeValue)
+      val ssb = SpannableStringBuilder()
+      parameters.attributes.entries.forEachIndexed { index, (key, value) ->
+        if (index > 0) { ssb.append("\n\n") }
+        ssb.append(key)
 
-        tableCell0.text = key
-        tableCell1.text = value
-        this.errorAttributesTable.addView(tableRow)
+        val styleSpan = StyleSpan(Typeface.BOLD)
+        val spanStart = ssb.length - key.length
+        val spanEnd = ssb.length
+        ssb.setSpan(styleSpan, spanStart, spanEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+        ssb.append("\n")
+        ssb.append(value)
       }
+      this.errorDetails.text = ssb
     }
 
     this.errorStepsList.setHasFixedSize(false)

--- a/simplified-ui-errorpage/src/main/res/layout/error_page.xml
+++ b/simplified-ui-errorpage/src/main/res/layout/error_page.xml
@@ -15,6 +15,17 @@
       android:orientation="vertical">
 
       <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/errorTitle"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+      <TextView
         android:id="@+id/errorDetails"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/simplified-ui-errorpage/src/main/res/layout/error_page.xml
+++ b/simplified-ui-errorpage/src/main/res/layout/error_page.xml
@@ -1,95 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-  <TextView
-    android:id="@+id/errorTitle"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="16dp"
-    android:layout_marginTop="16dp"
-    android:layout_marginEnd="16dp"
-    android:text="@string/errorTitle"
-    android:textAlignment="viewStart"
-    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-    android:textSize="20sp"
-    android:textStyle="bold"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
-
-  <TextView
-    android:id="@+id/errorDetailsTitle"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="16dp"
-    android:layout_marginTop="16dp"
-    android:layout_marginEnd="16dp"
-    android:text="@string/errorDetailsTitle"
-    android:textAlignment="viewStart"
-    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-    android:textStyle="bold"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/errorTitle" />
-
-  <TableLayout
-    android:id="@+id/errorDetailsTable"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_marginBottom="16dp"
-    android:layout_marginEnd="16dp"
-    android:layout_marginStart="16dp"
-    android:layout_marginTop="16dp"
-    android:stretchColumns="1"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/errorDetailsTitle" />
-
-  <TextView
-    android:id="@+id/errorStepsTitle"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="16dp"
-    android:layout_marginTop="16dp"
-    android:layout_marginEnd="16dp"
-    android:text="@string/errorStepsTitle"
-    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-    android:textStyle="bold"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/errorDetailsTable" />
-
-  <androidx.recyclerview.widget.RecyclerView
-    android:id="@+id/errorSteps"
-    android:layout_width="0dp"
+  <androidx.core.widget.NestedScrollView
+    android:layout_width="match_parent"
     android:layout_height="0dp"
-    android:layout_marginStart="16dp"
-    android:layout_marginTop="16dp"
-    android:layout_marginEnd="16dp"
-    android:layout_marginBottom="32dp"
-    android:background="@drawable/border"
-    android:scrollbars="vertical"
-    app:layout_constraintBottom_toTopOf="@id/errorSendButton"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/errorStepsTitle" />
+    android:layout_weight="1">
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+
+      <TextView
+        android:id="@+id/errorDetails"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:typeface="monospace" />
+
+      <TextView
+        android:id="@+id/errorStepsTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/errorStepsTitle"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+        android:textStyle="bold" />
+
+      <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/errorSteps"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:background="@drawable/border"
+        android:scrollbars="vertical" />
+    </LinearLayout>
+  </androidx.core.widget.NestedScrollView>
 
   <Button
     android:id="@+id/errorSendButton"
-    android:layout_width="0dp"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginStart="32dp"
     android:layout_marginTop="16dp"
     android:layout_marginEnd="32dp"
-    android:layout_marginBottom="32dp"
-    android:text="@string/errorSendReport"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+    android:layout_marginBottom="16dp"
+    android:text="@string/errorSendReport" />
+</LinearLayout>
 

--- a/simplified-ui-errorpage/src/main/res/values/strings.xml
+++ b/simplified-ui-errorpage/src/main/res/values/strings.xml
@@ -3,5 +3,4 @@
   <string name="errorDetailsTitle">Error Details</string>
   <string name="errorSendReport">Send To Support</string>
   <string name="errorStepsTitle">Steps</string>
-  <string name="errorTitle">Here is the error log created by your issue:</string>
 </resources>

--- a/simplified-ui-errorpage/src/main/res/values/strings.xml
+++ b/simplified-ui-errorpage/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
   <string name="errorDetailsTitle">Error Details</string>
   <string name="errorSendReport">Send To Support</string>
   <string name="errorStepsTitle">Steps</string>
+  <string name="errorTitle">Here is the error log created by your issue:</string>
 </resources>

--- a/simplified-ui-settings/src/main/res/values/strings.xml
+++ b/simplified-ui-settings/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
   <string name="settingsAboutSummary" />
   <string name="settingsAccountAdd">Add account…</string>
   <string name="settingsAccountCreationFailed">Account creation failed</string>
-  <string name="settingsAccountCreationFailedMessage">The account \'%1$s\' could not be created.</string>
+  <string name="settingsAccountCreationFailedMessage">The account could not be created.</string>
   <string name="settingsAccountCurrent">Current Account</string>
   <string name="settingsAccountDelete">@string/settingsDelete</string>
   <string name="settingsAccountDeleteConfirm">Are you sure you want to remove your \"%1$s\" account from this device?</string>


### PR DESCRIPTION
**What's this do?**
This change shows a detailed "You have reached your loan limit" message on the book detail screen instead of the generic "operation failed" message.

Additionally, this patch also updates the error page layout to fix an issue that sometimes made contents unreadable.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2648

**How should this be tested? / Do these changes have associated tests?**
1. Settings -> App version -> Debug settings -> Show non-production libraries.
2. Add a "New York Public Library - QA Server" account.
3. Sign-in (ask Tristan for credentials, if needed).
4. Attempt to check out any book.
5. Ensure the correct error message is displayed.
6. Tap "details" and ensure the screen works as expected.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Yes, Tristan did.

**Screenshots**
- [Updated error message](https://user-images.githubusercontent.com/107117/77945277-3ee29c00-7275-11ea-8de6-5f2cee858ae9.png)
- [Error details - Before](https://user-images.githubusercontent.com/107117/77945283-41dd8c80-7275-11ea-8fe9-25239dec9d9a.png)
- [Error details - After](https://user-images.githubusercontent.com/107117/77945282-4144f600-7275-11ea-8677-5010b10e43ac.png)
