### PR TITLE
Feature/card creator bugs

### DIFF
--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
@@ -26,6 +26,7 @@ import androidx.navigation.Navigation
 import org.nypl.simplified.cardcreator.CardCreatorDebugging
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentLocationBinding
+import org.nypl.simplified.cardcreator.utils.startEllipses
 import org.slf4j.LoggerFactory
 import java.util.Locale
 
@@ -58,6 +59,7 @@ class LocationFragment : Fragment(), LocationListener {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
+    binding.ellipsesTv.startEllipses()
     locationMock = CardCreatorDebugging.fakeNewYorkLocation
 
     navController = Navigation.findNavController(requireActivity(), R.id.card_creator_nav_host_fragment)

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/TextViewUtils.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/TextViewUtils.kt
@@ -1,0 +1,42 @@
+package org.nypl.simplified.cardcreator.utils
+
+import android.annotation.SuppressLint
+import android.os.Handler
+import android.widget.TextView
+
+/**
+ * TextView utilities
+ */
+
+/**
+ * Start ellipses animation
+ */
+fun TextView.startEllipses() {
+  val ellipses = this
+  val handler = Handler()
+  val runnable: Runnable = object : Runnable {
+    var count = 0
+
+    @SuppressLint("SetTextI18n")
+    override fun run() {
+      count++
+      when (count) {
+        1 -> {
+          ellipses.text = ""
+        }
+        2 -> {
+          ellipses.text = "."
+        }
+        3 -> {
+          ellipses.text = ".."
+        }
+        4 -> {
+          ellipses.text = "..."
+        }
+      }
+      if (count == 4) count = 0
+      handler.postDelayed(this, 2 * 300)
+    }
+  }
+  handler.postDelayed(runnable, 1 * 300)
+}

--- a/simplified-cardcreator/src/main/res/layout/fragment_location.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_location.xml
@@ -22,18 +22,34 @@
             android:layout_height="wrap_content"
             android:text="@string/location_check" />
 
-        <TextView
-            android:id="@+id/header_status_desc_tv"
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginTop="16sp"
-            android:layout_marginRight="8dp"
-            android:layout_marginBottom="8dp"
-            android:fontFamily="sans-serif"
-            android:text="@string/validating_location"
-            android:gravity="center"
-            android:textSize="16sp" />
+            android:layout_height="wrap_content">
+            <TextView
+                android:id="@+id/header_status_desc_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="16sp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:layout_centerHorizontal="true"
+                android:text="@string/validating_location"
+                android:textSize="16sp" />
+            <TextView
+                android:id="@+id/ellipses_tv"
+                android:layout_toEndOf="@id/header_status_desc_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16sp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="sans-serif"
+                android:layout_centerHorizontal="true"
+                tools:text="..."
+                android:textSize="16sp" />
+
+        </RelativeLayout>
     </LinearLayout>
 
     <TextView

--- a/simplified-cardcreator/src/main/res/values/strings.xml
+++ b/simplified-cardcreator/src/main/res/values/strings.xml
@@ -130,7 +130,7 @@
     <string name="over_13">13 or Older</string>
     <string name="eula_checkbox">I agree to the terms of the End User License Agreement.</string>
     <string name="age_error">You are not old enough to sign up for a library card.</string>
-    <string name="validating_location">Validating your location&#8230;</string>
+    <string name="validating_location">Validating your location</string>
 
     <!-- Location -->
     <string name="checking_location">Checking location&#8230;</string>

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentAccount.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentAccount.kt
@@ -697,7 +697,7 @@ class SettingsFragmentAccount : Fragment() {
    * Hides or show sign up options if is user in accessing the NYPL
    */
   private fun hideCardCreatorForNonNYPL() {
-    if(this.account.provider.cardCreatorURI != null) {
+    if (this.account.provider.cardCreatorURI != null) {
       settingsCardCreator.visibility = View.GONE
     }
   }

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentAccount.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentAccount.kt
@@ -16,6 +16,7 @@ import android.widget.ProgressBar
 import android.widget.Switch
 import android.widget.TextView
 import androidx.annotation.UiThread
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
 import com.io7m.jfunctional.Some
 import io.reactivex.disposables.Disposable
@@ -85,6 +86,7 @@ class SettingsFragmentAccount : Fragment() {
   private lateinit var loginButtonErrorDetails: Button
   private lateinit var loginProgress: ProgressBar
   private lateinit var loginProgressText: TextView
+  private lateinit var settingsCardCreator: ConstraintLayout
   private lateinit var parameters: SettingsFragmentAccountParameters
   private lateinit var profilesController: ProfilesControllerType
   private lateinit var uiThread: UIThreadServiceType
@@ -92,6 +94,7 @@ class SettingsFragmentAccount : Fragment() {
   private var profileSubscription: Disposable? = null
   private val cardCreatorResultCode = 101
   private var cardCreatorService: CardCreatorServiceType? = null
+  private var cardCreatorLibrary = "The New York Public Library"
 
   companion object {
 
@@ -113,7 +116,7 @@ class SettingsFragmentAccount : Fragment() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    this.parameters = this.arguments!![PARAMETERS_ID] as SettingsFragmentAccountParameters
+    this.parameters = this.requireArguments()[PARAMETERS_ID] as SettingsFragmentAccountParameters
 
     val services = Services.serviceDirectory()
 
@@ -194,6 +197,8 @@ class SettingsFragmentAccount : Fragment() {
       layout.findViewById(R.id.settingsCardCreatorSignUp)
     this.signUpLabel =
       layout.findViewById(R.id.settingsCardCreatorLabel)
+    this.settingsCardCreator =
+      layout.findViewById(R.id.settingsCardCreator)
 
     this.loginButtonErrorDetails.visibility = View.GONE
     this.loginButton.isEnabled = false
@@ -272,6 +277,8 @@ class SettingsFragmentAccount : Fragment() {
     }
 
     this.configureToolbar()
+
+    this.hideCardCreatorForNonNYPL()
 
     this.accountTitle.text =
       this.account.provider.displayName
@@ -684,6 +691,15 @@ class SettingsFragmentAccount : Fragment() {
       age.yearsOld(DateTime.now()) >= 13
     } else {
       false
+    }
+  }
+
+  /**
+   * Hides or show sign up options if is user in accessing the NYPL
+   */
+  private fun hideCardCreatorForNonNYPL() {
+    if(this.account.provider.displayName != cardCreatorLibrary) {
+      settingsCardCreator.visibility = View.GONE
     }
   }
 

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentAccount.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentAccount.kt
@@ -94,7 +94,6 @@ class SettingsFragmentAccount : Fragment() {
   private var profileSubscription: Disposable? = null
   private val cardCreatorResultCode = 101
   private var cardCreatorService: CardCreatorServiceType? = null
-  private var cardCreatorLibrary = "The New York Public Library"
 
   companion object {
 
@@ -698,7 +697,7 @@ class SettingsFragmentAccount : Fragment() {
    * Hides or show sign up options if is user in accessing the NYPL
    */
   private fun hideCardCreatorForNonNYPL() {
-    if(this.account.provider.displayName != cardCreatorLibrary) {
+    if(this.account.provider.cardCreatorURI != null) {
       settingsCardCreator.visibility = View.GONE
     }
   }


### PR DESCRIPTION
**What's this do?**
This adds an ellipses to the location loading test. This also removes the sign up option from the settings screen for non-NYPL users. This also checks the location again when the user returns from the settings screen.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2734: In SA Card creator, please animate loading messages](https://jira.nypl.org/browse/SIMPLY-2734)
[SIMPLY-2732: SA Card Creator doesn't error out when an applicant is outside NY](https://jira.nypl.org/browse/SIMPLY-2732)

**How should this be tested? / Do these changes have associated tests?**
Access the card creator and proceed to the location check screen to observe the animated ellipses. Access settings from a library other that NYPL and you will find the sign up button is no longer there.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 