### PR TITLE
Refresh account providers frequently

### DIFF
--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
@@ -587,11 +587,12 @@ class Controller private constructor(
     account: AccountType
   ): FluentFuture<Unit> {
     return this.submitTask(BookSyncTask(
-      booksController = this,
       account = account,
+      accountRegistry = this.accountProviders,
       bookRegistry = this.bookRegistry,
-      http = this.http,
-      feedParser = this.feedParser
+      booksController = this,
+      feedParser = this.feedParser,
+      http = this.http
     ))
   }
 

--- a/simplified-ui-settings/build.gradle
+++ b/simplified-ui-settings/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
   implementation project(":simplified-adobe-extensions")
   implementation project(":simplified-analytics-api")
+  implementation project(":simplified-books-controller-api")
   implementation project(":simplified-boot-api")
   implementation project(":simplified-buildconfig-api")
   implementation project(":simplified-cardcreator")

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentVersion.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentVersion.kt
@@ -24,6 +24,7 @@ import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.adobe.extensions.AdobeDRMExtensions
 import org.nypl.simplified.analytics.api.AnalyticsEvent
 import org.nypl.simplified.analytics.api.AnalyticsType
+import org.nypl.simplified.books.controller.api.BooksControllerType
 import org.nypl.simplified.boot.api.BootFailureTesting
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.navigation.api.NavigationControllers
@@ -52,6 +53,7 @@ class SettingsFragmentVersion : Fragment() {
   private lateinit var accountRegistry: AccountProviderRegistryType
   private lateinit var adobeDRMActivationTable: TableLayout
   private lateinit var analytics: AnalyticsType
+  private lateinit var booksController: BooksControllerType
   private lateinit var buildConfig: BuildConfigurationServiceType
   private lateinit var buildText: TextView
   private lateinit var buildTitle: TextView
@@ -66,6 +68,7 @@ class SettingsFragmentVersion : Fragment() {
   private lateinit var sendReportButton: Button
   private lateinit var showErrorButton: Button
   private lateinit var showTesting: Switch
+  private lateinit var syncAccountsButton: Button
   private lateinit var toolbar: Toolbar
   private lateinit var uiThread: UIThreadServiceType
   private lateinit var versionText: TextView
@@ -79,6 +82,8 @@ class SettingsFragmentVersion : Fragment() {
 
     val services = Services.serviceDirectory()
 
+    this.booksController =
+      services.requireService(BooksControllerType::class.java)
     this.profilesController =
       services.requireService(ProfilesControllerType::class.java)
     this.accountRegistry =
@@ -113,6 +118,8 @@ class SettingsFragmentVersion : Fragment() {
       this.developerOptions.findViewById(R.id.settingsVersionDevShowError)
     this.sendAnalyticsButton =
       this.developerOptions.findViewById(R.id.settingsVersionDevSyncAnalytics)
+    this.syncAccountsButton =
+      this.developerOptions.findViewById(R.id.settingsVersionDevSyncAccounts)
 
     this.buildTitle =
       layout.findViewById(R.id.settingsVersionBuildTitle)
@@ -212,6 +219,25 @@ class SettingsFragmentVersion : Fragment() {
 
     this.showErrorButton.setOnClickListener {
       this.showErrorPage()
+    }
+
+    this.syncAccountsButton.setOnClickListener {
+      Toast.makeText(
+        this.requireContext(),
+        "Triggered sync of all accounts",
+        Toast.LENGTH_SHORT
+      ).show()
+
+      try {
+        this.profilesController.profileCurrent()
+          .accounts()
+          .values
+          .forEach { account ->
+            this.booksController.booksSync(account)
+          }
+      } catch (e: Exception) {
+        this.logger.error("ouch: ", e)
+      }
     }
 
     this.developerOptions.visibility = View.GONE

--- a/simplified-ui-settings/src/main/res/layout/settings_version.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_version.xml
@@ -97,6 +97,13 @@
         android:layout_marginBottom="16dp"
         android:text="Send Analytics" />
 
+      <Button
+        android:id="@+id/settingsVersionDevSyncAccounts"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="Sync Accounts" />
+
       <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
**What's this do?**
This updates the book account sync task to re-resolve account providers
before syncing loans. This ensures that we're always using up-to-date
information from the authentication document.

Additionally, a button has been added in the developer settings menu
to manually trigger a sync of all accounts.

**Why are we doing this? (w/ JIRA link if applicable)**
Fix: https://jira.nypl.org/browse/SIMPLY-2629

**How should this be tested? / Do these changes have associated tests?**
I'm not completely sure how this should be tested as I'm not sure what the problem was that prompted this ticket. @leonardr Do you have any ideas?

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Documentation on the accounts system may be incoming.

**Did someone actually run this code to verify it works?**
@io7m 