### PR TITLE
SIMPLY-2708: First name with 3 letters doesn't allow new signup to continue

### DIFF
--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/PersonalInformationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/PersonalInformationFragment.kt
@@ -27,7 +27,6 @@ class PersonalInformationFragment : Fragment() {
 
   private lateinit var navController: NavController
   private lateinit var nextAction: NavDirections
-  private val nameMinChars = 3
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -91,8 +90,9 @@ class PersonalInformationFragment : Fragment() {
   }
 
   private fun validateForm() {
-    binding.nextBtn.isEnabled = binding.firstNameEt.text.length > nameMinChars &&
-      binding.lastNameEt.text.length > nameMinChars &&
+    binding.nextBtn.isEnabled =
+      binding.firstNameEt.text.trim().isNotEmpty() &&
+      binding.lastNameEt.text.trim().isNotEmpty() &&
       isValidEmailAddress()
   }
 


### PR DESCRIPTION
**What's this do?**
This removes the 4 character minimum from first and last name during the card creation process.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2708: First name with 3 letters doesn't allow new signup to continue](https://jira.nypl.org/browse/SIMPLY-2708)  
During QA, Joe found that he cannot create a card using the name `Bob`. @killerpuppytails has verified with Antonio that there is no character minimum on patron names.

**How should this be tested? / Do these changes have associated tests?**
Attempt to create a card with just 1 character for the first and last name fields in the card creator.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 