### PR TITLE
SIMPLY-2623: Save and restore the most recent account

### DIFF
--- a/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
+++ b/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
@@ -1,5 +1,6 @@
 package org.nypl.simplified.profiles.api
 
+import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.reader.api.ReaderPreferences
 
 /**
@@ -29,5 +30,11 @@ data class ProfilePreferences(
    * @return The reader-specific preferences
    */
 
-  val readerPreferences: ReaderPreferences
+  val readerPreferences: ReaderPreferences,
+
+  /**
+   * The most recently used account provider.
+   */
+
+  val mostRecentAccount: AccountID?
 )

--- a/simplified-profiles-controller-api/src/main/java/org/nypl/simplified/profiles/controller/api/ProfilesControllerType.kt
+++ b/simplified-profiles-controller-api/src/main/java/org/nypl/simplified/profiles/controller/api/ProfilesControllerType.kt
@@ -97,7 +97,8 @@ interface ProfilesControllerType {
       ProfilePreferences(
         dateOfBirth = ProfileDateOfBirth(date, false),
         showTestingLibraries = false,
-        readerPreferences = ReaderPreferences.builder().build()
+        readerPreferences = ReaderPreferences.builder().build(),
+        mostRecentAccount = null
       )
 
     val attributes =

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
@@ -437,7 +437,8 @@ object ProfilesDatabases {
           preferences = ProfilePreferences(
             dateOfBirth = null,
             showTestingLibraries = false,
-            readerPreferences = ReaderPreferences.builder().build()
+            readerPreferences = ReaderPreferences.builder().build(),
+            mostRecentAccount = null
           ),
           attributes = ProfileAttributes(sortedMapOf())
         )

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/MockProfile.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/MockProfile.kt
@@ -29,7 +29,7 @@ class MockProfile(
   override fun description(): ProfileDescription {
     return ProfileDescription(
       displayName = "Profile ${id.uuid}",
-      preferences = ProfilePreferences(null, false, ReaderPreferences.builder().build()),
+      preferences = ProfilePreferences(null, false, ReaderPreferences.builder().build(), null),
       attributes = ProfileAttributes(sortedMapOf())
     )
   }

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONContract.kt
@@ -45,7 +45,9 @@ abstract class ProfileDescriptionJSONContract {
         displayName = "Kermit",
         preferences = ProfilePreferences(ProfileDateOfBirth(dateTime, true),
           showTestingLibraries = false,
-          readerPreferences = ReaderPreferences.builder().build()),
+          readerPreferences = ReaderPreferences.builder().build(),
+          mostRecentAccount = null
+        ),
         attributes = ProfileAttributes(
           sortedMapOf(
             Pair("a", "b"),

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/profiles/ProfilesDatabaseContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/profiles/ProfilesDatabaseContract.kt
@@ -1130,4 +1130,40 @@ abstract class ProfilesDatabaseContract {
     Assert.assertEquals("Big Bird", p0.displayName)
     Assert.assertEquals("Grouch", p1.displayName)
   }
+
+  /**
+   * The most recently used account is stored as a preference.
+   */
+
+  @Test
+  @Throws(Exception::class)
+  fun testSetCurrentAccountPreference() {
+    val fileTemp = DirectoryUtilities.directoryCreateTemporary()
+    val fileProfiles = File(fileTemp, "profiles")
+
+    val db0 = ProfilesDatabases.openWithAnonymousProfileDisabled(
+      this.context(),
+      this.analytics,
+      this.accountEvents,
+      MockAccountProviders.fakeAccountProviders(),
+      AccountBundledCredentialsEmpty.getInstance(),
+      this.credentialStore,
+      this.accountsDatabases(),
+      fileProfiles)
+
+    val acc0 =
+      MockAccountProviders.fakeProvider("http://www.example.com/accounts0/")
+    val acc1 =
+      MockAccountProviders.fakeProvider("http://www.example.com/accounts1/")
+
+    val p0 = db0.createProfile(acc0, "Kermit")
+    db0.setProfileCurrent(p0.id)
+    val ac0 = p0.accountsByProvider()[acc0.id]!!
+    val ac1 = p0.createAccount(acc1)
+
+    p0.selectAccount(acc0.id)
+    Assert.assertEquals(p0.preferences().mostRecentAccount, ac0.id)
+    p0.selectAccount(acc1.id)
+    Assert.assertEquals(p0.preferences().mostRecentAccount, ac1.id)
+  }
 }


### PR DESCRIPTION
**What's this do?**
This adds a per-profile preference that's used to save and restore the
most recently used account. The identifier of an account is stored
every time the setAccountCurrent() method is called, and the stored
identifier is used when the profile is loaded to set the correct
account.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2623

**How should this be tested? / Do these changes have associated tests?**
1. Open any build of the app, and create a couple of accounts (such as NYPL, Classics Collection, etc).
2. Select any account that isn't the Classics Collection (because this is currently the default startup account).
3. Close the app.
4. Reopen the app.
5. Check that you're now looking at the account you were on when you closed the app.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m 