### PR TITLE
Feature/refresh accounts on background thread

### DIFF
--- a/simplified-books-controller-api/src/main/java/org/nypl/simplified/books/controller/api/BooksControllerType.kt
+++ b/simplified-books-controller-api/src/main/java/org/nypl/simplified/books/controller/api/BooksControllerType.kt
@@ -21,22 +21,6 @@ interface BooksControllerType {
   /**
    * Attempt to borrow the given book.
    *
-   * @param account The account that will receive the book
-   * @param id The ID of the book
-   * @param acquisition The acquisition entry for the book
-   * @param entry The OPDS feed entry for the book
-   */
-
-  fun bookBorrow(
-    account: AccountType,
-    bookID: BookID,
-    acquisition: OPDSAcquisition,
-    entry: OPDSAcquisitionFeedEntry
-  ): FluentFuture<TaskResult<BookStatusDownloadErrorDetails, Unit>>
-
-  /**
-   * Attempt to borrow the given book.
-   *
    * @param accountID The account that will receive the book
    * @param id The ID of the book
    * @param acquisition The acquisition entry for the book
@@ -47,21 +31,6 @@ interface BooksControllerType {
     accountID: AccountID,
     bookID: BookID,
     acquisition: OPDSAcquisition,
-    entry: OPDSAcquisitionFeedEntry
-  ): FluentFuture<TaskResult<BookStatusDownloadErrorDetails, Unit>>
-
-  /**
-   * Attempt to borrow the given book. The controller will pick the acquisition.
-   *
-   * @param account The account that will receive the book
-   * @param id The ID of the book
-   * @param entry The OPDS feed entry for the book
-   * @see org.nypl.simplified.books.book_database.api.BookAcquisitionSelection.preferredAcquisition
-   */
-
-  fun bookBorrowWithDefaultAcquisition(
-    account: AccountType,
-    bookID: BookID,
     entry: OPDSAcquisitionFeedEntry
   ): FluentFuture<TaskResult<BookStatusDownloadErrorDetails, Unit>>
 

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
@@ -1,6 +1,5 @@
 package org.nypl.simplified.books.controller
 
-import android.content.ContentResolver
 import android.net.Uri
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.base.Preconditions
@@ -12,11 +11,11 @@ import com.io7m.junreachable.UnreachableCodeException
 import one.irradia.mime.api.MIMEType
 import one.irradia.mime.vanilla.MIMEParser
 import org.joda.time.Duration
+import org.joda.time.Instant
 import org.joda.time.LocalDateTime
 import org.joda.time.Period
 import org.joda.time.PeriodType
 import org.librarysimplified.audiobook.api.PlayerUserAgent
-import org.librarysimplified.services.api.ServiceDirectoryType
 import org.nypl.drm.core.AdobeAdeptConnectorType
 import org.nypl.drm.core.AdobeAdeptExecutorType
 import org.nypl.drm.core.AdobeAdeptFulfillmentToken
@@ -33,13 +32,11 @@ import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookID
 import org.nypl.simplified.books.audio.AudioBookCredentials
 import org.nypl.simplified.books.audio.AudioBookManifestRequest
-import org.nypl.simplified.books.audio.AudioBookManifestStrategiesType
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleAudioBook
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleEPUB
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandlePDF
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryType
 import org.nypl.simplified.books.book_database.api.BookFormats
-import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails
 import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails.BookDatabaseFailed
@@ -63,7 +60,6 @@ import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails.Un
 import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails.UnusableAcquisitions
 import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails.WrongAvailability
 import org.nypl.simplified.books.book_registry.BookWithStatus
-import org.nypl.simplified.books.bundled.api.BundledContentResolverType
 import org.nypl.simplified.books.bundled.api.BundledURIs
 import org.nypl.simplified.books.controller.BookBorrowTask.DownloadResult.DownloadCancelled
 import org.nypl.simplified.books.controller.BookBorrowTask.DownloadResult.DownloadFailed
@@ -72,20 +68,16 @@ import org.nypl.simplified.books.controller.api.BookBorrowExceptionBadBorrowFeed
 import org.nypl.simplified.books.controller.api.BookBorrowExceptionDeviceNotActivated
 import org.nypl.simplified.books.controller.api.BookBorrowExceptionNoCredentials
 import org.nypl.simplified.books.controller.api.BookBorrowExceptionNoUsableAcquisition
-import org.nypl.simplified.books.controller.api.BookBorrowStringResourcesType
 import org.nypl.simplified.books.controller.api.BookUnexpectedTypeException
 import org.nypl.simplified.books.controller.api.BookUnsupportedTypeException
-import org.nypl.simplified.clock.ClockType
 import org.nypl.simplified.downloader.core.DownloadListenerType
 import org.nypl.simplified.downloader.core.DownloadType
-import org.nypl.simplified.downloader.core.DownloaderType
 import org.nypl.simplified.feeds.api.Feed
 import org.nypl.simplified.feeds.api.FeedEntry
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryCorrupt
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryOPDS
 import org.nypl.simplified.feeds.api.FeedGroup
 import org.nypl.simplified.feeds.api.FeedLoaderResult
-import org.nypl.simplified.feeds.api.FeedLoaderType
 import org.nypl.simplified.files.FileUtilities
 import org.nypl.simplified.http.core.HTTP
 import org.nypl.simplified.http.core.HTTPAuthOAuth
@@ -93,7 +85,6 @@ import org.nypl.simplified.http.core.HTTPAuthType
 import org.nypl.simplified.http.core.HTTPHasProblemReportType
 import org.nypl.simplified.http.core.HTTPOAuthToken
 import org.nypl.simplified.http.core.HTTPProblemReport
-import org.nypl.simplified.http.core.HTTPType
 import org.nypl.simplified.opds.core.OPDSAcquisition
 import org.nypl.simplified.opds.core.OPDSAcquisition.Relation.ACQUISITION_BORROW
 import org.nypl.simplified.opds.core.OPDSAcquisition.Relation.ACQUISITION_BUY
@@ -110,7 +101,6 @@ import org.nypl.simplified.opds.core.OPDSAvailabilityLoaned
 import org.nypl.simplified.opds.core.OPDSAvailabilityMatcherType
 import org.nypl.simplified.opds.core.OPDSAvailabilityOpenAccess
 import org.nypl.simplified.opds.core.OPDSAvailabilityRevoked
-import org.nypl.simplified.profiles.api.ProfilesDatabaseType
 import org.nypl.simplified.taskrecorder.api.TaskRecorder
 import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.slf4j.LoggerFactory
@@ -131,37 +121,16 @@ import java.util.concurrent.TimeoutException
  */
 
 class BookBorrowTask(
+  private val services: BookTaskRequiredServices,
   private val accountId: AccountID,
   private val acquisition: OPDSAcquisition,
   private val bookId: BookID,
   private val borrowTimeoutDuration: Duration = Duration.standardMinutes(1L),
   private val cacheDirectory: File,
-  private val contentResolver: ContentResolver,
   private val downloads: ConcurrentHashMap<BookID, DownloadType>,
   private val downloadTimeoutDuration: Duration = Duration.standardMinutes(3L),
-  private val entry: OPDSAcquisitionFeedEntry,
-  private val profiles: ProfilesDatabaseType,
-  private val services: ServiceDirectoryType
+  private val entry: OPDSAcquisitionFeedEntry
 ) : Callable<TaskResult<BookStatusDownloadErrorDetails, Unit>> {
-
-  private val adobeDRM =
-    this.services.optionalService(AdobeAdeptExecutorType::class.java)
-  private val audioBookManifestStrategies =
-    this.services.requireService(AudioBookManifestStrategiesType::class.java)
-  private val bookRegistry =
-    this.services.requireService(BookRegistryType::class.java)
-  private val borrowStrings =
-    this.services.requireService(BookBorrowStringResourcesType::class.java)
-  private val bundledContent =
-    this.services.requireService(BundledContentResolverType::class.java)
-  private val clock =
-    this.services.requireService(ClockType::class.java)
-  private val downloader =
-    this.services.requireService(DownloaderType::class.java)
-  private val feedLoader =
-    this.services.requireService(FeedLoaderType::class.java)
-  private val http =
-    this.services.requireService(HTTPType::class.java)
 
   private val contentTypeACSM =
     MIMEParser.parseRaisingException("application/vnd.adobe.adept+xml")
@@ -194,7 +163,7 @@ class BookBorrowTask(
   private var downloadRunningTotal: Long = 0L
 
   @Volatile
-  private var downloadTimeThen = this.clock.clockNow()
+  private var downloadTimeThen = Instant(0L)
 
   @Volatile
   private lateinit var fulfillURI: URI
@@ -229,6 +198,9 @@ class BookBorrowTask(
   @Throws(Exception::class)
   override fun call(): TaskResult<BookStatusDownloadErrorDetails, Unit> {
     return try {
+      this.steps.beginNewStep(this.services.borrowStrings.borrowStarted)
+      this.downloadTimeThen = this.services.clock.clockNow()
+
       this.debug(
         "borrowing will time out after {} seconds",
         this.borrowTimeoutDuration.standardSeconds
@@ -238,22 +210,24 @@ class BookBorrowTask(
         this.downloadTimeoutDuration.standardSeconds
       )
 
-      this.steps.beginNewStep(this.borrowStrings.borrowStarted)
+      /*
+       * Locate the account in the current profile.
+       */
 
       val foundAccount = try {
-        val profile = this.profiles.currentProfileUnsafe()
+        val profile = this.services.profiles.currentProfileUnsafe()
         profile.account(this.accountId)
       } catch (e: Throwable) {
-        this.logger.error("[{}]: failed to find account!", this.bookId.brief())
+        this.logger.error("[{}]: failed to find account! ", this.bookId.brief(), e)
 
         val failure =
           TaskResult.fail<BookStatusDownloadErrorDetails, Unit>(
-            description = this.borrowStrings.borrowStarted,
-            resolution = this.borrowStrings.borrowBookUnexpectedException,
-            errorValue = BookStatusDownloadErrorDetails.UnexpectedException(e)
+            description = this.services.borrowStrings.borrowStarted,
+            resolution = this.services.borrowStrings.borrowBookUnexpectedException,
+            errorValue = UnexpectedException(e)
           ) as TaskResult.Failure<BookStatusDownloadErrorDetails, Unit>
 
-        this.bookRegistry.update(
+        this.services.bookRegistry.update(
           BookWithStatus(this.bookInitial, BookStatus.FailedLoan(this.bookId, failure)))
 
         return failure
@@ -313,7 +287,7 @@ class BookBorrowTask(
         ACQUISITION_SUBSCRIBE -> {
           this.debug("acquisition type is {}, cannot continue!", type)
           val exception = UnsupportedOperationException()
-          val message = this.borrowStrings.borrowBookUnsupportedAcquisition(type)
+          val message = this.services.borrowStrings.borrowBookUnsupportedAcquisition(type)
           this.steps.currentStepFailed(
             message = message,
             errorValue = UnsupportedAcquisition(
@@ -330,7 +304,7 @@ class BookBorrowTask(
       this.error("borrow failed: ", e)
 
       this.steps.currentStepFailedAppending(
-        this.borrowStrings.borrowBookUnexpectedException,
+        this.services.borrowStrings.borrowBookUnexpectedException,
         UnexpectedException(e, this.currentAttributesWith()),
         e
       )
@@ -340,7 +314,7 @@ class BookBorrowTask(
         if (this.databaseEntryInitialized) {
           BookStatus.fromBook(this.databaseEntry.book)
         } else {
-          this.bookRegistry.bookStatusOrNull(this.bookId)
+          this.services.bookRegistry.bookStatusOrNull(this.bookId)
         }
 
       if (status is BookStatus.Loaned) {
@@ -376,7 +350,7 @@ class BookBorrowTask(
    */
 
   private fun createBookDatabaseEntry() {
-    this.steps.beginNewStep(this.borrowStrings.borrowBookDatabaseCreateOrUpdate)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookDatabaseCreateOrUpdate)
 
     try {
       this.debug("setting up book database entry")
@@ -387,13 +361,13 @@ class BookBorrowTask(
       this.publishBookStatus(
         BookStatus.RequestingLoan(
           id = this.bookId,
-          detailMessage = this.borrowStrings.borrowBookDatabaseCreateOrUpdate
+          detailMessage = this.services.borrowStrings.borrowBookDatabaseCreateOrUpdate
         )
       )
-      this.steps.currentStepSucceeded(this.borrowStrings.borrowBookDatabaseUpdated)
+      this.steps.currentStepSucceeded(this.services.borrowStrings.borrowBookDatabaseUpdated)
     } catch (e: Exception) {
       this.error("failed to set up book database entry: ", e)
-      val message = this.borrowStrings.borrowBookDatabaseFailed
+      val message = this.services.borrowStrings.borrowBookDatabaseFailed
       this.steps.currentStepFailed(
         message = message,
         errorValue = BookDatabaseFailed(message, this.currentAttributesWith()),
@@ -420,7 +394,7 @@ class BookBorrowTask(
    */
 
   private fun runAcquisitionBorrowGetFeedEntry(): FeedEntryOPDS {
-    this.steps.beginNewStep(this.borrowStrings.borrowBookGetFeedEntry)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookGetFeedEntry)
 
     val httpAuth = this.createHttpAuthIfRequired()
     this.debug("fetching item feed: {}", this.acquisition.uri)
@@ -428,13 +402,13 @@ class BookBorrowTask(
     this.publishBookStatus(
       BookStatus.RequestingLoan(
         id = this.bookId,
-        detailMessage = this.borrowStrings.borrowBookGetFeedEntry
+        detailMessage = this.services.borrowStrings.borrowBookGetFeedEntry
       )
     )
 
     val feedResult =
       try {
-        this.feedLoader.fetchURIRefreshing(this.acquisition.uri, httpAuth, "PUT")
+        this.services.feedLoader.fetchURIRefreshing(this.acquisition.uri, httpAuth, "PUT")
           .get(this.borrowTimeoutDuration.standardSeconds, TimeUnit.SECONDS)
       } catch (e: Exception) {
         this.error("feed loader raised exception: ", e)
@@ -446,7 +420,7 @@ class BookBorrowTask(
         }
 
         val message =
-          this.borrowStrings.borrowBookFeedLoadingFailed(e.localizedMessage)
+          this.services.borrowStrings.borrowBookFeedLoadingFailed(e.localizedMessage)
 
         this.steps.currentStepFailed(
           message = message,
@@ -472,7 +446,7 @@ class BookBorrowTask(
               is FeedEntryCorrupt -> {
                 this.error("unexpectedly received corrupt feed entry")
                 this.steps.currentStepFailed(
-                  message = this.borrowStrings.borrowBookBadBorrowFeed,
+                  message = this.services.borrowStrings.borrowBookBadBorrowFeed,
                   errorValue = FeedCorrupted(
                     exception = feedEntry.error,
                     attributes = this.currentAttributesWith()
@@ -495,7 +469,7 @@ class BookBorrowTask(
               is FeedEntryCorrupt -> {
                 this.error("unexpectedly received corrupt feed entry")
                 this.steps.currentStepFailed(
-                  message = this.borrowStrings.borrowBookBadBorrowFeed,
+                  message = this.services.borrowStrings.borrowBookBadBorrowFeed,
                   errorValue = FeedCorrupted(
                     exception = feedEntry.error,
                     attributes = this.currentAttributesWith()
@@ -513,7 +487,7 @@ class BookBorrowTask(
 
       is FeedLoaderResult.FeedLoaderFailure.FeedLoaderFailedGeneral -> {
         val message =
-          this.borrowStrings.borrowBookFeedLoadingFailed(feedResult.message)
+          this.services.borrowStrings.borrowBookFeedLoadingFailed(feedResult.message)
 
         this.steps.currentStepFailed(
           message = message,
@@ -530,7 +504,7 @@ class BookBorrowTask(
 
       is FeedLoaderResult.FeedLoaderFailure.FeedLoaderFailedAuthentication -> {
         val message =
-          this.borrowStrings.borrowBookFeedLoadingFailed(feedResult.message)
+          this.services.borrowStrings.borrowBookFeedLoadingFailed(feedResult.message)
 
         this.steps.currentStepFailed(
           message = message,
@@ -563,9 +537,9 @@ class BookBorrowTask(
       this.error("unexpectedly received feed with zero groups")
       val exception = BookBorrowExceptionBadBorrowFeed(IOException("No groups in feed: $uri"))
       this.steps.currentStepFailed(
-        message = this.borrowStrings.borrowBookBadBorrowFeed,
+        message = this.services.borrowStrings.borrowBookBadBorrowFeed,
         errorValue = FeedUnusable(
-          message = this.borrowStrings.borrowBookBadBorrowFeed,
+          message = this.services.borrowStrings.borrowBookBadBorrowFeed,
           attributes = this.currentAttributesWith(attribute)
         ),
         exception = exception
@@ -591,9 +565,9 @@ class BookBorrowTask(
       this.error("unexpectedly received feed with no entries")
       val exception = BookBorrowExceptionBadBorrowFeed(IOException("No entries in feed: $uri"))
       this.steps.currentStepFailed(
-        message = this.borrowStrings.borrowBookBadBorrowFeed,
+        message = this.services.borrowStrings.borrowBookBadBorrowFeed,
         errorValue = FeedUnusable(
-          message = this.borrowStrings.borrowBookBadBorrowFeed,
+          message = this.services.borrowStrings.borrowBookBadBorrowFeed,
           attributes = this.currentAttributesWith(attribute)
         ),
         exception = exception
@@ -609,7 +583,7 @@ class BookBorrowTask(
 
   private fun runAcquisitionBorrowForOPDSEntry(feedEntry: FeedEntryOPDS) {
     val availability = feedEntry.feedEntry.availability
-    this.steps.beginNewStep(this.borrowStrings.borrowBookBorrowForAvailability(availability))
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookBorrowForAvailability(availability))
 
     this.debug("received OPDS feed entry")
     this.debug("book availability is {}", availability)
@@ -735,7 +709,7 @@ class BookBorrowTask(
       this.runAcquisitionFulfill(feedEntry.feedEntry)
     } else {
       val exception = IllegalStateException()
-      val message = this.borrowStrings.borrowBookBorrowAvailabilityInappropriate(availability)
+      val message = this.services.borrowStrings.borrowBookBorrowAvailabilityInappropriate(availability)
       this.steps.currentStepFailed(
         message = message,
         errorValue = WrongAvailability(message, this.currentAttributesWith()),
@@ -752,7 +726,7 @@ class BookBorrowTask(
   private fun runAcquisitionFulfill(
     ee: OPDSAcquisitionFeedEntry
   ) {
-    this.steps.beginNewStep(this.borrowStrings.borrowBookFulfill)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookFulfill)
 
     this.debug("fulfilling book")
 
@@ -774,7 +748,7 @@ class BookBorrowTask(
     }
 
     val exception = BookBorrowExceptionNoUsableAcquisition()
-    val message = this.borrowStrings.borrowBookFulfillNoUsableAcquisitions
+    val message = this.services.borrowStrings.borrowBookFulfillNoUsableAcquisitions
     this.steps.currentStepFailed(
       message = message,
       errorValue = UnusableAcquisitions(message, this.currentAttributesWith()),
@@ -787,18 +761,14 @@ class BookBorrowTask(
     opdsEntry: OPDSAcquisitionFeedEntry,
     httpAuth: OptionType<HTTPAuthType>
   ) {
-    this.steps.beginNewStep(this.borrowStrings.borrowBookFetchingCover)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookFetchingCover)
     this.debug("fetching cover")
 
     return when (val result =
       BookCoverFetchTask(
-        bookRegistry = this.bookRegistry,
-        borrowStrings = this.borrowStrings,
-        bundledContent = this.bundledContent,
-        contentResolver = this.contentResolver,
+        services = this.services,
         databaseEntry = this.databaseEntry,
         feedEntry = opdsEntry,
-        http = this.http,
         httpAuth = httpAuth
       ).call()) {
       is TaskResult.Success -> {
@@ -913,7 +883,7 @@ class BookBorrowTask(
     acquisition: OPDSAcquisition,
     httpAuth: OptionType<HTTPAuthType>
   ) {
-    this.steps.beginNewStep(this.borrowStrings.borrowBookFulfillDownload)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookFulfillDownload)
     this.fulfillURI = acquisition.uri
 
     val (file, contentType) =
@@ -927,7 +897,7 @@ class BookBorrowTask(
     this.debug("content type is {}", contentType)
 
     this.steps.currentStepSucceeded(
-      this.borrowStrings.borrowBookFulfillDownloaded(file, contentType))
+      this.services.borrowStrings.borrowBookFulfillDownloaded(file, contentType))
 
     return when (contentType) {
       this.contentTypeACSM ->
@@ -962,7 +932,7 @@ class BookBorrowTask(
     val downloadListener =
       DownloadListener(downloadFuture) { runningTotal, expectedTotal, unconditional ->
         this.downloadDataReceived(
-          detailMessage = this.borrowStrings.borrowBookFulfillDownload,
+          detailMessage = this.services.borrowStrings.borrowBookFulfillDownload,
           runningTotal = runningTotal,
           expectedTotal = expectedTotal,
           unconditional = unconditional
@@ -970,14 +940,14 @@ class BookBorrowTask(
       }
 
     val download =
-      this.downloader.download(acquisition.uri, httpAuth, downloadListener)
+      this.services.downloader.download(acquisition.uri, httpAuth, downloadListener)
 
     this.downloads[this.bookId] = download
 
     val result = try {
       downloadFuture.get(this.downloadTimeoutDuration.standardSeconds, TimeUnit.SECONDS)
     } catch (ex: TimeoutException) {
-      val message = this.borrowStrings.borrowBookFulfillTimedOut
+      val message = this.services.borrowStrings.borrowBookFulfillTimedOut
       this.steps.currentStepFailed(
         message = message,
         errorValue = TimedOut(message, this.currentAttributesWith()),
@@ -1011,13 +981,13 @@ class BookBorrowTask(
       }
 
     val strategy =
-      this.audioBookManifestStrategies.createStrategy(
+      this.services.audioBookManifestStrategies.createStrategy(
         AudioBookManifestRequest(
           targetURI = acquisition.uri,
           contentType = targetContentType,
           userAgent = PlayerUserAgent(HTTP.userAgent()),
           credentials = audioBookCredentials,
-          services = this.services
+          services = this.services.services
         )
       )
 
@@ -1067,7 +1037,7 @@ class BookBorrowTask(
         val exception =
           this.someOrNull(result.exception) ?: IOException("I/O error")
         val message =
-          this.borrowStrings.borrowBookFulfillDownloadFailed(exception.localizedMessage)
+          this.services.borrowStrings.borrowBookFulfillDownloadFailed(exception.localizedMessage)
         val uriAttribute =
           Pair("Book URI", result.uri.toASCIIString())
 
@@ -1086,7 +1056,7 @@ class BookBorrowTask(
 
       DownloadCancelled -> {
         val exception = CancellationException()
-        val message = this.borrowStrings.borrowBookFulfillCancelled
+        val message = this.services.borrowStrings.borrowBookFulfillCancelled
         this.steps.currentStepFailed(
           message = message,
           errorValue = BookStatusDownloadErrorDetails.DownloadCancelled(
@@ -1114,7 +1084,7 @@ class BookBorrowTask(
     receivedContentType: MIMEType
   ) {
     this.steps.beginNewStep(
-      this.borrowStrings.borrowBookSaving(receivedContentType, expectedContentTypes)
+      this.services.borrowStrings.borrowBookSaving(receivedContentType, expectedContentTypes)
     )
 
     this.debug(
@@ -1155,7 +1125,7 @@ class BookBorrowTask(
     } else {
       this.error("database entry does not have a format handle for {}", handleContentType)
       val exception = BookUnsupportedTypeException(handleContentType)
-      val message = this.borrowStrings.borrowBookSavingCheckingContentTypeUnacceptable
+      val message = this.services.borrowStrings.borrowBookSavingCheckingContentTypeUnacceptable
       this.steps.currentStepFailed(
         message = message,
         errorValue = UnsupportedType(message, this.currentAttributesWith()),
@@ -1177,7 +1147,7 @@ class BookBorrowTask(
   ): MIMEType {
 
     this.steps.beginNewStep(
-      this.borrowStrings.borrowBookSavingCheckingContentType(
+      this.services.borrowStrings.borrowBookSavingCheckingContentType(
         receivedContentType, expectedContentTypes
       )
     )
@@ -1194,7 +1164,7 @@ class BookBorrowTask(
         receivedContentType
       )
 
-      this.steps.currentStepSucceeded(this.borrowStrings.borrowBookSavingCheckingContentTypeOK)
+      this.steps.currentStepSucceeded(this.services.borrowStrings.borrowBookSavingCheckingContentTypeOK)
       return expectedContentTypes.first()
     }
 
@@ -1225,7 +1195,7 @@ class BookBorrowTask(
         received = receivedContentType
       )
 
-    val message = this.borrowStrings.borrowBookSavingCheckingContentTypeUnacceptable
+    val message = this.services.borrowStrings.borrowBookSavingCheckingContentTypeUnacceptable
     this.steps.currentStepFailed(
       message = message,
       errorValue = UnsupportedType(
@@ -1247,7 +1217,7 @@ class BookBorrowTask(
   ) {
     this.debug("fulfilling ACSM file")
 
-    this.steps.beginNewStep(this.borrowStrings.borrowBookFulfillACSM)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookFulfillACSM)
 
     /*
      * The ACSM file will typically have downloaded almost instantly, leaving
@@ -1258,22 +1228,23 @@ class BookBorrowTask(
      */
 
     this.downloadDataReceived(
-      detailMessage = this.borrowStrings.borrowBookFulfillACSM,
+      detailMessage = this.services.borrowStrings.borrowBookFulfillACSM,
       runningTotal = 0L,
       expectedTotal = 100L,
       unconditional = true
     )
 
-    return if (this.adobeDRM != null) {
+    val adept = this.services.adobeDRM
+    return if (adept != null) {
       this.debug("DRM support is available, using DRM connector")
-      this.runFulfillACSMWithConnector(this.adobeDRM, file)
+      this.runFulfillACSMWithConnector(adept, file)
     } else {
       this.debug("DRM support is unavailable, cannot continue!")
       val ex = DRMUnsupportedException("DRM support is not available")
       this.steps.currentStepFailed(
-        message = this.borrowStrings.borrowBookFulfillDRMNotSupported,
+        message = this.services.borrowStrings.borrowBookFulfillDRMNotSupported,
         errorValue = DRMUnsupportedSystem(
-          message = this.borrowStrings.borrowBookFulfillDRMNotSupported,
+          message = this.services.borrowStrings.borrowBookFulfillDRMNotSupported,
           system = this.adobeACS
         ),
         exception = ex
@@ -1328,10 +1299,10 @@ class BookBorrowTask(
     acsmBytes: ByteArray,
     credentials: AccountAuthenticationAdobePostActivationCredentials
   ): AdobeDRMExtensions.Fulfillment {
-    this.steps.beginNewStep(this.borrowStrings.borrowBookFulfillACSMConnector)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookFulfillACSMConnector)
 
     this.downloadDataReceived(
-      detailMessage = this.borrowStrings.borrowBookFulfillACSMConnector,
+      detailMessage = this.services.borrowStrings.borrowBookFulfillACSMConnector,
       runningTotal = 0,
       expectedTotal = 100,
       unconditional = true
@@ -1348,7 +1319,7 @@ class BookBorrowTask(
         { connector -> this.runFulfillACSMWithConnectorCreateFakeDownload(connector) },
         { progress ->
           this.downloadDataReceived(
-            detailMessage = this.borrowStrings.borrowBookFulfillACSMConnector,
+            detailMessage = this.services.borrowStrings.borrowBookFulfillACSMConnector,
             runningTotal = progress.toLong(),
             expectedTotal = 100,
             unconditional = false
@@ -1365,7 +1336,7 @@ class BookBorrowTask(
         this.logger.debug("waiting for fulfillment for {} seconds", seconds)
         future.get(seconds, TimeUnit.SECONDS)
       } catch (e: TimeoutException) {
-        val message = this.borrowStrings.borrowBookFulfillTimedOut
+        val message = this.services.borrowStrings.borrowBookFulfillTimedOut
         this.steps.currentStepFailed(
           message = message,
           errorValue = TimedOut(message, this.currentAttributesWith()),
@@ -1376,7 +1347,7 @@ class BookBorrowTask(
       } catch (e: ExecutionException) {
         throw when (val cause = e.cause!!) {
           is CancellationException -> {
-            val message = this.borrowStrings.borrowBookFulfillCancelled
+            val message = this.services.borrowStrings.borrowBookFulfillCancelled
             this.steps.currentStepFailed(
               message = message,
               errorValue = BookStatusDownloadErrorDetails.DownloadCancelled(
@@ -1389,7 +1360,7 @@ class BookBorrowTask(
           }
           is AdobeDRMFulfillmentException -> {
             val message =
-              this.borrowStrings.borrowBookFulfillACSMConnectorFailed(cause.errorCode)
+              this.services.borrowStrings.borrowBookFulfillACSMConnectorFailed(cause.errorCode)
             this.steps.currentStepFailed(
               message = message,
               errorValue = DRMFailure(
@@ -1403,7 +1374,7 @@ class BookBorrowTask(
           }
           else -> {
             this.steps.currentStepFailed(
-              message = this.borrowStrings.borrowBookFulfillACSMFailed,
+              message = this.services.borrowStrings.borrowBookFulfillACSMFailed,
               errorValue = UnexpectedException(cause, this.currentAttributesWith()),
               exception = cause
             )
@@ -1412,14 +1383,14 @@ class BookBorrowTask(
         }
       } catch (e: Throwable) {
         this.steps.currentStepFailed(
-          message = this.borrowStrings.borrowBookFulfillACSMFailed,
+          message = this.services.borrowStrings.borrowBookFulfillACSMFailed,
           errorValue = UnexpectedException(e, this.currentAttributesWith()),
           exception = e
         )
         throw e
       }
 
-    this.steps.currentStepSucceeded(this.borrowStrings.borrowBookFulfillACSMConnectorOK)
+    this.steps.currentStepSucceeded(this.services.borrowStrings.borrowBookFulfillACSMConnectorOK)
     return fulfillment
   }
 
@@ -1429,7 +1400,7 @@ class BookBorrowTask(
    */
 
   private fun runFulfillACSMWithConnectorGetCredentials(): AccountAuthenticationAdobePostActivationCredentials {
-    this.steps.beginNewStep(this.borrowStrings.borrowBookFulfillACSMGettingDeviceCredentials)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookFulfillACSMGettingDeviceCredentials)
 
     val credentials =
       this.someOrNull(this.getRequiredAccountCredentials().adobePostActivationCredentials())
@@ -1437,7 +1408,7 @@ class BookBorrowTask(
     if (credentials == null) {
       val exception = BookBorrowExceptionDeviceNotActivated()
       val message =
-        this.borrowStrings.borrowBookFulfillACSMGettingDeviceCredentialsNotActivated
+        this.services.borrowStrings.borrowBookFulfillACSMGettingDeviceCredentialsNotActivated
       this.steps.currentStepFailed(
         message,
         errorValue = DRMDeviceNotActive(
@@ -1450,7 +1421,7 @@ class BookBorrowTask(
     }
 
     this.steps.currentStepSucceeded(
-      this.borrowStrings.borrowBookFulfillACSMGettingDeviceCredentialsOK
+      this.services.borrowStrings.borrowBookFulfillACSMGettingDeviceCredentialsOK
     )
     return credentials
   }
@@ -1460,12 +1431,12 @@ class BookBorrowTask(
    */
 
   private fun runFulfillACSMWithConnectorReadACSM(file: File): ByteArray {
-    this.steps.beginNewStep(this.borrowStrings.borrowBookFulfillACSMRead)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookFulfillACSMRead)
 
     try {
       return FileUtilities.fileReadBytes(file)
     } catch (e: Exception) {
-      val message = this.borrowStrings.borrowBookFulfillACSMReadFailed
+      val message = this.services.borrowStrings.borrowBookFulfillACSMReadFailed
       this.steps.currentStepFailed(
         message = message,
         errorValue = DRMUnreadableACSM(
@@ -1507,12 +1478,12 @@ class BookBorrowTask(
    */
 
   private fun runFulfillACSMWithConnectorCheckContentType(parsed: AdobeAdeptFulfillmentToken) {
-    this.steps.beginNewStep(this.borrowStrings.borrowBookFulfillACSMCheckContentType)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookFulfillACSMCheckContentType)
 
     val contentType = MIMEParser.parseRaisingException(parsed.format)
     if (this.contentTypeEPUB.fullType != contentType.fullType) {
       val exception = BookUnsupportedTypeException(contentType)
-      val message = this.borrowStrings.borrowBookFulfillACSMUnsupportedContentType
+      val message = this.services.borrowStrings.borrowBookFulfillACSMUnsupportedContentType
       this.steps.currentStepFailed(
         message = message,
         errorValue = DRMUnsupportedContentType(
@@ -1526,7 +1497,7 @@ class BookBorrowTask(
     }
 
     this.steps.currentStepSucceeded(
-      this.borrowStrings.borrowBookFulfillACSMCheckContentTypeOK(contentType)
+      this.services.borrowStrings.borrowBookFulfillACSMCheckContentTypeOK(contentType)
     )
   }
 
@@ -1535,12 +1506,12 @@ class BookBorrowTask(
    */
 
   private fun runFulfillACSMWithConnectorParse(acsmBytes: ByteArray): AdobeAdeptFulfillmentToken {
-    this.steps.beginNewStep(this.borrowStrings.borrowBookFulfillACSMParse)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookFulfillACSMParse)
 
     return try {
       AdobeAdeptFulfillmentToken.parseFromBytes(acsmBytes)
     } catch (e: Exception) {
-      val message = this.borrowStrings.borrowBookFulfillACSMParseFailed
+      val message = this.services.borrowStrings.borrowBookFulfillACSMParseFailed
       this.steps.currentStepFailed(
         message = message,
         errorValue = DRMUnparseableACSM(
@@ -1559,7 +1530,7 @@ class BookBorrowTask(
   ) {
     this.debug("fulfilling Simplified bearer token file")
 
-    this.steps.beginNewStep(this.borrowStrings.borrowBookFulfillBearerToken)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookFulfillBearerToken)
 
     /*
      * The bearer token file will typically have downloaded almost instantly, leaving
@@ -1568,7 +1539,7 @@ class BookBorrowTask(
      */
 
     this.downloadDataReceived(
-      detailMessage = this.borrowStrings.borrowBookFulfillBearerToken,
+      detailMessage = this.services.borrowStrings.borrowBookFulfillBearerToken,
       runningTotal = 0L,
       expectedTotal = 100L,
       unconditional = true
@@ -1578,7 +1549,7 @@ class BookBorrowTask(
       SimplifiedBearerTokenJSON.deserializeFromFile(ObjectMapper(), LocalDateTime.now(), file)
     } catch (ex: Exception) {
       this.error("failed to parse bearer token: {}: ", acquisition.uri, ex)
-      val message = this.borrowStrings.borrowBookFulfillUnparseableBearerToken
+      val message = this.services.borrowStrings.borrowBookFulfillUnparseableBearerToken
       this.steps.currentStepFailed(
         message = message,
         errorValue = UnparseableBearerToken(message, this.currentAttributesWith()),
@@ -1587,7 +1558,7 @@ class BookBorrowTask(
       throw ex
     }
 
-    this.steps.currentStepSucceeded(this.borrowStrings.borrowBookFulfillBearerTokenOK)
+    this.steps.currentStepSucceeded(this.services.borrowStrings.borrowBookFulfillBearerTokenOK)
 
     val nextAcquisition =
       OPDSAcquisition(
@@ -1636,12 +1607,12 @@ class BookBorrowTask(
 
   private fun runAcquisitionBundled() {
     this.debug("acquisition is bundled")
-    this.steps.beginNewStep(this.borrowStrings.borrowBookBundledCopy)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookBundledCopy)
 
     this.publishBookStatus(
       BookStatus.RequestingLoan(
         id = this.bookId,
-        detailMessage = this.borrowStrings.borrowBookBundledCopy
+        detailMessage = this.services.borrowStrings.borrowBookBundledCopy
       )
     )
 
@@ -1651,11 +1622,11 @@ class BookBorrowTask(
 
     try {
       return FileOutputStream(file).use { output ->
-        this.bundledContent.resolve(this.acquisition.uri).use { stream ->
+        this.services.bundledContent.resolve(this.acquisition.uri).use { stream ->
           val size = stream.available().toLong()
           var consumed = 0L
           this.downloadDataReceived(
-            detailMessage = this.borrowStrings.borrowBookBundledCopy,
+            detailMessage = this.services.borrowStrings.borrowBookBundledCopy,
             runningTotal = consumed,
             expectedTotal = size,
             unconditional = true
@@ -1670,7 +1641,7 @@ class BookBorrowTask(
             output.write(buffer, 0, r)
 
             this.downloadDataReceived(
-              detailMessage = this.borrowStrings.borrowBookBundledCopy,
+              detailMessage = this.services.borrowStrings.borrowBookBundledCopy,
               runningTotal = consumed,
               expectedTotal = size,
               unconditional = false
@@ -1695,7 +1666,7 @@ class BookBorrowTask(
     } catch (e: Exception) {
       this.logger.error("could not copy content: ", e)
 
-      val message = this.borrowStrings.borrowBookBundledCopyFailed
+      val message = this.services.borrowStrings.borrowBookBundledCopyFailed
       this.steps.currentStepFailed(
         message = message,
         errorValue = BundledCopyFailed(message, this.currentAttributesWith()),
@@ -1708,12 +1679,12 @@ class BookBorrowTask(
 
   private fun runAcquisitionContentURI() {
     this.debug("acquisition is content")
-    this.steps.beginNewStep(this.borrowStrings.borrowBookContentCopy)
+    this.steps.beginNewStep(this.services.borrowStrings.borrowBookContentCopy)
 
     this.publishBookStatus(
       BookStatus.RequestingLoan(
         id = this.bookId,
-        detailMessage = this.borrowStrings.borrowBookContentCopy
+        detailMessage = this.services.borrowStrings.borrowBookContentCopy
       )
     )
 
@@ -1726,14 +1697,14 @@ class BookBorrowTask(
         val uriText = this.acquisition.uri.toString()
 
         val streamMaybe =
-          this.contentResolver.openInputStream(Uri.parse(uriText))
+          this.services.contentResolver.openInputStream(Uri.parse(uriText))
             ?: throw FileNotFoundException(uriText)
 
         streamMaybe.use { stream ->
           val size = stream.available().toLong()
           var consumed = 0L
           this.downloadDataReceived(
-            detailMessage = this.borrowStrings.borrowBookContentCopy,
+            detailMessage = this.services.borrowStrings.borrowBookContentCopy,
             runningTotal = consumed,
             expectedTotal = size,
             unconditional = true
@@ -1748,7 +1719,7 @@ class BookBorrowTask(
             output.write(buffer, 0, r)
 
             this.downloadDataReceived(
-              detailMessage = this.borrowStrings.borrowBookContentCopy,
+              detailMessage = this.services.borrowStrings.borrowBookContentCopy,
               runningTotal = consumed,
               expectedTotal = size,
               unconditional = false
@@ -1773,7 +1744,7 @@ class BookBorrowTask(
     } catch (e: Exception) {
       this.logger.error("could not copy content: ", e)
 
-      val message = this.borrowStrings.borrowBookContentCopyFailed
+      val message = this.services.borrowStrings.borrowBookContentCopyFailed
       this.steps.currentStepFailed(
         message = message,
         errorValue = ContentCopyFailed(message, this.currentAttributesWith()),
@@ -1792,7 +1763,7 @@ class BookBorrowTask(
         this.warn("publishing status using a fake book")
         this.bookInitial
       }
-    this.bookRegistry.update(BookWithStatus(book, status))
+    this.services.bookRegistry.update(BookWithStatus(book, status))
   }
 
   private fun downloadDataReceived(
@@ -1809,7 +1780,7 @@ class BookBorrowTask(
      * second.
      */
 
-    val timeNow = this.clock.clockNow()
+    val timeNow = this.services.clock.clockNow()
     val period = Period(this.downloadTimeThen, timeNow, PeriodType.millis())
     if (period.millis >= 100 || unconditional) {
       val status =
@@ -1819,7 +1790,7 @@ class BookBorrowTask(
           currentTotalBytes = runningTotal,
           expectedTotalBytes = expectedTotal
         )
-      this.bookRegistry.update(BookWithStatus(this.databaseEntry.book, status))
+      this.services.bookRegistry.update(BookWithStatus(this.databaseEntry.book, status))
       this.downloadRunningTotal = runningTotal
       this.downloadTimeThen = timeNow
     }

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowWithDefaultAcquisitionTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowWithDefaultAcquisitionTask.kt
@@ -3,7 +3,7 @@ package org.nypl.simplified.books.controller
 import android.content.ContentResolver
 import org.joda.time.Duration
 import org.librarysimplified.services.api.ServiceDirectoryType
-import org.nypl.simplified.accounts.database.api.AccountType
+import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookID
 import org.nypl.simplified.books.book_database.api.BookAcquisitionSelection
@@ -14,6 +14,7 @@ import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.controller.api.BookBorrowStringResourcesType
 import org.nypl.simplified.downloader.core.DownloadType
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
+import org.nypl.simplified.profiles.api.ProfilesDatabaseType
 import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -25,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 
 class BookBorrowWithDefaultAcquisitionTask(
-  private val account: AccountType,
+  private val accountId: AccountID,
   private val bookId: BookID,
   private val borrowTimeoutDuration: Duration = Duration.standardMinutes(1L),
   private val cacheDirectory: File,
@@ -33,6 +34,7 @@ class BookBorrowWithDefaultAcquisitionTask(
   private val downloads: ConcurrentHashMap<BookID, DownloadType>,
   private val downloadTimeoutDuration: Duration = Duration.standardMinutes(3L),
   private val entry: OPDSAcquisitionFeedEntry,
+  private val profiles: ProfilesDatabaseType,
   private val services: ServiceDirectoryType
 ) : Callable<TaskResult<BookStatusDownloadErrorDetails, Unit>> {
 
@@ -50,7 +52,7 @@ class BookBorrowWithDefaultAcquisitionTask(
   private val bookInitial =
     Book(
       id = this.bookId,
-      account = this.account.id,
+      account = this.accountId,
       cover = null,
       thumbnail = null,
       entry = this.entry,
@@ -81,7 +83,7 @@ class BookBorrowWithDefaultAcquisitionTask(
     }
 
     return BookBorrowTask(
-      account = this.account,
+      accountId = accountId,
       acquisition = acquisition,
       bookId = this.bookId,
       borrowTimeoutDuration = this.borrowTimeoutDuration,
@@ -90,6 +92,7 @@ class BookBorrowWithDefaultAcquisitionTask(
       downloads = this.downloads,
       downloadTimeoutDuration = this.downloadTimeoutDuration,
       entry = this.entry,
+      profiles = this.profiles,
       services = this.services
     ).call()
   }

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowWithDefaultAcquisitionTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowWithDefaultAcquisitionTask.kt
@@ -1,20 +1,15 @@
 package org.nypl.simplified.books.controller
 
-import android.content.ContentResolver
 import org.joda.time.Duration
-import org.librarysimplified.services.api.ServiceDirectoryType
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookID
 import org.nypl.simplified.books.book_database.api.BookAcquisitionSelection
-import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails
 import org.nypl.simplified.books.book_registry.BookWithStatus
-import org.nypl.simplified.books.controller.api.BookBorrowStringResourcesType
 import org.nypl.simplified.downloader.core.DownloadType
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
-import org.nypl.simplified.profiles.api.ProfilesDatabaseType
 import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -30,20 +25,14 @@ class BookBorrowWithDefaultAcquisitionTask(
   private val bookId: BookID,
   private val borrowTimeoutDuration: Duration = Duration.standardMinutes(1L),
   private val cacheDirectory: File,
-  private val contentResolver: ContentResolver,
   private val downloads: ConcurrentHashMap<BookID, DownloadType>,
   private val downloadTimeoutDuration: Duration = Duration.standardMinutes(3L),
   private val entry: OPDSAcquisitionFeedEntry,
-  private val profiles: ProfilesDatabaseType,
-  private val services: ServiceDirectoryType
+  private val services: BookTaskRequiredServices
 ) : Callable<TaskResult<BookStatusDownloadErrorDetails, Unit>> {
 
   private val logger =
     LoggerFactory.getLogger(BookBorrowWithDefaultAcquisitionTask::class.java)
-  private val borrowStrings =
-    this.services.requireService(BookBorrowStringResourcesType::class.java)
-  private val bookRegistry =
-    this.services.requireService(BookRegistryType::class.java)
 
   /**
    * The initial book value.
@@ -68,31 +57,29 @@ class BookBorrowWithDefaultAcquisitionTask(
 
       val failure =
         TaskResult.fail<BookStatusDownloadErrorDetails, Unit>(
-          description = this.borrowStrings.borrowBookSelectingAcquisition,
-          resolution = this.borrowStrings.borrowBookFulfillNoUsableAcquisitions,
+          description = this.services.borrowStrings.borrowBookSelectingAcquisition,
+          resolution = this.services.borrowStrings.borrowBookFulfillNoUsableAcquisitions,
           errorValue = BookStatusDownloadErrorDetails.UnusableAcquisitions(
-            message = this.borrowStrings.borrowBookFulfillNoUsableAcquisitions,
+            message = this.services.borrowStrings.borrowBookFulfillNoUsableAcquisitions,
             attributes = mapOf()
           )
         ) as TaskResult.Failure<BookStatusDownloadErrorDetails, Unit>
 
-      this.bookRegistry.update(
+      this.services.bookRegistry.update(
         BookWithStatus(this.bookInitial, BookStatus.FailedLoan(this.bookId, failure)))
 
       return failure
     }
 
     return BookBorrowTask(
-      accountId = accountId,
+      accountId = this.accountId,
       acquisition = acquisition,
       bookId = this.bookId,
       borrowTimeoutDuration = this.borrowTimeoutDuration,
       cacheDirectory = this.cacheDirectory,
-      contentResolver = this.contentResolver,
       downloads = this.downloads,
       downloadTimeoutDuration = this.downloadTimeoutDuration,
       entry = this.entry,
-      profiles = this.profiles,
       services = this.services
     ).call()
   }

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookTaskRequiredServices.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookTaskRequiredServices.kt
@@ -1,0 +1,51 @@
+package org.nypl.simplified.books.controller
+
+import android.content.ContentResolver
+import org.librarysimplified.services.api.ServiceDirectoryType
+import org.nypl.drm.core.AdobeAdeptExecutorType
+import org.nypl.simplified.books.audio.AudioBookManifestStrategiesType
+import org.nypl.simplified.books.book_registry.BookRegistryType
+import org.nypl.simplified.books.bundled.api.BundledContentResolverType
+import org.nypl.simplified.books.controller.api.BookBorrowStringResourcesType
+import org.nypl.simplified.clock.ClockType
+import org.nypl.simplified.downloader.core.DownloaderType
+import org.nypl.simplified.feeds.api.FeedLoaderType
+import org.nypl.simplified.http.core.HTTPType
+import org.nypl.simplified.profiles.api.ProfilesDatabaseType
+
+class BookTaskRequiredServices(
+  val adobeDRM: AdobeAdeptExecutorType?,
+  val audioBookManifestStrategies: AudioBookManifestStrategiesType,
+  val bookRegistry: BookRegistryType,
+  val borrowStrings: BookBorrowStringResourcesType,
+  val bundledContent: BundledContentResolverType,
+  val clock: ClockType,
+  val contentResolver: ContentResolver,
+  val downloader: DownloaderType,
+  val feedLoader: FeedLoaderType,
+  val http: HTTPType,
+  val profiles: ProfilesDatabaseType,
+  val services: ServiceDirectoryType
+) {
+  companion object {
+    fun createFromServices(
+      contentResolver: ContentResolver,
+      services: ServiceDirectoryType
+    ): BookTaskRequiredServices {
+      return BookTaskRequiredServices(
+        adobeDRM = services.optionalService(AdobeAdeptExecutorType::class.java),
+        audioBookManifestStrategies = services.requireService(AudioBookManifestStrategiesType::class.java),
+        bundledContent = services.requireService(BundledContentResolverType::class.java),
+        clock = services.requireService(ClockType::class.java),
+        downloader = services.requireService(DownloaderType::class.java),
+        feedLoader = services.requireService(FeedLoaderType::class.java),
+        http = services.requireService(HTTPType::class.java),
+        profiles = services.requireService(ProfilesDatabaseType::class.java),
+        bookRegistry = services.requireService(BookRegistryType::class.java),
+        borrowStrings = services.requireService(BookBorrowStringResourcesType::class.java),
+        contentResolver = contentResolver,
+        services = services
+      )
+    }
+  }
+}

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -1016,6 +1016,21 @@ internal object MainServices {
       interfaceType = ProfileIdleTimerType::class.java,
       serviceConstructor = { this.createProfileIdleTimer(profileEvents) })
 
+    addService(
+      message = strings.bootingAudioBookManifestStrategiesService,
+      interfaceType = AudioBookManifestStrategiesType::class.java,
+      serviceConstructor = { return@addService AudioBookManifests })
+
+    addServiceOptionally(
+      message = strings.bootingFeedbooksSecretService,
+      interfaceType = AudioBookFeedbooksSecretServiceType::class.java,
+      serviceConstructor = { MainFeedbooksSecretService.createConditionally(context) })
+
+    addServiceOptionally(
+      message = strings.bootingOverdriveSecretService,
+      interfaceType = AudioBookOverdriveSecretServiceType::class.java,
+      serviceConstructor = { MainOverdriveSecretService.createConditionally(context) })
+
     val bookController = this.run {
       publishEvent(strings.bootingBookController)
       val execBooks =
@@ -1132,21 +1147,6 @@ internal object MainServices {
       message = strings.bootingCardCreatorService,
       interfaceType = CardCreatorServiceType::class.java,
       serviceConstructor = { this.createCardCreatorService(context) })
-
-    addService(
-      message = strings.bootingAudioBookManifestStrategiesService,
-      interfaceType = AudioBookManifestStrategiesType::class.java,
-      serviceConstructor = { AudioBookManifests })
-
-    addServiceOptionally(
-      message = strings.bootingFeedbooksSecretService,
-      interfaceType = AudioBookFeedbooksSecretServiceType::class.java,
-      serviceConstructor = { MainFeedbooksSecretService.createConditionally(context) })
-
-    addServiceOptionally(
-      message = strings.bootingOverdriveSecretService,
-      interfaceType = AudioBookOverdriveSecretServiceType::class.java,
-      serviceConstructor = { MainOverdriveSecretService.createConditionally(context) })
 
     this.showThreads()
 

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/MockBooksController.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/MockBooksController.kt
@@ -32,14 +32,6 @@ class MockBooksController : BooksControllerType {
   }
 
   override fun bookBorrowWithDefaultAcquisition(
-    account: AccountType,
-    bookID: BookID,
-    entry: OPDSAcquisitionFeedEntry
-  ): FluentFuture<TaskResult<BookStatusDownloadErrorDetails, Unit>> {
-    return FluentFuture.from(SettableFuture.create())
-  }
-
-  override fun bookBorrowWithDefaultAcquisition(
     accountID: AccountID,
     id: BookID,
     entry: OPDSAcquisitionFeedEntry
@@ -70,15 +62,6 @@ class MockBooksController : BooksControllerType {
     accountID: AccountID,
     bookID: BookID
   ): FluentFuture<Unit> {
-    return FluentFuture.from(SettableFuture.create())
-  }
-
-  override fun bookBorrow(
-    account: AccountType,
-    bookID: BookID,
-    acquisition: OPDSAcquisition,
-    entry: OPDSAcquisitionFeedEntry
-  ): FluentFuture<TaskResult<BookStatusDownloadErrorDetails, Unit>> {
     return FluentFuture.from(SettableFuture.create())
   }
 

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/controller/BookBorrowTaskContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/controller/BookBorrowTaskContract.kt
@@ -52,6 +52,7 @@ import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails.Un
 import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.bundled.api.BundledContentResolverType
 import org.nypl.simplified.books.controller.BookBorrowTask
+import org.nypl.simplified.books.controller.BookTaskRequiredServices
 import org.nypl.simplified.books.controller.api.BookBorrowExceptionNoCredentials
 import org.nypl.simplified.books.controller.api.BookBorrowStringResourcesType
 import org.nypl.simplified.books.controller.api.BookUnexpectedTypeException
@@ -129,6 +130,7 @@ abstract class BookBorrowTaskContract {
   private lateinit var bookEvents: MutableList<BookEvent>
   private lateinit var bookRegistry: BookRegistryType
   private lateinit var booksDirectory: File
+  private lateinit var bookTaskRequiredServices: BookTaskRequiredServices
   private lateinit var bundledContent: BundledContentResolverType
   private lateinit var cacheDirectory: File
   private lateinit var clock: () -> Instant
@@ -170,6 +172,8 @@ abstract class BookBorrowTaskContract {
       Mockito.mock(ProfilesDatabaseType::class.java)
     this.profile =
       Mockito.mock(ProfileType::class.java)
+    this.downloader =
+      Mockito.mock(DownloaderType::class.java)
 
     Mockito.`when`(this.profilesDatabase.currentProfileUnsafe())
       .thenReturn(this.profile)
@@ -201,6 +205,10 @@ abstract class BookBorrowTaskContract {
     this.services.putService(DownloaderType::class.java, this.downloader)
     this.services.putService(FeedLoaderType::class.java, this.feedLoader)
     this.services.putService(HTTPType::class.java, this.http)
+    this.services.putService(ProfilesDatabaseType::class.java, this.profilesDatabase)
+
+    this.bookTaskRequiredServices =
+      BookTaskRequiredServices.createFromServices(this.contentResolver, this.services)
   }
 
   @After
@@ -313,9 +321,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -419,9 +425,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -567,9 +571,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -673,6 +675,9 @@ abstract class BookBorrowTaskContract {
     this.services.putService(BundledContentResolverType::class.java, bundledContent)
     this.services.putService(FeedLoaderType::class.java, feedLoader)
 
+    this.bookTaskRequiredServices =
+      BookTaskRequiredServices.createFromServices(this.contentResolver, this.services)
+
     val task =
       BookBorrowTask(
         accountId = account.id,
@@ -681,9 +686,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -762,9 +765,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -877,9 +878,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -982,9 +981,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -1102,9 +1099,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -1187,9 +1182,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -1286,9 +1279,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -1411,9 +1402,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -1506,9 +1495,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -1631,9 +1618,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -1715,9 +1700,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -1798,9 +1781,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -1894,9 +1875,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -1998,9 +1977,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -2120,9 +2097,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -2219,9 +2194,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -2346,9 +2319,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -2471,9 +2442,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -2493,11 +2462,14 @@ abstract class BookBorrowTaskContract {
 
   @Test(timeout = 5_000L)
   fun testBorrowFeedEPUBCancelled() {
-
-    this.downloader =
-      Mockito.mock(DownloaderType::class.java)
     val download =
       Mockito.mock(DownloadType::class.java)
+    this.downloader =
+      Mockito.mock(DownloaderType::class.java)
+    this.services.putService(
+      DownloaderType::class.java, this.downloader)
+    this.bookTaskRequiredServices =
+      BookTaskRequiredServices.createFromServices(this.contentResolver, this.services)
 
     Mockito.`when`(
       this.downloader.download(
@@ -2505,13 +2477,12 @@ abstract class BookBorrowTaskContract {
         this.anyNonNull(),
         this.anyNonNull()
       )
-    )
-      .then { invocation ->
-        val listener = invocation.arguments[2] as DownloadListenerType
-        listener.onDownloadStarted(download, 1000L)
-        listener.onDownloadCancelled(download)
-        download
-      }
+    ).then { invocation ->
+      val listener = invocation.arguments[2] as DownloadListenerType
+      listener.onDownloadStarted(download, 1000L)
+      listener.onDownloadCancelled(download)
+      download
+    }
 
     val account =
       Mockito.mock(AccountType::class.java)
@@ -2576,7 +2547,6 @@ abstract class BookBorrowTaskContract {
       .thenReturn(bookDatabase)
 
     this.services.ensureServiceIsNotPresent(AdobeAdeptExecutorType::class.java)
-    this.services.putService(DownloaderType::class.java, this.downloader)
 
     val task =
       BookBorrowTask(
@@ -2586,9 +2556,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -2612,11 +2580,14 @@ abstract class BookBorrowTaskContract {
 
   @Test(timeout = 5_000L)
   fun testBorrowFeedEPUBDownloadFails() {
-
-    this.downloader =
-      Mockito.mock(DownloaderType::class.java)
     val download =
       Mockito.mock(DownloadType::class.java)
+    this.downloader =
+      Mockito.mock(DownloaderType::class.java)
+    this.services.putService(
+      DownloaderType::class.java, this.downloader)
+    this.bookTaskRequiredServices =
+      BookTaskRequiredServices.createFromServices(this.contentResolver, this.services)
 
     Mockito.`when`(download.uri())
       .thenReturn(URI.create("urn:somewhere"))
@@ -2703,7 +2674,6 @@ abstract class BookBorrowTaskContract {
       .thenReturn(bookDatabase)
 
     this.services.ensureServiceIsNotPresent(AdobeAdeptExecutorType::class.java)
-    this.services.putService(DownloaderType::class.java, this.downloader)
 
     val task =
       BookBorrowTask(
@@ -2713,9 +2683,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -2790,9 +2758,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -2869,9 +2835,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -2993,9 +2957,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)
@@ -3019,9 +2981,6 @@ abstract class BookBorrowTaskContract {
 
   @Test(timeout = 5_000L)
   fun testBorrowCoverFailure() {
-
-    val feedLoader =
-      Mockito.mock(FeedLoaderType::class.java)
     val account =
       Mockito.mock(AccountType::class.java)
     val bookDatabase =
@@ -3112,7 +3071,6 @@ abstract class BookBorrowTaskContract {
       .thenReturn(formatHandle)
 
     this.services.ensureServiceIsNotPresent(AdobeAdeptExecutorType::class.java)
-    this.services.putService(FeedLoaderType::class.java, feedLoader)
 
     val task =
       BookBorrowTask(
@@ -3122,9 +3080,7 @@ abstract class BookBorrowTaskContract {
         cacheDirectory = this.cacheDirectory,
         downloads = ConcurrentHashMap(),
         entry = opdsEntry,
-        profiles = this.profilesDatabase,
-        services = this.services,
-        contentResolver = this.contentResolver
+        services = this.bookTaskRequiredServices
       )
 
     val results = task.call(); TaskDumps.dump(this.logger, results)

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
@@ -29,6 +29,7 @@ import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.analytics.api.AnalyticsType
 import org.nypl.simplified.books.api.BookEvent
 import org.nypl.simplified.books.api.BookID
+import org.nypl.simplified.books.audio.AudioBookManifestStrategiesType
 import org.nypl.simplified.books.book_database.api.BookFormats
 import org.nypl.simplified.books.book_registry.BookRegistry
 import org.nypl.simplified.books.book_registry.BookRegistryType
@@ -104,6 +105,7 @@ abstract class BooksControllerContract {
 
   private lateinit var accountEvents: PublishSubject<AccountEvent>
   private lateinit var accountEventsReceived: MutableList<AccountEvent>
+  private lateinit var audioBookManifestStrategies: AudioBookManifestStrategiesType
   private lateinit var authDocumentParsers: AuthenticationDocumentParsersType
   private lateinit var bookEvents: MutableList<BookEvent>
   private lateinit var bookRegistry: BookRegistryType
@@ -183,6 +185,8 @@ abstract class BooksControllerContract {
 
     val services = MutableServiceDirectory()
     services.putService(
+      AudioBookManifestStrategiesType::class.java, this.audioBookManifestStrategies)
+    services.putService(
       AnalyticsType::class.java, this.analytics)
     services.putService(
       AccountLoginStringResourcesType::class.java, this.accountLoginStringResources)
@@ -236,6 +240,7 @@ abstract class BooksControllerContract {
   @Before
   @Throws(Exception::class)
   fun setUp() {
+    this.audioBookManifestStrategies = Mockito.mock(AudioBookManifestStrategiesType::class.java)
     this.credentialsStore = FakeAccountCredentialStorage()
     this.http = MockingHTTP()
     this.authDocumentParsers = Mockito.mock(AuthenticationDocumentParsersType::class.java)

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/controller/ProfilesControllerContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/controller/ProfilesControllerContract.kt
@@ -21,6 +21,7 @@ import org.nypl.simplified.accounts.database.AccountBundledCredentialsEmpty
 import org.nypl.simplified.accounts.database.AccountsDatabases
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.analytics.api.AnalyticsType
+import org.nypl.simplified.books.audio.AudioBookManifestStrategiesType
 import org.nypl.simplified.books.book_database.api.BookFormats
 import org.nypl.simplified.books.book_registry.BookRegistry
 import org.nypl.simplified.books.book_registry.BookRegistryType
@@ -93,6 +94,7 @@ abstract class ProfilesControllerContract {
 
   private lateinit var accountEvents: PublishSubject<AccountEvent>
   private lateinit var accountEventsReceived: MutableList<AccountEvent>
+  private lateinit var audioBookManifestStrategies: AudioBookManifestStrategiesType
   private lateinit var authDocumentParsers: AuthenticationDocumentParsersType
   private lateinit var bookRegistry: BookRegistryType
   private lateinit var cacheDirectory: File
@@ -159,7 +161,9 @@ abstract class ProfilesControllerContract {
 
     val services = MutableServiceDirectory()
     services.putService(
-      AnalyticsType::class.java, analyticsLogger)
+      AudioBookManifestStrategiesType::class.java, this.audioBookManifestStrategies)
+    services.putService(
+      AnalyticsType::class.java, this.analyticsLogger)
     services.putService(
       AccountLoginStringResourcesType::class.java, this.accountLoginStringResources)
     services.putService(
@@ -177,23 +181,25 @@ abstract class ProfilesControllerContract {
     services.putService(
       BundledContentResolverType::class.java, bundledContent)
     services.putService(
-      DownloaderType::class.java, downloader)
+      DownloaderType::class.java, this.downloader)
     services.putService(
       FeedLoaderType::class.java, feedLoader)
     services.putService(
       OPDSFeedParserType::class.java, parser)
     services.putService(
-      HTTPType::class.java, http)
+      HTTPType::class.java, this.http)
     services.putService(
-      PatronUserProfileParsersType::class.java, patronUserProfileParsers)
+      PatronUserProfileParsersType::class.java, this.patronUserProfileParsers)
     services.putService(
-      ProfileAccountCreationStringResourcesType::class.java, profileAccountCreationStringResources)
+      ProfileAccountCreationStringResourcesType::class.java,
+      this.profileAccountCreationStringResources)
     services.putService(
-      ProfileAccountDeletionStringResourcesType::class.java, profileAccountDeletionStringResources)
+      ProfileAccountDeletionStringResourcesType::class.java,
+      this.profileAccountDeletionStringResources)
     services.putService(
       ProfilesDatabaseType::class.java, profiles)
     services.putService(
-      BookRevokeStringResourcesType::class.java, bookRevokeStringResources)
+      BookRevokeStringResourcesType::class.java, this.bookRevokeStringResources)
     services.putService(
       ProfileIdleTimerType::class.java, InoperableIdleTimer())
     services.putService(
@@ -203,8 +209,8 @@ abstract class ProfilesControllerContract {
       services = services,
       contentResolver = this.contentResolver,
       executorService = this.executorBooks,
-      accountEvents = accountEvents,
-      profileEvents = profileEvents,
+      accountEvents = this.accountEvents,
+      profileEvents = this.profileEvents,
       cacheDirectory = this.cacheDirectory
     )
   }
@@ -212,6 +218,7 @@ abstract class ProfilesControllerContract {
   @Before
   @Throws(Exception::class)
   fun setUp() {
+    this.audioBookManifestStrategies = Mockito.mock(AudioBookManifestStrategiesType::class.java)
     this.credentialsStore = FakeAccountCredentialStorage()
     this.http = MockingHTTP()
     this.authDocumentParsers = Mockito.mock(AuthenticationDocumentParsersType::class.java)

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -48,8 +48,8 @@ import org.nypl.simplified.opds.core.OPDSAvailabilityRevoked
 import org.nypl.simplified.presentableerror.api.PresentableErrorType
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.taskrecorder.api.TaskResult
-import org.nypl.simplified.taskrecorder.api.TaskStepResolution
 import org.nypl.simplified.taskrecorder.api.TaskStepResolution.TaskStepFailed
+import org.nypl.simplified.taskrecorder.api.TaskStepResolution.TaskStepSucceeded
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.nypl.simplified.ui.screen.ScreenSizeInformationType
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
@@ -995,21 +995,35 @@ class CatalogFragmentBookDetail : Fragment() {
 
   private fun tryReserveAuthenticated(book: Book) {
     this.logger.debug("reserving: {}", book.id)
-    this.booksController.bookBorrowWithDefaultAcquisition(
-      this.parameters.accountId, book.id, book.entry
-    )
+    try {
+      this.booksController.bookBorrowWithDefaultAcquisition(
+        this.parameters.accountId, book.id, book.entry
+      )
+    } catch (e: Throwable) {
+      this.logger.error("failed to start borrow task: ", e)
+    }
   }
 
   private fun tryRevokeAuthenticated(book: Book) {
     this.logger.debug("revoking: {}", book.id)
-    this.booksController.bookRevoke(this.parameters.accountId, book.id)
+
+    try {
+      this.booksController.bookRevoke(this.parameters.accountId, book.id)
+    } catch (e: Throwable) {
+      this.logger.error("failed to start revocation task: ", e)
+    }
   }
 
   private fun tryBorrowAuthenticated(book: Book) {
     this.logger.debug("borrowing: {}", book.id)
-    this.booksController.bookBorrowWithDefaultAcquisition(
-      this.parameters.accountId, book.id, book.entry
-    )
+
+    try {
+      this.booksController.bookBorrowWithDefaultAcquisition(
+        this.parameters.accountId, book.id, book.entry
+      )
+    } catch (e: Throwable) {
+      this.logger.error("failed to start borrow task: ", e)
+    }
   }
 
   private fun <E : PresentableErrorType> tryShowError(
@@ -1040,9 +1054,9 @@ class CatalogFragmentBookDetail : Fragment() {
     val attributes = mutableMapOf<String, String>()
     for (step in result.steps) {
       when (val resolution = step.resolution) {
-        is TaskStepResolution.TaskStepSucceeded -> {
+        is TaskStepSucceeded -> {
         }
-        is TaskStepResolution.TaskStepFailed -> {
+        is TaskStepFailed -> {
           attributes.putAll(resolution.errorValue.attributes)
         }
       }
@@ -1052,21 +1066,41 @@ class CatalogFragmentBookDetail : Fragment() {
 
   private fun tryDismissBorrowError(id: BookID) {
     this.logger.debug("dismissing borrow error: {}", id)
-    this.booksController.bookBorrowFailedDismiss(this.parameters.accountId, id)
+
+    try {
+      this.booksController.bookBorrowFailedDismiss(this.parameters.accountId, id)
+    } catch (e: Throwable) {
+      this.logger.error("failed to dismiss task error: ", e)
+    }
   }
 
   private fun tryDismissRevokeError(id: BookID) {
     this.logger.debug("dismissing revoke error: {}", id)
-    this.booksController.bookRevokeFailedDismiss(this.parameters.accountId, id)
+
+    try {
+      this.booksController.bookRevokeFailedDismiss(this.parameters.accountId, id)
+    } catch (e: Throwable) {
+      this.logger.error("failed to dismiss revoke error: ", e)
+    }
   }
 
   private fun tryCancelDownload(id: BookID) {
     this.logger.debug("cancelling: {}", id)
-    this.booksController.bookDownloadCancel(this.parameters.accountId, id)
+
+    try {
+      this.booksController.bookDownloadCancel(this.parameters.accountId, id)
+    } catch (e: Throwable) {
+      this.logger.error("failed to cancel download: ", e)
+    }
   }
 
   private fun tryDelete(id: BookID) {
     this.logger.debug("deleting: {}", id)
-    this.booksController.bookDelete(this.parameters.accountId, id)
+
+    try {
+      this.booksController.bookDelete(this.parameters.accountId, id)
+    } catch (e: Throwable) {
+      this.logger.error("failed to start deletion: ", e)
+    }
   }
 }

--- a/simplified-ui-settings/build.gradle
+++ b/simplified-ui-settings/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   implementation project(":simplified-profiles-controller-api")
   implementation project(":simplified-reports")
   implementation project(":simplified-services-api")
+  implementation project(":simplified-threads")
   implementation project(":simplified-ui-images")
   implementation project(":simplified-ui-navigation-api")
   implementation project(":simplified-ui-theme")

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookViewer.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookViewer.kt
@@ -1,7 +1,6 @@
 package org.nypl.simplified.viewer.audiobook
 
 import android.app.Activity
-import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookFormat
 import org.nypl.simplified.http.core.HTTP

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookViewer.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookViewer.kt
@@ -1,8 +1,10 @@
 package org.nypl.simplified.viewer.audiobook
 
 import android.app.Activity
+import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookFormat
+import org.nypl.simplified.http.core.HTTP
 import org.nypl.simplified.viewer.spi.ViewerProviderType
 import org.slf4j.LoggerFactory
 
@@ -38,12 +40,14 @@ class AudioBookViewer : ViewerProviderType {
     book: Book,
     format: BookFormat
   ) {
-    val formatAudio = format as BookFormat.BookFormatAudioBook
-    val manifest = formatAudio.manifest!!
+    val formatAudio =
+      format as BookFormat.BookFormatAudioBook
+    val manifest =
+      formatAudio.manifest!!
 
     val params =
       AudioBookPlayerParameters(
-        userAgent = TODO(),
+        userAgent = HTTP.userAgent(),
         manifestContentType = format.contentType.fullType,
         manifestFile = manifest.manifestFile,
         manifestURI = manifest.manifestURI,


### PR DESCRIPTION
**What's this do?**
This incorporates a number of updates. Specifically:

* Account registry refreshes are now run on a background I/O thread. This caused issues with SimplyE which was running in strict mode (which is a good thing!).
* We no longer hang forever when trying to borrow books, due to a missing service.
* Task exceptions are _always_ logged, unconditionally.
* It's now harder for book tasks to miss required services; the controller fetches them eagerly from the directory and the application will, as a result, refuse to boot if a service is missing.

**Why are we doing this? (w/ JIRA link if applicable)**
Numerous issues discovered during QA of recent builds. Not least of which, the terrifying https://jira.nypl.org/browse/SIMPLY-2716.

**How should this be tested? / Do these changes have associated tests?**
Try to borrow books. Try to borrow audio books. Essentially, continue with the QA that was already in progress. :laughing: 

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m, who is still in recovery