### PR TITLE
SIMPLY-2674: Respect input types in authentication documents

### DIFF
--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountProviderAuthenticationDescription.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountProviderAuthenticationDescription.kt
@@ -52,8 +52,42 @@ sealed class AccountProviderAuthenticationDescription {
     init {
       Preconditions.checkState(
         this.greaterEqual13 != this.under13,
-        "URIs ${this.greaterEqual13} and ${this.under13} must differ")
+        "URIs ${this.greaterEqual13} and ${this.under13} must differ"
+      )
     }
+  }
+
+  /**
+   * Values used in the NYPL's "input" extension.
+   *
+   * @see "https://github.com/NYPL-Simplified/Simplified/wiki/Authentication-For-OPDS-Extensions#keyboard"
+   */
+
+  enum class KeyboardInput {
+
+    /**
+     * The default keyboard for the platform.
+     */
+
+    DEFAULT,
+
+    /**
+     * A keyboard optimized for entering email addresses.
+     */
+
+    EMAIL_ADDRESS,
+
+    /**
+     * A numeric keypad.
+     */
+
+    NUMBER_PAD,
+
+    /**
+     * This server does not expect this input to be provided at all, and the client should not collect it.
+     */
+
+    NO_INPUT
   }
 
   /**
@@ -71,9 +105,11 @@ sealed class AccountProviderAuthenticationDescription {
 
     /**
      * The keyboard type used for barcode entry, such as "DEFAULT".
+     *
+     * Note: If the keyboard extension is missing or null, the value assumed should be DEFAULT, not NO_INPUT.
      */
 
-    val keyboard: String?,
+    val keyboard: KeyboardInput,
 
     /**
      * The maximum length of the password.
@@ -83,9 +119,11 @@ sealed class AccountProviderAuthenticationDescription {
 
     /**
      * The keyboard type used for password entry, such as "DEFAULT".
+     *
+     * Note: If the keyboard extension is missing or null, the value assumed should be DEFAULT, not NO_INPUT.
      */
 
-    val passwordKeyboard: String?,
+    val passwordKeyboard: KeyboardInput,
 
     /**
      * The description of the login dialog.
@@ -109,12 +147,6 @@ sealed class AccountProviderAuthenticationDescription {
       Preconditions.checkArgument(
         this.barcodeFormat?.all { c -> c.isUpperCase() || c.isWhitespace() } ?: true,
         "Barcode format ${this.barcodeFormat} must be uppercase")
-      Preconditions.checkArgument(
-        this.keyboard?.all { c -> c.isUpperCase() || c.isWhitespace() } ?: true,
-        "Keyboard ${this.keyboard} must be uppercase")
-      Preconditions.checkArgument(
-        this.passwordKeyboard?.all { c -> c.isUpperCase() || c.isWhitespace() } ?: true,
-        "Password keyboard ${this.passwordKeyboard} must be uppercase")
     }
   }
 }

--- a/simplified-main/src/main/res/values/stringsLogin.xml
+++ b/simplified-main/src/main/res/values/stringsLogin.xml
@@ -10,7 +10,7 @@
   <string name="loginErrorServer">Server returned an error: %1$d %2$s</string>
   <string name="loginErrorAuthNotRequired">Authentication is not required!</string>
   <string name="loginErrorNoPatronURI">No patron settings URI is defined!</string>
-  <string name="loginErrorInvalidCredentials">Your barcode and pin combination was not valid. Please try again.</string>
+  <string name="loginErrorInvalidCredentials">Your login is incorrect. Please try again.</string>
   <string name="loginErrorConnectionFailed">A network error occurred. Please check your connection or try again later.</string>
   <string name="loginErrorPatronSettingsParseError">Could not parse patron settings returned by server!</string>
   <string name="loginDeviceDRMNotSupported">This account requires Adobe ACS DRM, but this version of the application does not support it.</string>

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccount.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccount.kt
@@ -28,9 +28,9 @@ class MockAccount(override val id: AccountID) : AccountType {
       val authentication =
         AccountProviderAuthenticationDescription.Basic(
           barcodeFormat = null,
-          keyboard = null,
+          keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
           passwordMaximumLength = 4,
-          passwordKeyboard = null,
+          passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
           description = "What?",
           labels = mapOf()
         )

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccountProviders.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccountProviders.kt
@@ -170,9 +170,9 @@ object MockAccountProviders {
     return fakeProvider(uri)
       .copy(authentication = AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 4,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Stuff!",
         labels = mapOf()
       ))

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/TransformProviders.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/TransformProviders.kt
@@ -30,9 +30,9 @@ class TransformProviders {
           if (entry.needsAuth) {
             AccountProviderAuthenticationDescription.Basic(
               barcodeFormat = if (entry.supportsBarcodeDisplay) "CodaBar" else null,
-              keyboard = entry.loginKeyboard,
-              passwordMaximumLength = entry.authPasscodeLength.toInt(),
-              passwordKeyboard = entry.pinKeyboard,
+              keyboard = AccountProviderAuthenticationDescription.KeyboardInput.valueOf(entry.loginKeyboard ?: "DEFAULT"),
+              passwordMaximumLength = entry.authPasscodeLength,
+              passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.valueOf(entry.pinKeyboard ?: "DEFAULT"),
               description = "",
               labels = mapOf())
           } else {

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderSourceNYPLRegistryDescriptionContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderSourceNYPLRegistryDescriptionContract.kt
@@ -355,9 +355,9 @@ abstract class AccountProviderSourceNYPLRegistryDescriptionContract {
       annotationsURI = null,
       authentication = AccountProviderAuthenticationDescription.Basic(
         "CODABAR",
-        "DEFAULT",
+        AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         20,
-        "DEFAULT",
+        AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         "Basic Auth",
         labels = mapOf(
           Pair("LOGIN", "LOGIN!"),

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLoginTaskContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLoginTaskContract.kt
@@ -176,9 +176,9 @@ abstract class ProfileAccountLoginTaskContract {
     Mockito.`when`(provider.authentication)
       .thenReturn(AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 10,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Library Login",
         labels = mapOf()))
 
@@ -252,9 +252,9 @@ abstract class ProfileAccountLoginTaskContract {
     Mockito.`when`(provider.authentication)
       .thenReturn(AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 10,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Library Login",
         labels = mapOf()))
 
@@ -334,9 +334,9 @@ abstract class ProfileAccountLoginTaskContract {
     Mockito.`when`(provider.authentication)
       .thenReturn(AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 10,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Library Login",
         labels = mapOf()))
 
@@ -405,9 +405,9 @@ abstract class ProfileAccountLoginTaskContract {
     Mockito.`when`(provider.authentication)
       .thenReturn(AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 10,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Library Login",
         labels = mapOf()))
 
@@ -474,9 +474,9 @@ abstract class ProfileAccountLoginTaskContract {
     Mockito.`when`(provider.authentication)
       .thenReturn(AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 10,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Library Login",
         labels = mapOf()))
 
@@ -567,9 +567,9 @@ abstract class ProfileAccountLoginTaskContract {
     Mockito.`when`(provider.authentication)
       .thenReturn(AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 10,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Library Login",
         labels = mapOf()))
 
@@ -660,9 +660,9 @@ abstract class ProfileAccountLoginTaskContract {
     Mockito.`when`(provider.authentication)
       .thenReturn(AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 10,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Library Login",
         labels = mapOf()))
 
@@ -808,9 +808,9 @@ abstract class ProfileAccountLoginTaskContract {
     Mockito.`when`(provider.authentication)
       .thenReturn(AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 10,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Library Login",
         labels = mapOf()))
 
@@ -915,9 +915,9 @@ abstract class ProfileAccountLoginTaskContract {
     Mockito.`when`(provider.authentication)
       .thenReturn(AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 10,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Library Login",
         labels = mapOf()))
 
@@ -1032,9 +1032,9 @@ abstract class ProfileAccountLoginTaskContract {
     Mockito.`when`(provider.authentication)
       .thenReturn(AccountProviderAuthenticationDescription.Basic(
         barcodeFormat = "CODABAR",
-        keyboard = "DEFAULT",
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         passwordMaximumLength = 10,
-        passwordKeyboard = "DEFAULT",
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
         description = "Library Login",
         labels = mapOf()))
 

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/migration/from3master/MigrationFrom3MasterContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/migration/from3master/MigrationFrom3MasterContract.kt
@@ -83,12 +83,16 @@ abstract class MigrationFrom3MasterContract {
           val taskRecorder =
             TaskRecorder.create<AccountLoginState.AccountLoginErrorData>()
           taskRecorder.beginNewStep("Starting...")
-          taskRecorder.currentStepFailed("FAILED!", AccountLoginUnexpectedException("Ouch", Exception()))
+          taskRecorder.currentStepFailed(
+            "FAILED!",
+            AccountLoginUnexpectedException("Ouch", Exception())
+          )
           taskRecorder.finishFailure()
         },
         accountEvents = this.accountEvents,
         applicationVersion = "test suite 0.0.1",
-        context = this.context)
+        context = this.context
+      )
 
     this.tempDir.delete()
     this.tempDir.mkdirs()
@@ -294,12 +298,16 @@ abstract class MigrationFrom3MasterContract {
           val taskRecorder =
             TaskRecorder.create<AccountLoginState.AccountLoginErrorData>()
           taskRecorder.beginNewStep("Starting...")
-          taskRecorder.currentStepFailed("FAILED!", AccountLoginUnexpectedException("Ouch", Exception()))
+          taskRecorder.currentStepFailed(
+            "FAILED!",
+            AccountLoginUnexpectedException("Ouch", Exception())
+          )
           taskRecorder.finishFailure()
         },
         accountEvents = this.accountEvents,
         applicationVersion = "test suite 0.0.1",
-        context = this.context)
+        context = this.context
+      )
 
     val acc = File(this.tempDir, "12")
     acc.mkdirs()
@@ -354,7 +362,16 @@ abstract class MigrationFrom3MasterContract {
       Mockito.mock(AccountType::class.java)
 
     Mockito.`when`(accountProvider.authentication)
-      .thenReturn(AccountProviderAuthenticationDescription.Basic(null, null, 20, null, "Basic", mapOf()))
+      .thenReturn(
+        AccountProviderAuthenticationDescription.Basic(
+          null,
+          AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+          20,
+          AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+          "Basic",
+          mapOf()
+        )
+      )
     Mockito.`when`(accountProvider.displayName)
       .thenReturn("Account 0")
     Mockito.`when`(account.provider)
@@ -381,7 +398,8 @@ abstract class MigrationFrom3MasterContract {
         },
         accountEvents = this.accountEvents,
         applicationVersion = "test suite 0.0.1",
-        context = this.context)
+        context = this.context
+      )
 
     val acc = File(this.tempDir, "12")
     acc.mkdirs()
@@ -421,7 +439,8 @@ abstract class MigrationFrom3MasterContract {
       BookDatabases.openDatabase(
         context = this.context,
         owner = AccountID(UUID.randomUUID()),
-        directory = this.tempBookDatabaseDir)
+        directory = this.tempBookDatabaseDir
+      )
 
     val accountProvider =
       Mockito.mock(AccountProviderType::class.java)
@@ -429,7 +448,16 @@ abstract class MigrationFrom3MasterContract {
       Mockito.mock(AccountType::class.java)
 
     Mockito.`when`(accountProvider.authentication)
-      .thenReturn(AccountProviderAuthenticationDescription.Basic(null, null, 20, null, "Basic", mapOf()))
+      .thenReturn(
+        AccountProviderAuthenticationDescription.Basic(
+          null,
+          AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+          20,
+          AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+          "Basic",
+          mapOf()
+        )
+      )
     Mockito.`when`(accountProvider.displayName)
       .thenReturn("Account 0")
     Mockito.`when`(account.provider)
@@ -457,7 +485,8 @@ abstract class MigrationFrom3MasterContract {
         },
         accountEvents = this.accountEvents,
         applicationVersion = "test suite 0.0.1",
-        context = this.context)
+        context = this.context
+      )
 
     val acc = File(this.tempDir, "12")
     acc.mkdirs()
@@ -466,7 +495,8 @@ abstract class MigrationFrom3MasterContract {
 
     val booksDir = File(acc, "books")
     val booksDataDir = File(booksDir, "data")
-    val bookDir = File(booksDataDir, "5924cb11000f67c5879f70d0bdfa11cbbd13a3e0feb5a9beda3f4a81032019a0")
+    val bookDir =
+      File(booksDataDir, "5924cb11000f67c5879f70d0bdfa11cbbd13a3e0feb5a9beda3f4a81032019a0")
     bookDir.mkdirs()
 
     val bookEPUBFile = File(bookDir, "book.epub")
@@ -566,7 +596,16 @@ abstract class MigrationFrom3MasterContract {
       Mockito.mock(AccountType::class.java)
 
     Mockito.`when`(accountProvider.authentication)
-      .thenReturn(AccountProviderAuthenticationDescription.Basic(null, null, 20, null, "Basic", mapOf()))
+      .thenReturn(
+        AccountProviderAuthenticationDescription.Basic(
+          null,
+          AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+          20,
+          AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+          "Basic",
+          mapOf()
+        )
+      )
     Mockito.`when`(accountProvider.displayName)
       .thenReturn("Account 0")
     Mockito.`when`(account.provider)
@@ -604,7 +643,8 @@ abstract class MigrationFrom3MasterContract {
         },
         accountEvents = this.accountEvents,
         applicationVersion = "test suite 0.0.1",
-        context = this.context)
+        context = this.context
+      )
 
     val acc = File(this.tempDir, "12")
     acc.mkdirs()
@@ -613,7 +653,8 @@ abstract class MigrationFrom3MasterContract {
 
     val booksDir = File(acc, "books")
     val booksDataDir = File(booksDir, "data")
-    val bookDir = File(booksDataDir, "5924cb11000f67c5879f70d0bdfa11cbbd13a3e0feb5a9beda3f4a81032019a0")
+    val bookDir =
+      File(booksDataDir, "5924cb11000f67c5879f70d0bdfa11cbbd13a3e0feb5a9beda3f4a81032019a0")
     bookDir.mkdirs()
 
     val bookEPUBFile = File(bookDir, "book.epub")
@@ -668,7 +709,8 @@ abstract class MigrationFrom3MasterContract {
       BookDatabases.openDatabase(
         context = this.context,
         owner = AccountID(UUID.randomUUID()),
-        directory = this.tempBookDatabaseDir)
+        directory = this.tempBookDatabaseDir
+      )
 
     val accountProvider =
       Mockito.mock(AccountProviderType::class.java)
@@ -676,7 +718,16 @@ abstract class MigrationFrom3MasterContract {
       Mockito.mock(AccountType::class.java)
 
     Mockito.`when`(accountProvider.authentication)
-      .thenReturn(AccountProviderAuthenticationDescription.Basic(null, null, 20, null, "Basic", mapOf()))
+      .thenReturn(
+        AccountProviderAuthenticationDescription.Basic(
+          null,
+          AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+          20,
+          AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+          "Basic",
+          mapOf()
+        )
+      )
     Mockito.`when`(accountProvider.displayName)
       .thenReturn("Account 0")
     Mockito.`when`(account.provider)
@@ -700,12 +751,16 @@ abstract class MigrationFrom3MasterContract {
           val taskRecorder =
             TaskRecorder.create<AccountLoginState.AccountLoginErrorData>()
           taskRecorder.beginNewStep("Starting...")
-          taskRecorder.currentStepFailed("FAILURE!", AccountLoginUnexpectedException("FAILURE!", Exception()))
+          taskRecorder.currentStepFailed(
+            "FAILURE!",
+            AccountLoginUnexpectedException("FAILURE!", Exception())
+          )
           taskRecorder.finishFailure()
         },
         accountEvents = this.accountEvents,
         applicationVersion = "test suite 0.0.1",
-        context = this.context)
+        context = this.context
+      )
 
     val acc = File(this.tempDir, "12")
     acc.mkdirs()
@@ -714,7 +769,8 @@ abstract class MigrationFrom3MasterContract {
 
     val booksDir = File(acc, "books")
     val booksDataDir = File(booksDir, "data")
-    val bookDir = File(booksDataDir, "5924cb11000f67c5879f70d0bdfa11cbbd13a3e0feb5a9beda3f4a81032019a0")
+    val bookDir =
+      File(booksDataDir, "5924cb11000f67c5879f70d0bdfa11cbbd13a3e0feb5a9beda3f4a81032019a0")
     bookDir.mkdirs()
 
     val bookEPUBFile = File(bookDir, "book.epub")
@@ -787,7 +843,8 @@ abstract class MigrationFrom3MasterContract {
 
   private fun resource(name: String): ByteArray {
     return MigrationFrom3MasterContract::class.java.getResource(
-      "/org/nypl/simplified/tests/migration/from3master/$name")
+        "/org/nypl/simplified/tests/migration/from3master/$name"
+      )
       .readBytes()
   }
 }


### PR DESCRIPTION
**What's this do?**
This makes the changes necessary to respect the "input" values given
in authentication documents. In practical terms, this means showing
or hiding the username/password fields appropriately both in the
settings account view, and in the popup dialog that appears in the
catalog.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2674

**How should this be tested? / Do these changes have associated tests?**

In the settings screen:

1. Open the settings for an NYPL account, and make sure that there's still a barcode and PIN field.
2. Open the settings for the SimplyE collection, and make sure that there isn't a barcode or PIN field.
3. Open the settings for a Hodgekiss Library Of Sharon account and make sure that there's _only_ a username field visible.

In the catalog:

1. Without being logged in, try to borrow a book in the NYPL collection so that the login dialog box pops up, and make sure that there's still a barcode and PIN field.
2. Without being logged in, try to borrow a book in the Hodgekiss Library Of Sharon collection so that the login dialog box pops up, and make sure that there's _only_ a username field visible in the dialog.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m 