### PR TITLE
Migrate from external to internal storage

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainExt2IntHook.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainExt2IntHook.kt
@@ -1,0 +1,60 @@
+package org.nypl.simplified.main
+
+import android.content.Context
+import android.os.Environment
+import com.google.common.base.Preconditions
+import org.nypl.simplified.boot.api.BootPreHookType
+import org.nypl.simplified.main.MainServices.CURRENT_DATA_VERSION
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * A pre-boot hook to migrate data from the external storage to internal storage. Applications
+ * prior to the mid-2020 5.* branch may have been using external storage. We now require internal
+ * storage to be used at all times.
+ */
+
+class MainExt2IntHook : BootPreHookType {
+  private val logger = LoggerFactory.getLogger(MainExt2IntHook::class.java)
+
+  private fun findOldExternalDirectory(context: Context): File? {
+    if (Environment.MEDIA_MOUNTED == Environment.getExternalStorageState()) {
+      this.logger.debug("trying external storage")
+      if (!Environment.isExternalStorageRemovable()) {
+        val result = context.getExternalFilesDir(null)
+        this.logger.debug("external storage is not removable, using it ({})", result)
+        Preconditions.checkArgument(result!!.isDirectory, "Data directory {} is a directory", result)
+        return File(result, CURRENT_DATA_VERSION)
+      }
+    }
+
+    this.logger.debug("external storage is unsuitable, ignoring it")
+    return null
+  }
+
+  override fun execute(context: Context) {
+    this.logger.debug("executing")
+
+    val newDirectory = File(context.filesDir, CURRENT_DATA_VERSION)
+    val oldDirectory = this.findOldExternalDirectory(context)
+    if (oldDirectory != null) {
+      oldDirectory.delete()
+
+      if (oldDirectory.isDirectory) {
+        newDirectory.mkdirs()
+        this.logger.debug("copying old external {} to internal {}", oldDirectory, newDirectory)
+        oldDirectory.copyRecursively(
+          target = newDirectory,
+          overwrite = false,
+          onError = { file, exception ->
+          this.logger.error("failed to copy file: {}: ", file, exception)
+          OnErrorAction.SKIP
+        })
+        oldDirectory.deleteRecursively()
+        this.logger.debug("deleted old directory")
+      }
+    } else {
+      this.logger.debug("nothing to do!")
+    }
+  }
+}

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -149,10 +149,8 @@ internal object MainServices {
    */
 
   const val CURRENT_DATA_VERSION = "v4.0"
-  const val SIMPLYE = "org.nypl.simplified.simplye"
 
   private data class Directories(
-    val directoryPrivateBaseVersioned: File,
     val directoryStorageBaseVersioned: File,
     val directoryStorageDownloads: File,
     val directoryStorageDocuments: File,
@@ -162,14 +160,8 @@ internal object MainServices {
   private fun initializeDirectories(context: Context): Directories {
     this.logger.debug("initializing directories")
 
-    val directoryPrivateBase =
-      context.filesDir
-    val directoryPrivateBaseVersioned =
-      File(directoryPrivateBase, this.CURRENT_DATA_VERSION)
-    val directoryStorageBase =
-      this.determineDiskDataDirectory(context)
     val directoryStorageBaseVersioned =
-      File(directoryStorageBase, this.CURRENT_DATA_VERSION)
+      File(context.filesDir, this.CURRENT_DATA_VERSION)
     val directoryStorageDownloads =
       File(directoryStorageBaseVersioned, "downloads")
     val directoryStorageDocuments =
@@ -177,9 +169,6 @@ internal object MainServices {
     val directoryStorageProfiles =
       File(directoryStorageBaseVersioned, "profiles")
 
-    this.logger.debug("directoryPrivateBase:          {}", directoryPrivateBase)
-    this.logger.debug("directoryPrivateBaseVersioned: {}", directoryPrivateBaseVersioned)
-    this.logger.debug("directoryStorageBase:          {}", directoryStorageBase)
     this.logger.debug("directoryStorageBaseVersioned: {}", directoryStorageBaseVersioned)
     this.logger.debug("directoryStorageDownloads:     {}", directoryStorageDownloads)
     this.logger.debug("directoryStorageDocuments:     {}", directoryStorageDocuments)
@@ -192,9 +181,6 @@ internal object MainServices {
 
     val directories =
       listOf<File>(
-        directoryPrivateBase,
-        directoryPrivateBaseVersioned,
-        directoryStorageBase,
         directoryStorageBaseVersioned,
         directoryStorageDownloads,
         directoryStorageDocuments,
@@ -218,7 +204,6 @@ internal object MainServices {
     }
 
     return Directories(
-      directoryPrivateBaseVersioned = directoryPrivateBaseVersioned,
       directoryStorageBaseVersioned = directoryStorageBaseVersioned,
       directoryStorageDownloads = directoryStorageDownloads,
       directoryStorageDocuments = directoryStorageDocuments,
@@ -423,9 +408,9 @@ internal object MainServices {
   ): AccountAuthenticationCredentialsStoreType {
     val accountCredentialsStore = try {
       val credentials =
-        File(directories.directoryPrivateBaseVersioned, "credentials.json")
+        File(directories.directoryStorageBaseVersioned, "credentials.json")
       val credentialsTemp =
-        File(directories.directoryPrivateBaseVersioned, "credentials.json.tmp")
+        File(directories.directoryStorageBaseVersioned, "credentials.json.tmp")
 
       this.logger.debug("credentials store path: {}", credentials)
       AccountAuthenticationCredentialsStore.open(credentials, credentialsTemp)

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -5,9 +5,7 @@ import android.content.pm.PackageManager
 import android.content.res.AssetManager
 import android.content.res.Resources
 import android.graphics.Color
-import android.os.Environment
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.common.base.Preconditions
 import com.google.common.util.concurrent.ListeningScheduledExecutorService
 import com.io7m.jfunctional.Option
 import com.io7m.jfunctional.OptionType
@@ -41,6 +39,9 @@ import org.nypl.simplified.analytics.api.Analytics
 import org.nypl.simplified.analytics.api.AnalyticsConfiguration
 import org.nypl.simplified.analytics.api.AnalyticsEvent
 import org.nypl.simplified.analytics.api.AnalyticsType
+import org.nypl.simplified.books.audio.AudioBookFeedbooksSecretServiceType
+import org.nypl.simplified.books.audio.AudioBookManifestStrategiesType
+import org.nypl.simplified.books.audio.AudioBookManifests
 import org.nypl.simplified.books.audio.AudioBookOverdriveSecretServiceType
 import org.nypl.simplified.books.book_database.api.BookFormats
 import org.nypl.simplified.books.book_registry.BookRegistry
@@ -117,9 +118,6 @@ import org.nypl.simplified.ui.theme.ThemeControl
 import org.nypl.simplified.ui.theme.ThemeServiceType
 import org.nypl.simplified.ui.theme.ThemeValue
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
-import org.nypl.simplified.books.audio.AudioBookFeedbooksSecretServiceType
-import org.nypl.simplified.books.audio.AudioBookManifestStrategiesType
-import org.nypl.simplified.books.audio.AudioBookManifests
 import org.nypl.simplified.viewer.epub.readium1.ReaderHTTPMimeMap
 import org.nypl.simplified.viewer.epub.readium1.ReaderHTTPServerAAsync
 import org.nypl.simplified.viewer.epub.readium1.ReaderHTTPServerType

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -210,33 +210,6 @@ internal object MainServices {
       directoryStorageProfiles = directoryStorageProfiles)
   }
 
-  private fun determineDiskDataDirectory(context: Context): File {
-
-    /*
-     * If external storage is mounted and is on a device that doesn't allow
-     * the storage to be removed, use the external storage for data.
-     */
-
-    if (Environment.MEDIA_MOUNTED == Environment.getExternalStorageState()) {
-      this.logger.debug("trying external storage")
-      if (!Environment.isExternalStorageRemovable()) {
-        val result = context.getExternalFilesDir(null)
-        this.logger.debug("external storage is not removable, using it ({})", result)
-        Preconditions.checkArgument(result!!.isDirectory, "Data directory {} is a directory", result)
-        return result
-      }
-    }
-
-    /*
-     * Otherwise, use internal storage.
-     */
-
-    val result = context.filesDir
-    this.logger.debug("no non-removable external storage, using internal storage ({})", result)
-    Preconditions.checkArgument(result.isDirectory, "Data directory {} is a directory", result)
-    return result
-  }
-
   private fun themeForProfile(profile: OptionType<ProfileType>): ThemeValue {
     if (profile.isSome) {
       val currentProfile = (profile as Some<ProfileType>).get()

--- a/simplified-main/src/main/resources/META-INF/services/org.nypl.simplified.boot.api.BootPreHookType
+++ b/simplified-main/src/main/resources/META-INF/services/org.nypl.simplified.boot.api.BootPreHookType
@@ -1,0 +1,1 @@
+org.nypl.simplified.main.MainExt2IntHook


### PR DESCRIPTION
**What's this do?**
This registers an unconditional boot hook that moves any and all
application data from external storage to internal storage.

**Why are we doing this? (w/ JIRA link if applicable)**
This ensures that we never have any state that outlives an application uninstall.

Affects: https://jira.nypl.org/browse/SIMPLY-2767

**How should this be tested? / Do these changes have associated tests?**
If the app starts up and all of your existing accounts are intact, it worked.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Not applicable.

**Did someone actually run this code to verify it works?**
@io7m tested that the accounts still existed after the migration, and also tested that the app didn't explode after it started up with no data to migrate.