### PR TITLE
SIMPLY-2403: Retrieve annotations links from loans feeds

### DIFF
--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountProvider.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountProvider.kt
@@ -11,7 +11,6 @@ data class AccountProvider(
   override val subtitle: String?,
   override val logo: URI?,
   override val authentication: AccountProviderAuthenticationDescription?,
-  override val supportsSimplyESynchronization: Boolean,
   override val supportsReservations: Boolean,
   override val loansURI: URI?,
   override val cardCreatorURI: URI?,
@@ -30,6 +29,9 @@ data class AccountProvider(
   override fun compareTo(other: AccountProviderType): Int {
     return this.id.compareTo(other.id)
   }
+
+  override val supportsSimplyESynchronization: Boolean =
+    this.annotationsURI != null
 
   companion object {
 
@@ -64,7 +66,6 @@ data class AccountProvider(
         subtitle = other.subtitle,
         supportEmail = other.supportEmail,
         supportsReservations = other.supportsReservations,
-        supportsSimplyESynchronization = other.supportsSimplyESynchronization,
         updated = other.updated
       )
     }

--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountProviderType.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountProviderType.kt
@@ -2,6 +2,7 @@ package org.nypl.simplified.accounts.api
 
 import org.joda.time.DateTime
 import org.nypl.simplified.links.Link
+import org.nypl.simplified.opds.core.OPDSFeedConstants.AUTHENTICATION_DOCUMENT_RELATION_URI_TEXT
 import java.net.URI
 import javax.annotation.concurrent.ThreadSafe
 
@@ -212,6 +213,9 @@ interface AccountProviderType : Comparable<AccountProviderType> {
     this.annotationsURI?.let { uri ->
       addLink(links, uri, "http://www.w3.org/ns/oa#annotationService")
     }
+    this.authenticationDocumentURI?.let { uri ->
+      addLink(links, uri, AUTHENTICATION_DOCUMENT_RELATION_URI_TEXT)
+    }
     this.cardCreatorURI?.let { uri ->
       addLink(links, uri, "register")
     }
@@ -231,15 +235,19 @@ interface AccountProviderType : Comparable<AccountProviderType> {
       addLink(links, uri, "privacy-policy")
     }
 
-    return AccountProviderDescription(
-      id = this.id,
-      title = this.displayName,
-      updated = this.updated,
-      links = links.toList(),
-      images = imageLinks.toList(),
-      isAutomatic = this.addAutomatically,
-      isProduction = this.isProduction
-    )
+    val accountProviderDescription =
+      AccountProviderDescription(
+        id = id,
+        title = displayName,
+        updated = updated,
+        links = links.toList(),
+        images = imageLinks.toList(),
+        isAutomatic = addAutomatically,
+        isProduction = isProduction
+      )
+
+    check((this.authenticationDocumentURI != null) == (accountProviderDescription.authenticationDocumentURI != null))
+    return accountProviderDescription
   }
 
   private fun addLink(links: MutableList<Link>, uri: URI, relation: String): Boolean {

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
@@ -155,8 +155,6 @@ object AccountProvidersJSON {
         JSONParserUtilities.getStringOrNull(obj, "supportEmail")
       val supportsReservations =
         JSONParserUtilities.getBooleanDefault(obj, "supportsReservations", false)
-      val supportsSimplyESynchronization =
-        JSONParserUtilities.getBooleanDefault(obj, "supportsSimplyESynchronization", false)
       val isProduction =
         JSONParserUtilities.getBooleanDefault(obj, "isProduction", false)
       val idNumeric =
@@ -188,7 +186,6 @@ object AccountProvidersJSON {
         subtitle = subtitle,
         supportEmail = supportEmail,
         supportsReservations = supportsReservations,
-        supportsSimplyESynchronization = supportsSimplyESynchronization,
         updated = updated
       )
     } catch (e: JSONParseException) {

--- a/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderResolution.kt
+++ b/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderResolution.kt
@@ -124,7 +124,6 @@ class AccountProviderResolution(
           subtitle = authDocument?.description,
           supportEmail = authDocument?.supportURI?.toString(),
           supportsReservations = supportsReservations,
-          supportsSimplyESynchronization = false,
           updated = updated
         )
 

--- a/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaAccountFallback.kt
+++ b/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaAccountFallback.kt
@@ -37,7 +37,6 @@ class VanillaAccountFallback : AccountProviderFallbackType {
       subtitle = "A selection of classics and modern material available to anyone, with no library card necessary.",
       supportEmail = "mailto:gethelp+simplye-collection@nypl.org",
       supportsReservations = false,
-      supportsSimplyESynchronization = false,
       updated = DateTime.parse("2019-07-08T16:32:52+00:00")
     )
   }

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeed.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeed.java
@@ -3,7 +3,6 @@ package org.nypl.simplified.opds.core;
 import com.io7m.jfunctional.Option;
 import com.io7m.jfunctional.OptionType;
 import com.io7m.jfunctional.Pair;
-import com.io7m.jnull.Nullable;
 
 import org.joda.time.DateTime;
 import org.nypl.simplified.parser.api.ParseError;
@@ -43,6 +42,7 @@ public final class OPDSAcquisitionFeed implements Serializable {
   private final OptionType<URI> privacy_policy;
   private final List<ParseError> errors;
   private final OptionType<URI> auth_document;
+  private final OptionType<URI> annotations;
 
   private OPDSAcquisitionFeed(
     final URI in_uri,
@@ -62,7 +62,7 @@ public final class OPDSAcquisitionFeed implements Serializable {
     final OptionType<URI> in_licenses,
     final OptionType<DRMLicensor> in_licensor,
     final List<ParseError> in_errors,
-    final OptionType<URI> in_auth_document) {
+    final OptionType<URI> in_auth_document, OptionType<URI> in_annotations) {
     this.uri =
       Objects.requireNonNull(in_uri);
     this.entries =
@@ -98,6 +98,8 @@ public final class OPDSAcquisitionFeed implements Serializable {
       Objects.requireNonNull(in_errors, "in_errors");
     this.auth_document =
       Objects.requireNonNull(in_auth_document, "in_auth_document");
+    this.annotations =
+      Objects.requireNonNull(in_annotations, "in_annotations");
   }
 
   /**
@@ -118,33 +120,49 @@ public final class OPDSAcquisitionFeed implements Serializable {
     return new Builder(in_uri, in_title, in_id, in_updated);
   }
 
+  public OptionType<URI> getAnnotations() {
+    return annotations;
+  }
+
   @Override
-  public boolean equals(
-    final @Nullable Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (this.getClass() != obj.getClass()) {
-      return false;
-    }
-    final OPDSAcquisitionFeed other = (OPDSAcquisitionFeed) obj;
-    return this.uri.equals(other.uri)
-      && this.entries.equals(other.entries)
-      && this.facets_by_group.equals(other.facets_by_group)
-      && this.facets_order.equals(other.facets_order)
-      && this.groups.equals(other.groups)
-      && this.groups_order.equals(other.groups_order)
-      && this.id.equals(other.id)
-      && this.title.equals(other.title)
-      && this.updated.equals(other.updated)
-      && this.next.equals(other.next)
-      && this.search.equals(other.search)
-      && this.terms_of_service.equals(other.terms_of_service)
-      && this.about.equals(other.about)
-      && this.privacy_policy.equals(other.privacy_policy);
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    OPDSAcquisitionFeed that = (OPDSAcquisitionFeed) o;
+    return id.equals(that.id)
+      && next.equals(that.next)
+      && search.equals(that.search)
+      && title.equals(that.title)
+      && updated.equals(that.updated)
+      && uri.equals(that.uri)
+      && terms_of_service.equals(that.terms_of_service)
+      && about.equals(that.about)
+      && licenses.equals(that.licenses)
+      && licensor.equals(that.licensor)
+      && privacy_policy.equals(that.privacy_policy)
+      && errors.equals(that.errors)
+      && auth_document.equals(that.auth_document)
+      && annotations.equals(that.annotations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+      id,
+      next,
+      search,
+      title,
+      updated,
+      uri,
+      terms_of_service,
+      about,
+      licenses,
+      licensor,
+      privacy_policy,
+      errors,
+      auth_document,
+      annotations
+    );
   }
 
   /**
@@ -290,28 +308,6 @@ public final class OPDSAcquisitionFeed implements Serializable {
     return this.errors;
   }
 
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = (prime * result) + this.uri.hashCode();
-    result = (prime * result) + this.entries.hashCode();
-    result = (prime * result) + this.groups.hashCode();
-    result = (prime * result) + this.groups_order.hashCode();
-    result = (prime * result) + this.facets_by_group.hashCode();
-    result = (prime * result) + this.facets_order.hashCode();
-    result = (prime * result) + this.id.hashCode();
-    result = (prime * result) + this.title.hashCode();
-    result = (prime * result) + this.updated.hashCode();
-    result = (prime * result) + this.next.hashCode();
-    result = (prime * result) + this.search.hashCode();
-    result = (prime * result) + this.terms_of_service.hashCode();
-    result = (prime * result) + this.about.hashCode();
-    result = (prime * result) + this.privacy_policy.hashCode();
-    result = (prime * result) + this.licenses.hashCode();
-    return result;
-  }
-
   private static final class Builder implements OPDSAcquisitionFeedBuilderType {
     private final List<OPDSAcquisitionFeedEntry> entries;
     private final Map<String, List<OPDSFacet>> facets_by_group;
@@ -332,6 +328,7 @@ public final class OPDSAcquisitionFeed implements Serializable {
     private OptionType<DRMLicensor> licensor;
     private final List<ParseError> errors;
     private OptionType<URI> auth_document;
+    private OptionType<URI> annotations;
 
     private Builder(
       final URI in_uri,
@@ -356,6 +353,7 @@ public final class OPDSAcquisitionFeed implements Serializable {
       this.auth_document = Option.none();
       this.licenses = Option.none();
       this.licensor = Option.none();
+      this.annotations = Option.none();
       this.errors = new ArrayList<>();
     }
 
@@ -440,6 +438,12 @@ public final class OPDSAcquisitionFeed implements Serializable {
     }
 
     @Override
+    public OPDSAcquisitionFeedBuilderType setAnnotationsOption(OptionType<URI> u) {
+      this.annotations = Objects.requireNonNull(u);
+      return this;
+    }
+
+    @Override
     public OPDSAcquisitionFeedBuilderType setPrivacyPolicyOption(final OptionType<URI> u) {
       this.privacy_policy = Objects.requireNonNull(u);
       return this;
@@ -476,7 +480,8 @@ public final class OPDSAcquisitionFeed implements Serializable {
         this.licenses,
         this.licensor,
         this.errors,
-        this.auth_document);
+        this.auth_document,
+        this.annotations);
     }
 
     @Override

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedBuilderType.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedBuilderType.java
@@ -104,4 +104,13 @@ public interface OPDSAcquisitionFeedBuilderType
 
   OPDSAcquisitionFeedBuilderType setAuthenticationDocumentLink(
     OptionType<URI> u);
+
+  /**
+   * Set the URI of the annotations service for the feed, if any
+   *
+   * @param u The annotations service URI, if any
+   */
+
+  OPDSAcquisitionFeedBuilderType setAnnotationsOption(
+    OptionType<URI> u);
 }

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccount.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccount.kt
@@ -56,7 +56,6 @@ class MockAccount(override val id: AccountID) : AccountType {
         subtitle = "Library ${this.id.uuid} Subtitle!",
         supportEmail = null,
         supportsReservations = false,
-        supportsSimplyESynchronization = false,
         updated = DateTime())
     }
 

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccountProviders.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/MockAccountProviders.kt
@@ -67,7 +67,6 @@ object MockAccountProviders {
       subtitle = "Imaginary books",
       supportEmail = "postmaster@example.com",
       supportsReservations = false,
-      supportsSimplyESynchronization = false,
       updated = DateTime.parse("2000-01-01T00:00:00Z")
     )
   }

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/TransformProviders.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/TransformProviders.kt
@@ -68,7 +68,6 @@ class TransformProviders {
             subtitle = entry.subtitle,
             supportEmail = entry.supportEmail,
             supportsReservations = entry.supportsReservations,
-            supportsSimplyESynchronization = entry.supportsSimplyESync,
             updated = DateTime.parse(entry.updated))
         providers.add(provider)
       }

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderSourceNYPLRegistryDescriptionContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderSourceNYPLRegistryDescriptionContract.kt
@@ -394,7 +394,6 @@ abstract class AccountProviderSourceNYPLRegistryDescriptionContract {
       subtitle = "Some library you've never heard of",
       supportEmail = "mailto:someone@example.com",
       supportsReservations = true,
-      supportsSimplyESynchronization = false,
       updated = DateTime.parse("1970-01-01T00:00:00.000Z"))
 
     Assert.assertEquals(provider, result.result)
@@ -540,7 +539,6 @@ abstract class AccountProviderSourceNYPLRegistryDescriptionContract {
       subtitle = "Some library you've never heard of",
       supportEmail = "mailto:someone@example.com",
       supportsReservations = true,
-      supportsSimplyESynchronization = false,
       updated = DateTime.parse("1970-01-01T00:00:00.000Z"))
 
     Assert.assertEquals(provider, result.result)
@@ -669,7 +667,6 @@ abstract class AccountProviderSourceNYPLRegistryDescriptionContract {
       subtitle = "Some library you've never heard of",
       supportEmail = "mailto:someone@example.com",
       supportsReservations = true,
-      supportsSimplyESynchronization = false,
       updated = DateTime.parse("1970-01-01T00:00:00.000Z"))
 
     Assert.assertEquals(provider, result.result)


### PR DESCRIPTION
**What's this do?**
This implements the changes required for 2403: When the user syncs
their loans, the feed is inspected for a link with an annotation
service relation. If a link is found, the account provider is updated
with the new annotations service URI.

In the process of implementing this, two nasty bugs were discovered:

  1. In the accounts database, the call to setAccountProvider()
     was updating the description of the account on disk, but was
     not updating the visible account provider on the account
     instance. So, effectively: `a.setAccountProvider(p) -> a.accountProvider != p`
     This was fixed, and many extra assertions were added to the
     code to aggressively ensure that this doesn't happen again.

  2. Authentication document links were being lost on account
     descriptions, meaning that account providers were losing
     authentication descriptions when resolved. This was
     corrected, and some assertions were added to ensure that
     this doesn't happen again.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2403

**How should this be tested? / Do these changes have associated tests?**
Open an NYPL account in the settings section. Ensure that the switch to
enable/disable bookmark syncing can be toggled. Open a book and check
to see if your bookmarks are syncing across devices.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m tried the code on various accounts, and saw the bookmarks were downloaded from the server.