### PR TITLE
SIMPLY-2627: Add a default cache duration of four hours for the NYPL account provider list.

### DIFF
--- a/simplified-accounts-registry-api/src/main/java/org/nypl/simplified/accounts/registry/api/AccountProviderRegistryType.kt
+++ b/simplified-accounts-registry-api/src/main/java/org/nypl/simplified/accounts/registry/api/AccountProviderRegistryType.kt
@@ -3,7 +3,6 @@ package org.nypl.simplified.accounts.registry.api
 import io.reactivex.Observable
 import org.nypl.simplified.accounts.api.AccountProviderDescriptionType
 import org.nypl.simplified.accounts.api.AccountProviderType
-
 import java.net.URI
 import javax.annotation.concurrent.ThreadSafe
 
@@ -48,6 +47,12 @@ interface AccountProviderRegistryType {
    */
 
   fun refresh(includeTestingLibraries: Boolean)
+
+  /**
+   * Clear cached account providers from all sources.
+   */
+
+  fun clear()
 
   /**
    * Return an immutable read-only of the account provider descriptions.

--- a/simplified-accounts-registry/src/main/java/org/nypl/simplified/accounts/registry/AccountProviderRegistry.kt
+++ b/simplified-accounts-registry/src/main/java/org/nypl/simplified/accounts/registry/AccountProviderRegistry.kt
@@ -95,6 +95,12 @@ class AccountProviderRegistry private constructor(
     }
   }
 
+  override fun clear() {
+    for (source in this.sources) {
+      source.clear(this.context)
+    }
+  }
+
   override fun updateProvider(accountProvider: AccountProviderType): AccountProviderType {
     val id = accountProvider.id
     val existing = this.resolved[id]

--- a/simplified-accounts-source-filebased/src/main/java/org/nypl/simplified/accounts/source/filebased/AccountProviderSourceFileBased.kt
+++ b/simplified-accounts-source-filebased/src/main/java/org/nypl/simplified/accounts/source/filebased/AccountProviderSourceFileBased.kt
@@ -49,6 +49,10 @@ class AccountProviderSourceFileBased(
     }
   }
 
+  override fun clear(context: Context) {
+    cache = null
+  }
+
   private fun mapResult(cached: Map<URI, AccountProviderType>) =
     cached.mapValues { v -> v.value.toDescription() }
 }

--- a/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderSourceNYPLRegistry.kt
+++ b/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderSourceNYPLRegistry.kt
@@ -5,6 +5,9 @@ import com.io7m.jfunctional.Option
 import com.io7m.jfunctional.OptionType
 import com.io7m.jfunctional.Some
 import com.io7m.junreachable.UnreachableCodeException
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.Duration
 import org.nypl.simplified.accounts.api.AccountProviderDescriptionCollection
 import org.nypl.simplified.accounts.api.AccountProviderDescriptionCollectionParsersType
 import org.nypl.simplified.accounts.api.AccountProviderDescriptionCollectionSerializersType
@@ -89,6 +92,9 @@ class AccountProviderSourceNYPLRegistry(
     val fileTemp: File
   )
 
+  /** The default time to retain the disk cache. */
+  private val defaultCacheDuration = Duration.standardHours(4)
+
   override fun load(context: Context, includeTestingLibraries: Boolean): SourceResult {
     if (this.stringResources == null) {
       this.stringResources = AccountProviderSourceResolutionStrings(context.resources)
@@ -97,15 +103,21 @@ class AccountProviderSourceNYPLRegistry(
     val files = this.cacheFiles(context)
     val diskResults = this.fetchDiskResults(files)
 
-    /*
-     * If we've not called the server before, and the disk cache is not empty, then just
-     * return the disk cache. Otherwise, we need to call the server.
-     */
-
     return try {
-      if (this.firstCall) {
-        if (diskResults.isNotEmpty()) {
+      /*
+       * If we have a populated disk cache, and haven't exceeded the cache duration, then
+       * just return the disk cache.
+       */
+      if (diskResults.isNotEmpty()) {
+        val now = DateTime.now(DateTimeZone.UTC)
+        val lastModifiedTime = DateTime(files.file.lastModified(), DateTimeZone.UTC)
+        val age = Duration(lastModifiedTime, now)
+
+        if (age.isShorterThan(defaultCacheDuration)) {
+          logger.debug("disk cache is fresh; last-modified={}", lastModifiedTime)
           return SourceResult.SourceSucceeded(diskResults)
+        } else {
+          logger.debug("disk cache is expired; last-modified={}", lastModifiedTime)
         }
       }
 
@@ -121,6 +133,14 @@ class AccountProviderSourceNYPLRegistry(
       SourceResult.SourceFailed(diskResults, e)
     } finally {
       this.firstCall = false
+    }
+  }
+
+  override fun clear(context: Context) {
+    synchronized(this.writeLock) {
+      val files = this.cacheFiles(context)
+      FileUtilities.fileDelete(files.file)
+      FileUtilities.fileDelete(files.fileTemp)
     }
   }
 

--- a/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderSourceNYPLRegistry.kt
+++ b/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderSourceNYPLRegistry.kt
@@ -82,9 +82,6 @@ class AccountProviderSourceNYPLRegistry(
   private val writeLock = Any()
 
   @Volatile
-  private var firstCall = true
-
-  @Volatile
   private var stringResources: AccountProviderResolutionStringsType? = null
 
   private data class CacheFiles(
@@ -131,8 +128,6 @@ class AccountProviderSourceNYPLRegistry(
     } catch (e: Exception) {
       this.logger.error("failed to fetch providers: ", e)
       SourceResult.SourceFailed(diskResults, e)
-    } finally {
-      this.firstCall = false
     }
   }
 

--- a/simplified-accounts-source-spi/src/main/java/org/nypl/simplified/accounts/source/spi/AccountProviderSourceType.kt
+++ b/simplified-accounts-source-spi/src/main/java/org/nypl/simplified/accounts/source/spi/AccountProviderSourceType.kt
@@ -48,4 +48,8 @@ interface AccountProviderSourceType {
    */
 
   fun load(context: Context, includeTestingLibraries: Boolean): SourceResult
+
+  /** Clear any cached providers. */
+
+  fun clear(context: Context)
 }

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccountProviderRegistry.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccountProviderRegistry.kt
@@ -28,6 +28,9 @@ class MockAccountProviderRegistry : AccountProviderRegistryType {
   override fun refresh(includeTestingLibraries: Boolean) {
   }
 
+  override fun clear() {
+  }
+
   override fun accountProviderDescriptions(): Map<URI, AccountProviderDescriptionType> {
     return IntRange(0, 30)
       .toList()

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderDescriptionRegistryContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderDescriptionRegistryContract.kt
@@ -531,6 +531,8 @@ abstract class AccountProviderDescriptionRegistryContract {
           Pair(descriptionOld1.metadata.id, descriptionOld1),
           Pair(descriptionOld2.metadata.id, descriptionOld2)))
     }
+
+    override fun clear(context: Context) {}
   }
 
   class OKSource : AccountProviderSourceType {
@@ -541,17 +543,23 @@ abstract class AccountProviderDescriptionRegistryContract {
           Pair(description1.metadata.id, description1),
           Pair(description2.metadata.id, description2)))
     }
+
+    override fun clear(context: Context) {}
   }
 
   class CrashingSource : AccountProviderSourceType {
     override fun load(context: Context, includeTestingLibraries: Boolean): SourceResult {
       throw Exception()
     }
+
+    override fun clear(context: Context) {}
   }
 
   class FailingSource : AccountProviderSourceType {
     override fun load(context: Context, includeTestingLibraries: Boolean): SourceResult {
       return SourceResult.SourceFailed(mapOf(), java.lang.Exception())
     }
+
+    override fun clear(context: Context) {}
   }
 }


### PR DESCRIPTION
**What's this do?**
Cache account providers for four hours.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2627

**How should this be tested? / Do these changes have associated tests?**
Ensure account providers aren't refetched from the server (by looking at logcat) until the cache expires. This patch includes updated tests.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Yep!