### PR TITLE
Overhaul the login dialog

### DIFF
--- a/simplified-ui-catalog/build.gradle
+++ b/simplified-ui-catalog/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   implementation project(":simplified-analytics-api")
   implementation project(":simplified-books-controller-api")
   implementation project(":simplified-books-registry-api")
+  implementation project(":simplified-buildconfig-api")
   implementation project(":simplified-documents")
   implementation project(":simplified-futures")
   implementation project(":simplified-profiles-controller-api")

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -902,8 +902,7 @@ class CatalogFragmentBookDetail : Fragment() {
 
   private fun openLoginDialogAndThen(execute: () -> Unit) {
     val dialogParameters = CatalogFragmentLoginDialogParameters(this.parameters.accountId)
-    val dialog = CatalogFragmentLoginDialog.create(dialogParameters)
-    dialog.show(this.requireFragmentManager(), "LOGIN")
+    this.findNavigationController().openLoginDialog(dialogParameters)
     this.runOnLoginDialogClosed.set(execute)
   }
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogNavigationControllerType.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogNavigationControllerType.kt
@@ -32,6 +32,14 @@ interface CatalogNavigationControllerType : NavigationControllerType {
   )
 
   /**
+   * Open a login dialog for the given parameters.
+   */
+
+  fun openLoginDialog(
+    parameters: CatalogFragmentLoginDialogParameters
+  )
+
+  /**
    * A catalog screen wants to open a feed.
    */
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedAdapter.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedAdapter.kt
@@ -1,8 +1,8 @@
 package org.nypl.simplified.ui.catalog
 
-import android.app.Activity
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory
 
 class CatalogPagedAdapter(
   private val buttonCreator: CatalogButtons,
-  private val context: Activity,
+  private val context: FragmentActivity,
   private val fragmentManager: FragmentManager,
   private val loginViewModel: CatalogLoginViewModel,
   private val navigation: () -> CatalogNavigationControllerType,

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -1,6 +1,5 @@
 package org.nypl.simplified.ui.catalog
 
-import android.app.Activity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
@@ -8,6 +7,7 @@ import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.annotation.UiThread
+import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.common.base.Preconditions
@@ -28,6 +28,7 @@ import org.nypl.simplified.feeds.api.FeedEntry
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryCorrupt
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryOPDS
 import org.nypl.simplified.futures.FluentFutureExtensions.map
+import org.nypl.simplified.navigation.api.NavigationControllers
 import org.nypl.simplified.presentableerror.api.PresentableErrorType
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.taskrecorder.api.TaskResult
@@ -45,7 +46,7 @@ import java.util.concurrent.atomic.AtomicReference
 class CatalogPagedViewHolder(
   private val buttonCreator: CatalogButtons,
   private val registrySubscriptions: CompositeDisposable,
-  private val context: Activity,
+  private val context: FragmentActivity,
   private val fragmentManager: FragmentManager,
   private val loginViewModel: CatalogLoginViewModel,
   private val navigation: () -> CatalogNavigationControllerType,
@@ -570,13 +571,19 @@ class CatalogPagedViewHolder(
       val dialogParameters =
         CatalogFragmentLoginDialogParameters(
           this.profilesController.profileAccountCurrent().id)
-      val dialog = CatalogFragmentLoginDialog.create(dialogParameters)
-      dialog.show(this.fragmentManager, "LOGIN")
+
+      this.findNavigationController().openLoginDialog(dialogParameters)
       this.runOnLoginDialogClosed.set(execute)
     } catch (e: Exception) {
       this.logger.error("could not open login dialog: ", e)
     }
   }
+
+  private fun findNavigationController() =
+    NavigationControllers.find(
+      activity = this.context,
+      interfaceType = CatalogNavigationControllerType::class.java
+    )
 
   /**
    * @return `true` if a login is required on the current account

--- a/simplified-ui-catalog/src/main/res/layout/login_dialog.xml
+++ b/simplified-ui-catalog/src/main/res/layout/login_dialog.xml
@@ -92,16 +92,31 @@
       app:layout_constraintStart_toStartOf="@id/loginTable"
       app:layout_constraintTop_toBottomOf="@id/loginProgressBar" />
 
-    <Button
-      android:id="@+id/loginButton"
-      android:layout_width="match_parent"
+    <LinearLayout
+      android:orientation="horizontal"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
-      android:layout_margin="16dp"
-      android:layout_marginBottom="16dp"
-      android:text="@string/loginLogin"
+      android:layout_marginTop="32dp"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/loginEULA" />
+      app:layout_constraintTop_toBottomOf="@id/loginEULA">
+
+      <Button
+        android:id="@+id/loginErrorDetailsButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="16dp"
+        android:layout_weight="1"
+        android:text="@string/errorDetailsTitle"
+        android:visibility="gone" />
+
+      <Button
+        android:id="@+id/loginButton"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:text="@string/loginLogin" />
+    </LinearLayout>
 
     <View
       android:id="@+id/lockFormOverlay"
@@ -115,6 +130,7 @@
         android:id="@+id/loginProgressText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
         android:layout_marginBottom="16dp"
         android:ellipsize="end"
         android:gravity="center_horizontal"

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
@@ -24,6 +24,8 @@ import org.nypl.simplified.ui.catalog.CatalogFeedArguments.CatalogFeedArgumentsR
 import org.nypl.simplified.ui.catalog.CatalogFragmentBookDetail
 import org.nypl.simplified.ui.catalog.CatalogFragmentBookDetailParameters
 import org.nypl.simplified.ui.catalog.CatalogFragmentFeed
+import org.nypl.simplified.ui.catalog.CatalogFragmentLoginDialog
+import org.nypl.simplified.ui.catalog.CatalogFragmentLoginDialogParameters
 import org.nypl.simplified.ui.catalog.CatalogNavigationControllerType
 import org.nypl.simplified.ui.errorpage.ErrorPageFragment
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
@@ -213,6 +215,13 @@ class TabbedNavigationController private constructor(
   override fun <E : PresentableErrorType> openErrorPage(parameters: ErrorPageParameters<E>) {
     this.navigator.addFragment(
       fragment = ErrorPageFragment.create(parameters),
+      tab = this.navigator.currentTab()
+    )
+  }
+
+  override fun openLoginDialog(parameters: CatalogFragmentLoginDialogParameters) {
+    this.navigator.addFragment(
+      fragment = CatalogFragmentLoginDialog.create(parameters),
       tab = this.navigator.currentTab()
     )
   }


### PR DESCRIPTION
**What's this do?**
This adjusts the login dialog so that it is now a full-screen fragment
instead of a Dialog in the Android sense. It hooks up some missing
logic to allow for displaying error details on login failures.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2681

**How should this be tested? / Do these changes have associated tests?**

* On an account that requires authentication, when not logged in, try to borrow a book from
a book detail page or from a scrolling feed. Enter some credentials into the login form that you know to be incorrect; observe that an error message is displayed and that an error details button is present and does something.

* On an account that requires authentication, when not logged in, try to borrow a book from
a book detail page or from a scrolling feed. Enter some credentials into the login form that you know to be correct; observe that the dialog goes away when the login process is complete and that the book borrowing starts.

* Observe that the login dialog doesn't look like it spent time in a car crusher.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m 
Testing: Tested a successful login on an NYPL account
Testing: Tested a failed login on a Hotchkiss account