### PR TITLE
Add a "sync now" analytics event

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/NYPL-Simplified/Simplified-Android-C
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/NYPL-Simplified/Simplified-Android-Core
 POM_SCM_URL=http://github.com/NYPL-Simplified/Simplified-Android-Core
 POM_URL=http://github.com/NYPL-Simplified/Simplified-Android-Core
-VERSION_NAME=5.0.2
+VERSION_NAME=5.0.3-SNAPSHOT
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/simplified-analytics-api/src/main/java/org/nypl/simplified/analytics/api/AnalyticsEvent.kt
+++ b/simplified-analytics-api/src/main/java/org/nypl/simplified/analytics/api/AnalyticsEvent.kt
@@ -383,4 +383,13 @@ sealed class AnalyticsEvent {
 
     val bookTitle: String
   ) : AnalyticsEvent()
+
+  /**
+   * The user explicitly asked for any buffered analytics events to be sent
+   */
+
+  data class SyncRequested(
+    override val timestamp: LocalDateTime = LocalDateTime.now(),
+    override val credentials: AccountAuthenticationCredentials?
+  ) : AnalyticsEvent()
 }

--- a/simplified-analytics-circulation/src/main/java/org/nypl/simplified/analytics/circulation/CirculationAnalyticsSystem.kt
+++ b/simplified-analytics-circulation/src/main/java/org/nypl/simplified/analytics/circulation/CirculationAnalyticsSystem.kt
@@ -27,6 +27,7 @@ class CirculationAnalyticsSystem(
 
   private fun consumeEvent(event: AnalyticsEvent): Unit =
     when (event) {
+      is AnalyticsEvent.SyncRequested,
       is AnalyticsEvent.BookPageTurned,
       is AnalyticsEvent.BookClosed,
       is AnalyticsEvent.ApplicationOpened,

--- a/simplified-ui-settings/build.gradle
+++ b/simplified-ui-settings/build.gradle
@@ -7,8 +7,10 @@ dependencies {
   api libraries.androidXRecyclerView
 
   implementation project(":simplified-adobe-extensions")
+  implementation project(":simplified-analytics-api")
   implementation project(":simplified-boot-api")
   implementation project(":simplified-buildconfig-api")
+  implementation project(":simplified-cardcreator")
   implementation project(":simplified-documents")
   implementation project(":simplified-profiles-controller-api")
   implementation project(":simplified-reports")
@@ -18,7 +20,6 @@ dependencies {
   implementation project(":simplified-ui-theme")
   implementation project(":simplified-ui-thread-api")
   implementation project(":simplified-ui-toolbar")
-  implementation project(":simplified-cardcreator")
 
   implementation libraries.kotlinStdlib
   implementation libraries.slf4j

--- a/simplified-ui-settings/src/main/res/layout/settings_version.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_version.xml
@@ -90,6 +90,13 @@
         android:layout_marginBottom="16dp"
         android:text="Show Error Page" />
 
+      <Button
+        android:id="@+id/settingsVersionDevSyncAnalytics"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="Send Analytics" />
+
       <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
**What's this do?**
This adds an analytics event that implementations can respond to by
sending any buffered data to the server. This isn't used by Circulation
analytics (which doesn't buffer anything), but is used by LFA analytics
for debugging. This also adds a button to the developer settings menu
that manually publishes the event.

**Why are we doing this? (w/ JIRA link if applicable)**
LFA have an analytics implementation that heavily buffers data (due to having to work in extremely poor network conditions). For ease of debugging, we need to be able to tell the analytics system "Send everything you have right now!".

**How should this be tested? / Do these changes have associated tests?**
No testing required. The sync event is never published by the application outside of the debug menu.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m 