### PR TITLE
Remove account dialog filter

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogAccountsDialog.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogAccountsDialog.kt
@@ -65,7 +65,6 @@ object CatalogAccountsDialog {
     return profilesController.profileCurrent()
       .accounts()
       .values
-      .filter { account -> !this.accountIsCurrent(profilesController, account) }
       .sortedBy { account -> account.provider.displayName }
   }
 


### PR DESCRIPTION
**What's this do?**
This extensive and deeply complex patch removes the filter that stops the account dialog from showing "the current account" in the list.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2689

**How should this be tested? / Do these changes have associated tests?**
At any point in the catalog, select the accounts menu from the toolbar and check that the current account is visible in it.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m 