### PR TITLE
SIMPLY-2694: Retry 403 Forbidden response with auth, when available.

### DIFF
--- a/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTPRedirectFollower.java
+++ b/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTPRedirectFollower.java
@@ -130,6 +130,7 @@ public final class HTTPRedirectFollower
       this.logger, this.current_uri, e.getMessage(), e.getStatus(), e.getProblemReport());
 
     switch (code) {
+      case HttpURLConnection.HTTP_FORBIDDEN:
       case HttpURLConnection.HTTP_UNAUTHORIZED: {
         if (this.tried_auth.contains(this.current_uri)) {
           this.logger.error(
@@ -140,10 +141,6 @@ public final class HTTPRedirectFollower
         this.current_auth = this.target_auth;
         this.tried_auth.add(this.current_uri);
         return this.processURI();
-      }
-
-      case HttpURLConnection.HTTP_FORBIDDEN: {
-        return e;
       }
     }
 


### PR DESCRIPTION
**What's this do?**
This change fixes a failure with biblioboard where a 403 Forbidden
response is returned instead of a 401 Unauthorized. Instead, of
immediately giving up when a 403 is received, try again with
authentication like we would do with a 401.

Another improvement would be to proactively include the authentication
with the first attempt instead of waiting for a challenge response.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2694

**How should this be tested? / Do these changes have associated tests?**
1. Enable non-production libraries.
2. Add an account for Washington State Library.
3. Attempt to download a book and note that it succeeds where it would previously fail.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Yes, I did.