### PR TITLE
SIMPLY-2627: Load testing libraries only when required.

### DIFF
--- a/simplified-accounts-registry-api/src/main/java/org/nypl/simplified/accounts/registry/api/AccountProviderRegistryType.kt
+++ b/simplified-accounts-registry-api/src/main/java/org/nypl/simplified/accounts/registry/api/AccountProviderRegistryType.kt
@@ -42,9 +42,12 @@ interface AccountProviderRegistryType {
 
   /**
    * Refresh the available account providers from all sources.
+   *
+   * @param includeTestingLibraries A hint for providers indicating whether
+   * testing libraries should be loaded. May be ignored by some providers.
    */
 
-  fun refresh()
+  fun refresh(includeTestingLibraries: Boolean)
 
   /**
    * Return an immutable read-only of the account provider descriptions.

--- a/simplified-accounts-registry/src/main/java/org/nypl/simplified/accounts/registry/AccountProviderRegistry.kt
+++ b/simplified-accounts-registry/src/main/java/org/nypl/simplified/accounts/registry/AccountProviderRegistry.kt
@@ -56,7 +56,7 @@ class AccountProviderRegistry private constructor(
 
   override fun accountProviderDescriptions(): Map<URI, AccountProviderDescriptionType> {
     if (!this.initialized) {
-      this.refresh()
+      this.refresh(false)
     }
     return this.descriptionsReadOnly
   }
@@ -64,7 +64,7 @@ class AccountProviderRegistry private constructor(
   override val resolvedProviders: Map<URI, AccountProviderType>
     get() = this.resolvedReadOnly
 
-  override fun refresh() {
+  override fun refresh(includeTestingLibraries: Boolean) {
     this.logger.debug("refreshing account provider descriptions")
 
     this.statusRef = Refreshing
@@ -73,7 +73,7 @@ class AccountProviderRegistry private constructor(
     try {
       for (source in this.sources) {
         try {
-          when (val result = source.load(this.context)) {
+          when (val result = source.load(this.context, includeTestingLibraries)) {
             is AccountProviderSourceType.SourceResult.SourceSucceeded -> {
               val newDescriptions = result.results
               for (key in newDescriptions.keys) {

--- a/simplified-accounts-source-filebased/src/main/java/org/nypl/simplified/accounts/source/filebased/AccountProviderSourceFileBased.kt
+++ b/simplified-accounts-source-filebased/src/main/java/org/nypl/simplified/accounts/source/filebased/AccountProviderSourceFileBased.kt
@@ -28,7 +28,7 @@ class AccountProviderSourceFileBased(
   @Volatile
   private var cache: Map<URI, AccountProviderType>? = null
 
-  override fun load(context: Context): SourceResult {
+  override fun load(context: Context, includeTestingLibraries: Boolean): SourceResult {
     val cached = this.cache
     if (cached != null) {
       this.logger.debug("returning cached providers")

--- a/simplified-accounts-source-spi/src/main/java/org/nypl/simplified/accounts/source/spi/AccountProviderSourceType.kt
+++ b/simplified-accounts-source-spi/src/main/java/org/nypl/simplified/accounts/source/spi/AccountProviderSourceType.kt
@@ -42,7 +42,10 @@ interface AccountProviderSourceType {
 
   /**
    * Retrieve everything the source provides.
+   *
+   * @param includeTestingLibraries A hint for the provider indicating whether
+   * testing libraries should be loaded. May be ignored by some providers.
    */
 
-  fun load(context: Context): SourceResult
+  fun load(context: Context, includeTestingLibraries: Boolean): SourceResult
 }

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccountProviderRegistry.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccountProviderRegistry.kt
@@ -25,7 +25,7 @@ class MockAccountProviderRegistry : AccountProviderRegistryType {
   override val status: AccountProviderRegistryStatus
     get() = AccountProviderRegistryStatus.Idle
 
-  override fun refresh() {
+  override fun refresh(includeTestingLibraries: Boolean) {
   }
 
   override fun accountProviderDescriptions(): Map<URI, AccountProviderDescriptionType> {

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderDescriptionRegistryContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderDescriptionRegistryContract.kt
@@ -81,7 +81,7 @@ abstract class AccountProviderDescriptionRegistryContract {
         listOf(CrashingSource()))
 
     registry.events.subscribe { e -> this.events.add(e) }
-    registry.refresh()
+    registry.refresh(true)
 
     Assert.assertEquals(Idle, registry.status)
     Assert.assertEquals(3, this.events.size)
@@ -112,7 +112,7 @@ abstract class AccountProviderDescriptionRegistryContract {
         listOf(OKSource()))
 
     registry.events.subscribe { this.events.add(it) }
-    registry.refresh()
+    registry.refresh(true)
 
     val description0 =
       registry.findAccountProviderDescription(URI.create("urn:0"))
@@ -159,7 +159,7 @@ abstract class AccountProviderDescriptionRegistryContract {
         listOf(OKSource(), OKAncientSource()))
 
     registry.events.subscribe { this.events.add(it) }
-    registry.refresh()
+    registry.refresh(true)
 
     val description0 =
       registry.findAccountProviderDescription(URI.create("urn:0"))
@@ -212,7 +212,7 @@ abstract class AccountProviderDescriptionRegistryContract {
         listOf(OKSource(), CrashingSource()))
 
     registry.events.subscribe { this.events.add(it) }
-    registry.refresh()
+    registry.refresh(true)
 
     val description0 =
       registry.findAccountProviderDescription(URI.create("urn:0"))
@@ -260,7 +260,7 @@ abstract class AccountProviderDescriptionRegistryContract {
         listOf(OKSource(), FailingSource()))
 
     registry.events.subscribe { this.events.add(it) }
-    registry.refresh()
+    registry.refresh(true)
 
     val description0 =
       registry.findAccountProviderDescription(URI.create("urn:0"))
@@ -309,7 +309,7 @@ abstract class AccountProviderDescriptionRegistryContract {
         listOf(OKSource(), OKAncientSource()))
 
     registry.events.subscribe { this.events.add(it) }
-    registry.refresh()
+    registry.refresh(true)
 
     val existing0 =
       registry.findAccountProviderDescription(URI.create("urn:0"))!!
@@ -334,7 +334,7 @@ abstract class AccountProviderDescriptionRegistryContract {
         listOf())
 
     registry.events.subscribe { this.events.add(it) }
-    registry.refresh()
+    registry.refresh(true)
 
     val existing0 =
       MockAccountProviders.fakeProvider("urn:fake:0")
@@ -372,7 +372,7 @@ abstract class AccountProviderDescriptionRegistryContract {
       eventsWithRefreshing.add(registry.status)
     }
 
-    registry.refresh()
+    registry.refresh(true)
 
     Assert.assertEquals(5, eventsWithRefreshing.size)
     Assert.assertEquals(Refreshing::class.java, eventsWithRefreshing[0].javaClass)
@@ -524,7 +524,7 @@ abstract class AccountProviderDescriptionRegistryContract {
   }
 
   class OKAncientSource : AccountProviderSourceType {
-    override fun load(context: Context): SourceResult {
+    override fun load(context: Context, includeTestingLibraries: Boolean): SourceResult {
       return SourceResult.SourceSucceeded(
         mapOf(
           Pair(descriptionOld0.metadata.id, descriptionOld0),
@@ -534,7 +534,7 @@ abstract class AccountProviderDescriptionRegistryContract {
   }
 
   class OKSource : AccountProviderSourceType {
-    override fun load(context: Context): SourceResult {
+    override fun load(context: Context, includeTestingLibraries: Boolean): SourceResult {
       return SourceResult.SourceSucceeded(
         mapOf(
           Pair(description0.metadata.id, description0),
@@ -544,13 +544,13 @@ abstract class AccountProviderDescriptionRegistryContract {
   }
 
   class CrashingSource : AccountProviderSourceType {
-    override fun load(context: Context): SourceResult {
+    override fun load(context: Context, includeTestingLibraries: Boolean): SourceResult {
       throw Exception()
     }
   }
 
   class FailingSource : AccountProviderSourceType {
-    override fun load(context: Context): SourceResult {
+    override fun load(context: Context, includeTestingLibraries: Boolean): SourceResult {
       return SourceResult.SourceFailed(mapOf(), java.lang.Exception())
     }
   }

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderNYPLRegistryContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderNYPLRegistryContract.kt
@@ -62,7 +62,47 @@ abstract class AccountProviderNYPLRegistryContract {
    */
 
   @Test
-  fun testProvidersFromServerOK() {
+  fun testProductionProvidersFromServerOK() {
+    val mockHTTP = MockingHTTP()
+
+    mockHTTP.addResponse(
+      "https://libraryregistry.librarysimplified.org/libraries",
+      HTTPResultOK(
+        "OK",
+        200,
+        readAllFromResource("libraryregistry.json"),
+        0L,
+        mapOf(),
+        0L))
+
+    val provider =
+      AccountProviderSourceNYPLRegistry(
+        http = mockHTTP,
+        authDocumentParsers = AuthenticationDocumentParsers(),
+        parsers = AccountProviderDescriptionCollectionParsers(),
+        serializers = AccountProviderDescriptionCollectionSerializers())
+
+    val result = provider.load(this.context, false)
+    this.logger.debug("status: {}", result)
+    val success = result as SourceSucceeded
+
+    Assert.assertEquals(43, success.results.size)
+    Assert.assertEquals(
+      "The correct number of providers are in production",
+      43,
+      success.results.values.filter { p -> p.metadata.isProduction }.size)
+    Assert.assertEquals(
+      "The correct number of providers are not in production",
+      0,
+      success.results.values.filter { p -> !p.metadata.isProduction }.size)
+  }
+
+  /**
+   * The correct providers are returned from the server.
+   */
+
+  @Test
+  fun testAllProvidersFromServerOK() {
     val mockHTTP = MockingHTTP()
 
     mockHTTP.addResponse(
@@ -92,7 +132,7 @@ abstract class AccountProviderNYPLRegistryContract {
         parsers = AccountProviderDescriptionCollectionParsers(),
         serializers = AccountProviderDescriptionCollectionSerializers())
 
-    val result = provider.load(this.context)
+    val result = provider.load(this.context, true)
     this.logger.debug("status: {}", result)
     val success = result as SourceSucceeded
 
@@ -127,7 +167,7 @@ abstract class AccountProviderNYPLRegistryContract {
         parsers = AccountProviderDescriptionCollectionParsers(),
         serializers = AccountProviderDescriptionCollectionSerializers())
 
-    val result = provider.load(this.context)
+    val result = provider.load(this.context, true)
     this.logger.debug("status: {}", result)
     val success = result as SourceSucceeded
 
@@ -173,7 +213,7 @@ abstract class AccountProviderNYPLRegistryContract {
         parsers = AccountProviderDescriptionCollectionParsers(),
         serializers = AccountProviderDescriptionCollectionSerializers())
 
-    val result = provider.load(this.context)
+    val result = provider.load(this.context, true)
     this.logger.debug("status: {}", result)
     val success = result as SourceSucceeded
 
@@ -225,7 +265,7 @@ abstract class AccountProviderNYPLRegistryContract {
         parsers = AccountProviderDescriptionCollectionParsers(),
         serializers = AccountProviderDescriptionCollectionSerializers())
 
-    val result = provider.load(this.context)
+    val result = provider.load(this.context, true)
     this.logger.debug("status: {}", result)
     val failed = result as AccountProviderSourceType.SourceResult.SourceFailed
 
@@ -254,7 +294,7 @@ abstract class AccountProviderNYPLRegistryContract {
         serializers = AccountProviderDescriptionCollectionSerializers())
 
     run {
-      val result = provider.load(this.context)
+      val result = provider.load(this.context, true)
       this.logger.debug("status: {}", result)
       val success = result as SourceSucceeded
 
@@ -282,7 +322,7 @@ abstract class AccountProviderNYPLRegistryContract {
         0L))
 
     run {
-      val result = provider.load(this.context)
+      val result = provider.load(this.context, true)
       this.logger.debug("status: {}", result)
       val success = result as SourceSucceeded
 

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderSourceFileBasedContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderSourceFileBasedContract.kt
@@ -27,7 +27,7 @@ abstract class AccountProviderSourceFileBasedContract {
       this.readAllFromResource("providers-all.json")
     })
 
-    val result = provider.load(this.context)
+    val result = provider.load(this.context, true)
     this.logger.debug("status: {}", result)
     val success = result as SourceSucceeded
     Assert.assertEquals(172, success.results.size)

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentAccountRegistry.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentAccountRegistry.kt
@@ -189,7 +189,12 @@ class SettingsFragmentAccountRegistry : Fragment() {
 
     this.refresh.setOnClickListener {
       this.refresh.isEnabled = false
-      this.accountRegistry.refresh()
+      this.accountRegistry.refresh(
+        includeTestingLibraries = this.profilesController
+          .profileCurrent()
+          .preferences()
+          .showTestingLibraries
+      )
     }
 
     return layout
@@ -209,7 +214,12 @@ class SettingsFragmentAccountRegistry : Fragment() {
         .subscribe(this::onAccountEvent)
 
     this.reconfigureViewForRegistryStatus(this.accountRegistry.status)
-    this.accountRegistry.refresh()
+    this.accountRegistry.refresh(
+      includeTestingLibraries = this.profilesController
+        .profileCurrent()
+        .preferences()
+        .showTestingLibraries
+    )
   }
 
   private fun configureToolbar() {


### PR DESCRIPTION
**What's this do?**
This change updates the NYPL account provider registry to only load
testing libraries when necessary. This should speed up the first app
launch.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2627

**How should this be tested? / Do these changes have associated tests?**
1. Ensure the account list is populated normally.
2. Navigate to "Settings -> Version -> Build (Tap to enable debug settings)"
3. Toggle "Show non-production libraries" to true.
4. Ensure the account list shows non-production accounts as expected.

This pull-request includes tests.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Yep, I tested this.
