### PR TITLE
Removed the multidex support library.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,6 @@ ext.libraries = [
   androidXLegacyPreferenceV14      : "androidx.legacy:legacy-preference-v14:1.0.0",
   androidXLegacySupport            : "androidx.legacy:legacy-support-v4:1.0.0",
   androidXLifecycle                : "androidx.lifecycle:lifecycle-extensions:2.1.0",
-  androidXMultidex                 : "androidx.multidex:multidex:2.0.0",
   androidXPaging                   : "androidx.paging:paging-runtime-ktx:2.1.0",
   androidXPreference               : "androidx.preference:preference-ktx:1.1.0",
   androidXRecyclerView             : "androidx.recyclerview:recyclerview:1.1.0",
@@ -245,7 +244,6 @@ Automatic-Module-Name: ${POM_AUTOMATIC_MODULE_NAME}
         buildToolsVersion androidBuildToolsVersion
 
         defaultConfig {
-          multiDexEnabled true
           minSdkVersion androidMinimumSDKVersion
           targetSdkVersion androidTargetSDKVersion
           testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/simplified-app-vanilla/build.gradle
+++ b/simplified-app-vanilla/build.gradle
@@ -19,7 +19,6 @@ android {
   def version = versionValues()
 
   defaultConfig {
-    multiDexEnabled true
     versionName = version.get(0)
     versionCode = version.get(1)
     setProperty("archivesBaseName", "${versionName}-${versionCode}")

--- a/simplified-main/build.gradle
+++ b/simplified-main/build.gradle
@@ -64,7 +64,6 @@ dependencies {
 
   api libraries.androidAsync
   api libraries.androidXAppCompat
-  api libraries.androidXMultidex
   api libraries.kotlinStdlib
   api libraries.slf4j
 

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainApplication.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainApplication.kt
@@ -1,9 +1,9 @@
 package org.nypl.simplified.main
 
+import android.app.Application
 import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
-import androidx.multidex.MultiDexApplication
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.core.rolling.RollingFileAppender
 import com.google.common.util.concurrent.ListenableFuture
@@ -15,7 +15,7 @@ import org.nypl.simplified.boot.api.BootProcessType
 import org.slf4j.LoggerFactory
 import java.io.File
 
-class MainApplication : MultiDexApplication() {
+class MainApplication : Application() {
 
   companion object {
     private lateinit var INSTANCE: MainApplication

--- a/simplified-tests-sandbox/build.gradle
+++ b/simplified-tests-sandbox/build.gradle
@@ -42,7 +42,6 @@ dependencies {
   implementation libraries.androidXConstraintLayout
   implementation libraries.androidXLegacySupport
   implementation libraries.androidXLifecycle
-  implementation libraries.androidXMultidex
   implementation libraries.bottomNavigator
   implementation libraries.googleAndroidMaterial
   implementation libraries.io7mJFunctional


### PR DESCRIPTION
Multidex is on by default in API 21 and above.

> If your `minSdkVersion` is set to 21 or higher, multidex is enabled by
default and you do not need the multidex support library.

https://developer.android.com/studio/build/multidex#mdex-gradle