### PR TITLE
SIMPLY-2402: Allow problem report documents to control status codes

### DIFF
--- a/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTPProblemReport.java
+++ b/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTPProblemReport.java
@@ -3,6 +3,8 @@ package org.nypl.simplified.http.core;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.io7m.jfunctional.Option;
+import com.io7m.jfunctional.OptionType;
 import com.io7m.jnull.NullCheck;
 import org.nypl.simplified.json.core.JSONParserUtilities;
 
@@ -112,6 +114,23 @@ public final class HTTPProblemReport implements Serializable
       }
     }
     return ProblemType.Unknown;
+  }
+
+  /**
+   * @return The integer status code from the problem report, if present
+   */
+
+  public OptionType<Integer> getProblemStatusCode()
+  {
+    try {
+      if (this.raw.has("status")) {
+        final String typeValue = this.raw.get("status").asText().trim();
+        return Option.some(Integer.parseInt(typeValue));
+      }
+      return Option.none();
+    } catch (final NumberFormatException e) {
+      return Option.none();
+    }
   }
 
   /**


### PR DESCRIPTION
**What's this do?**
This adjusts the HTTP implementation to allow for fetching status
codes from problem report documents in preference to the actual status
code delivered by the HTTP server. Essentially, if the server returns
content of type `application/problem+json`, and that content contains
a `status` field, the integer value of that field will replace the
actual HTTP status code.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2402

Briefly, we want to be able to host problem documents on static web servers and have the app behave as if the servers returned error codes.

**How should this be tested? / Do these changes have associated tests?**
We don't have any servers for testing yet, but every HTTP request the app makes goes through the interface in question, so maybe just check that the app can still get books and feeds from catalogs...

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m 

We have insufficient test coverage around the HTTP interface itself, but no existing tests broke and all of the catalogs I have access to still work.