### PR TITLE
SIMPLY-2713: There is no indication to the user that the location is being fetched during the card creation process

### DIFF
--- a/simplified-cardcreator/src/main/res/layout/fragment_location.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_location.xml
@@ -31,6 +31,7 @@
             android:layout_marginRight="8dp"
             android:layout_marginBottom="8dp"
             android:fontFamily="sans-serif"
+            android:text="@string/validating_location"
             android:gravity="center"
             android:textSize="16sp" />
     </LinearLayout>
@@ -97,35 +98,5 @@
             android:textAllCaps="true" />
 
     </LinearLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/loading"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/trans_white"
-        android:visibility="gone">
-
-        <TextView
-            android:id="@+id/loading_tv"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:fontFamily="sans-serif"
-            android:text="@string/checking_location"
-            android:textSize="16sp"
-            app:layout_constraintBottom_toTopOf="@id/progress"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
-
-        <ProgressBar
-            android:id="@+id/progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-cardcreator/src/main/res/values/strings.xml
+++ b/simplified-cardcreator/src/main/res/values/strings.xml
@@ -126,6 +126,7 @@
     <string name="over_13">13 or Older</string>
     <string name="eula_checkbox">I agree to the terms of the End User License Agreement.</string>
     <string name="age_error">You are not old enough to sign up for a library card.</string>
+    <string name="validating_location">Validating your location&#8230;</string>
 
     <!-- Location -->
     <string name="checking_location">Checking location&#8230;</string>


### PR DESCRIPTION
**What's this do?**
QA reported some wonky behavior with the location screen. Here I have improved that logic a bit and provided some UI/UX indication that we are checking the user's location by way of a TextView set to `Validating your location....` proposed by @killerpuppytails 

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2713: There is no indication to the user that the location is being fetched during the card creation process](https://jira.nypl.org/browse/SIMPLY-2713)

**How should this be tested? / Do these changes have associated tests?**
Just launch the card creator and proceed to the location screen.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 