### PR TITLE
Fixed bug when creating a card and allow for quitting card creator

### DIFF
--- a/simplified-cardcreator/build.gradle
+++ b/simplified-cardcreator/build.gradle
@@ -16,8 +16,8 @@ dependencies {
   implementation libraries.androidXConstraintLayout
   implementation libraries.kotlinStdlib
 
-  def nav_version = "2.3.0-alpha04"
-  implementation "org.jetbrains.kotlin:kotlin-reflect:1.3.71"
+  def nav_version = "2.3.0-alpha05"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:1.3.72"
   implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
   implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
   implementation 'com.squareup.retrofit2:retrofit:2.7.2'

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AgeFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AgeFragment.kt
@@ -67,8 +67,7 @@ class AgeFragment : Fragment() {
         nextAction = AgeFragmentDirections.actionNext()
         navController.navigate(nextAction)
       } else {
-        val data = Intent()
-        requireActivity().setResult(Activity.RESULT_CANCELED, data)
+        requireActivity().setResult(Activity.RESULT_CANCELED)
         requireActivity().finish()
       }
     }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AgeFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AgeFragment.kt
@@ -1,7 +1,6 @@
 package org.nypl.simplified.cardcreator.ui
 
 import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ReviewFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ReviewFragment.kt
@@ -1,5 +1,6 @@
 package org.nypl.simplified.cardcreator.ui
 
+import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -93,8 +94,10 @@ class ReviewFragment : Fragment() {
         .setPositiveButton(getString(R.string.try_again)) { _, _ ->
           createPatron()
         }
-        .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
-          dialog.cancel()
+        .setNegativeButton(getString(R.string.quit)) { _, _ ->
+          Cache(requireContext()).clear()
+          requireActivity().setResult(Activity.RESULT_CANCELED)
+          requireActivity().finish()
         }
       val alert = dialogBuilder.create()
       alert.show()
@@ -120,7 +123,7 @@ class ReviewFragment : Fragment() {
         return Patron(
           homeAddress,
           personalInformation.email,
-          "$personalInformation.firstName $personalInformation.lastName",
+          "${personalInformation.firstName} ${personalInformation.lastName}",
           accountInformation.pin,
           accountInformation.username,
           workAddress)
@@ -129,7 +132,7 @@ class ReviewFragment : Fragment() {
         return Patron(
           homeAddress,
           personalInformation.email,
-          "$personalInformation.firstName $personalInformation.lastName",
+          "${personalInformation.firstName} ${personalInformation.lastName}",
           accountInformation.pin,
           accountInformation.username,
           workAddress)
@@ -138,7 +141,7 @@ class ReviewFragment : Fragment() {
         return Patron(
           homeAddress,
           personalInformation.email,
-          "$personalInformation.firstName $personalInformation.lastName",
+          "${personalInformation.firstName} ${personalInformation.lastName}",
           accountInformation.pin,
           accountInformation.username,
           schoolAddress)
@@ -179,7 +182,7 @@ class ReviewFragment : Fragment() {
       }
     }
     val personalInformation = cache.getPersonalInformation()
-    binding.nameTv.text = personalInformation.firstName + " " + personalInformation.lastName
+    binding.nameTv.text = "${personalInformation.firstName} ${personalInformation.lastName}"
     binding.emailTv.text = personalInformation.email
     val accountInformation = cache.getAccountInformation()
     binding.usernameTv.text = accountInformation.username

--- a/simplified-cardcreator/src/main/res/values/strings.xml
+++ b/simplified-cardcreator/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="sign_up">Sign Up for a Library Card</string>
 
     <!-- Review -->
+    <string name="quit">Quit</string>
     <string name="name">Name</string>
     <string name="username">Username</string>
     <string name="email">Email</string>


### PR DESCRIPTION
**What's this do?**
This will correctly unwrap the user's personal information attributes and adds a quit button incase the the createPatron() endpoint repeatedly fails

**Why are we doing this? (w/ JIRA link if applicable)**
QA found a bug that was stopping the creation of a card during testing

**How should this be tested? / Do these changes have associated tests?**
Attempt to create a card

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 