### PR TITLE
Juvenile card creator

### DIFF
--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorActivity.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorActivity.kt
@@ -3,6 +3,7 @@ package org.nypl.simplified.cardcreator
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import org.nypl.simplified.cardcreator.databinding.ActivityCardCreatorBinding
+import org.nypl.simplified.cardcreator.utils.Cache
 
 /**
  * Main view responsible for patrons to create library cards
@@ -16,5 +17,14 @@ class CardCreatorActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     binding = ActivityCardCreatorBinding.inflate(layoutInflater)
     setContentView(binding.root)
+    if (intent.extras.getBoolean("isLoggedIn")) {
+      Cache(this).isJuvenileCard = true
+      binding.toolbarTitleTv.text = getString(R.string.create_child_card)
+    }
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    Cache(this).clear()
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorActivity.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorActivity.kt
@@ -19,7 +19,7 @@ class CardCreatorActivity : AppCompatActivity() {
     setContentView(binding.root)
     if (intent.extras.getBoolean("isLoggedIn")) {
       Cache(this).isJuvenileCard = true
-      binding.toolbarTitleTv.text = getString(R.string.create_child_card)
+      binding.toolbarTitleTv.setText(R.string.create_child_card)
     }
   }
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorService.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorService.kt
@@ -6,7 +6,12 @@ import androidx.fragment.app.Fragment
 import java.io.InputStream
 import java.util.Properties
 
-class CardCreatorService(private val username: String, private val password: String) : CardCreatorServiceType {
+class CardCreatorService(
+  private val username: String,
+  private val password: String,
+  private val clientId: String,
+  private val clientSecret: String
+) : CardCreatorServiceType {
 
   companion object {
     fun create(configFile: InputStream): CardCreatorServiceType {
@@ -14,14 +19,26 @@ class CardCreatorService(private val username: String, private val password: Str
       properties.load(configFile)
       val username = properties.getProperty("cardcreator.prod.username")
       val password = properties.getProperty("cardcreator.prod.password")
-      return CardCreatorService(username, password)
+      val clientId = properties.getProperty("cardcreator.prod.client.id")
+      val clientSecret = properties.getProperty("cardcreator.prod.client.secret")
+      return CardCreatorService(username, password, clientId, clientSecret)
     }
   }
 
-  override fun openCardCreatorActivity(fragment: Fragment, context: Context?, resultCode: Int) {
+  override fun openCardCreatorActivity(
+    fragment: Fragment,
+    context: Context?,
+    resultCode: Int,
+    isLoggedIn: Boolean,
+    userIdentifier: String
+  ) {
     val intent = Intent(context, CardCreatorActivity::class.java)
     intent.putExtra("username", username)
     intent.putExtra("password", password)
+    intent.putExtra("clientId", clientId)
+    intent.putExtra("clientSecret", clientSecret)
+    intent.putExtra("isLoggedIn", isLoggedIn)
+    intent.putExtra("userIdentifier", userIdentifier)
     fragment.startActivityForResult(intent, resultCode)
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorServiceType.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorServiceType.kt
@@ -4,5 +4,11 @@ import android.content.Context
 import androidx.fragment.app.Fragment
 
 interface CardCreatorServiceType {
-  fun openCardCreatorActivity(fragment: Fragment, context: Context?, resultCode: Int)
+  fun openCardCreatorActivity(
+    fragment: Fragment,
+    context: Context?,
+    resultCode: Int,
+    isLoggedIn: Boolean,
+    userIdentifier: String
+  )
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/AccountInformation.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/AccountInformation.kt
@@ -1,3 +1,3 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 data class AccountInformation(val username: String, val pin: String)

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Address.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Address.kt
@@ -1,4 +1,4 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 import com.squareup.moshi.Json
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/AddressDetails.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/AddressDetails.kt
@@ -1,4 +1,4 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 import com.squareup.moshi.Json
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/AddressType.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/AddressType.kt
@@ -1,4 +1,4 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 /**
  * Three types of address types

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/CreatePatronResponse.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/CreatePatronResponse.kt
@@ -1,4 +1,4 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 import com.squareup.moshi.Json
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Data.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Data.kt
@@ -1,0 +1,6 @@
+package org.nypl.simplified.cardcreator.model
+
+data class Data(
+  val dependent: Dependent,
+  val parent: Parent
+)

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Dependent.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Dependent.kt
@@ -1,0 +1,9 @@
+package org.nypl.simplified.cardcreator.model
+
+data class Dependent(
+  val barcode: String,
+  val id: Int,
+  val name: String,
+  val pin: String,
+  val username: String
+)

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/DependentEligibilityData.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/DependentEligibilityData.kt
@@ -1,0 +1,9 @@
+package org.nypl.simplified.cardcreator.model
+
+data class DependentEligibilityData(
+  val status: Int,
+  val eligible: Boolean,
+  val type: String,
+  val message: String?,
+  val description: String?
+)

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/ISSOTokenData.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/ISSOTokenData.kt
@@ -1,0 +1,9 @@
+package org.nypl.simplified.cardcreator.model
+
+data class ISSOTokenData(
+  val access_token: String,
+  val expires_in: Int,
+  val id_token: String,
+  val scope: String,
+  val token_type: String
+)

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/JuvenilePatron.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/JuvenilePatron.kt
@@ -1,0 +1,19 @@
+package org.nypl.simplified.cardcreator.model
+
+import com.squareup.moshi.Json
+
+sealed class JuvenilePatron
+
+data class UsernameParent(
+  @field:Json(name = "name") val name: String,
+  @field:Json(name = "parentUsername") val parentUsername: String,
+  @field:Json(name = "username") val username: String,
+  @field:Json(name = "pin") val pin: String
+) : JuvenilePatron()
+
+data class BarcodeParent(
+  @field:Json(name = "barcode") val barcode: String,
+  @field:Json(name = "name") val name: String,
+  @field:Json(name = "username") val username: String,
+  @field:Json(name = "pin") val pin: String
+) : JuvenilePatron()

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/JuvenilePatronResponse.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/JuvenilePatronResponse.kt
@@ -1,0 +1,6 @@
+package org.nypl.simplified.cardcreator.model
+
+data class JuvenilePatronResponse(
+  val `data`: Data,
+  val status: Int
+)

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/OriginalAddress.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/OriginalAddress.kt
@@ -1,4 +1,4 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 import com.squareup.moshi.Json
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Parent.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Parent.kt
@@ -1,0 +1,7 @@
+package org.nypl.simplified.cardcreator.model
+
+data class Parent(
+  val barcode: String,
+  val dependents: String,
+  val updated: Boolean
+)

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Patron.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Patron.kt
@@ -1,4 +1,4 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 import com.squareup.moshi.Json
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/PersonalInformation.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/PersonalInformation.kt
@@ -1,4 +1,4 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 data class PersonalInformation(
   val firstName: String,

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Username.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/Username.kt
@@ -1,4 +1,4 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 import com.squareup.moshi.Json
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/ValidateAddressResponse.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/ValidateAddressResponse.kt
@@ -1,4 +1,4 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 import com.squareup.moshi.Json
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/ValidateUsernameResponse.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/model/ValidateUsernameResponse.kt
@@ -1,4 +1,4 @@
-package org.nypl.simplified.cardcreator.models
+package org.nypl.simplified.cardcreator.model
 
 import com.squareup.moshi.Json
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/CardCreatorService.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/CardCreatorService.kt
@@ -54,11 +54,9 @@ internal interface CardCreatorService {
 
   companion object {
     operator fun invoke(authUsername: String, authPassword: String): CardCreatorService {
-      val logging = run {
-        val httpLoggingInterceptor = HttpLoggingInterceptor()
-        httpLoggingInterceptor.apply {
-          httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.HEADERS
-        }
+
+      val logging = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.HEADERS
       }
 
       val auth = Interceptor {

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/CardCreatorService.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/CardCreatorService.kt
@@ -4,12 +4,12 @@ import okhttp3.Credentials
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import org.nypl.simplified.cardcreator.models.Address
-import org.nypl.simplified.cardcreator.models.ValidateAddressResponse
-import org.nypl.simplified.cardcreator.models.Username
-import org.nypl.simplified.cardcreator.models.ValidateUsernameResponse
-import org.nypl.simplified.cardcreator.models.Patron
-import org.nypl.simplified.cardcreator.models.CreatePatronResponse
+import org.nypl.simplified.cardcreator.model.Address
+import org.nypl.simplified.cardcreator.model.ValidateAddressResponse
+import org.nypl.simplified.cardcreator.model.Username
+import org.nypl.simplified.cardcreator.model.ValidateUsernameResponse
+import org.nypl.simplified.cardcreator.model.Patron
+import org.nypl.simplified.cardcreator.model.CreatePatronResponse
 import org.nypl.simplified.cardcreator.utils.Constants
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -57,7 +57,7 @@ internal interface CardCreatorService {
       val logging = run {
         val httpLoggingInterceptor = HttpLoggingInterceptor()
         httpLoggingInterceptor.apply {
-          httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.BASIC
+          httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.HEADERS
         }
       }
 

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/NYPLISSOService.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/NYPLISSOService.kt
@@ -1,0 +1,55 @@
+package org.nypl.simplified.cardcreator.network
+
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.nypl.simplified.cardcreator.model.ISSOTokenData
+import org.nypl.simplified.cardcreator.utils.Constants
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+import java.util.concurrent.TimeUnit
+
+internal interface NYPLISSOService {
+
+  /**
+   * Retrieves token needs for NYPL Platform API calls
+   *
+   * https://github.com/NYPL-Simplified/card-creator/wiki/API---V2#post-v2create_patron
+   */
+  @Multipart
+  @POST("token")
+  suspend fun getToken(
+    @Part grant_type: MultipartBody.Part,
+    @Part client_id: MultipartBody.Part,
+    @Part client_secret: MultipartBody.Part
+  ): ISSOTokenData
+
+  companion object {
+    operator fun invoke(): NYPLISSOService {
+
+      val logging = run {
+        val httpLoggingInterceptor = HttpLoggingInterceptor()
+        httpLoggingInterceptor.apply {
+          httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.HEADERS
+        }
+      }
+
+      val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .addInterceptor(logging)
+        .build()
+
+      return Retrofit.Builder()
+        .client(client)
+        .baseUrl(Constants.NYPL_ISSO_BASE_URL)
+        .addConverterFactory(MoshiConverterFactory.create())
+        .build()
+        .create(NYPLISSOService::class.java)
+    }
+  }
+}

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/NYPLISSOService.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/NYPLISSOService.kt
@@ -30,11 +30,8 @@ internal interface NYPLISSOService {
   companion object {
     operator fun invoke(): NYPLISSOService {
 
-      val logging = run {
-        val httpLoggingInterceptor = HttpLoggingInterceptor()
-        httpLoggingInterceptor.apply {
-          httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.HEADERS
-        }
+      val logging = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.HEADERS
       }
 
       val client = OkHttpClient.Builder()

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/NYPLPlatformService.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/NYPLPlatformService.kt
@@ -1,0 +1,84 @@
+package org.nypl.simplified.cardcreator.network
+
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import org.nypl.simplified.cardcreator.model.DependentEligibilityData
+import org.nypl.simplified.cardcreator.model.JuvenilePatron
+import org.nypl.simplified.cardcreator.model.JuvenilePatronResponse
+import org.nypl.simplified.cardcreator.utils.Constants
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+import java.util.concurrent.TimeUnit
+
+internal interface NYPLPlatformService {
+
+  /**
+   * Gets whether or not user can create juvenile cards using barcode
+   *
+   * Docs: https://platformdocs.nypl.org/#/patrons/patrons_eligibilityV03
+   */
+  @GET("patrons/dependent-eligibility")
+  suspend fun getDependentEligibilityWithBarcode(
+    @Query("barcode") barcode: String
+  ): DependentEligibilityData
+
+  /**
+   * Gets whether or not user can create juvenile cards using username
+   *
+   * Docs: https://platformdocs.nypl.org/#/patrons/patrons_eligibilityV03
+   */
+  @GET("patrons/dependent-eligibility")
+  suspend fun getDependentEligibilityWithUsername(
+    @Query("username") username: String
+  ): DependentEligibilityData
+
+  /**
+   * Creates juvenile card
+   *
+   * Docs: https://platformdocs.nypl.org/#/patrons/patrons_dependentsV03
+   */
+  @POST("patrons/dependents")
+  suspend fun createJuvenilePatron(
+    @Body juvenilePatron: JuvenilePatron
+  ): JuvenilePatronResponse
+
+  companion object {
+    operator fun invoke(token: String): NYPLPlatformService {
+
+      val authInterceptor = Interceptor {
+        val request = it.request().newBuilder()
+          .addHeader("Authorization", "Bearer $token")
+          .addHeader("Content-Type", "application/json")
+          .addHeader("Accept", "application/json").build()
+        it.proceed(request)
+      }
+
+      val logging = run {
+        val httpLoggingInterceptor = HttpLoggingInterceptor()
+        httpLoggingInterceptor.apply {
+          httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.HEADERS
+        }
+      }
+
+      val client = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .addInterceptor(authInterceptor)
+        .addInterceptor(logging)
+        .build()
+
+      return Retrofit.Builder()
+        .client(client)
+        .baseUrl(Constants.NYPL_PROD_PLATFORM_BASE_URL)
+        .addConverterFactory(MoshiConverterFactory.create())
+        .build()
+        .create(NYPLPlatformService::class.java)
+    }
+  }
+}

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/NYPLPlatformService.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/network/NYPLPlatformService.kt
@@ -58,11 +58,8 @@ internal interface NYPLPlatformService {
         it.proceed(request)
       }
 
-      val logging = run {
-        val httpLoggingInterceptor = HttpLoggingInterceptor()
-        httpLoggingInterceptor.apply {
-          httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.HEADERS
-        }
+      val logging = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.HEADERS
       }
 
       val client = OkHttpClient.Builder()

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AccountInformationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AccountInformationFragment.kt
@@ -18,7 +18,7 @@ import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentAccountInformationBinding
 import org.nypl.simplified.cardcreator.utils.Cache
 import org.nypl.simplified.cardcreator.utils.hideKeyboard
-import org.nypl.simplified.cardcreator.viewmodels.UsernameViewModel
+import org.nypl.simplified.cardcreator.viewmodel.UsernameViewModel
 import org.slf4j.LoggerFactory
 
 class AccountInformationFragment : Fragment() {
@@ -138,5 +138,10 @@ class AccountInformationFragment : Fragment() {
     } else {
       binding.loading.visibility = View.GONE
     }
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AgeFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AgeFragment.kt
@@ -11,6 +11,7 @@ import androidx.navigation.NavDirections
 import androidx.navigation.Navigation
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentAgeBinding
+import org.nypl.simplified.cardcreator.utils.Cache
 import org.slf4j.LoggerFactory
 
 /**
@@ -42,6 +43,14 @@ class AgeFragment : Fragment() {
 
     navController = Navigation.findNavController(requireActivity(), R.id.card_creator_nav_host_fragment)
 
+    /**
+     * User is already logged in, present with Juvenile Card Creator policy
+     */
+    if (Cache(requireActivity()).isJuvenileCard!!) {
+      nextAction = AgeFragmentDirections.actionJuvenilePolicy()
+      navController.navigate(nextAction)
+    }
+
     binding.older13Rb.setOnCheckedChangeListener { _, _ ->
       validateForm()
     }
@@ -70,6 +79,11 @@ class AgeFragment : Fragment() {
         requireActivity().finish()
       }
     }
+
+    binding.eula.setOnClickListener {
+      nextAction = AgeFragmentDirections.actionEula()
+      navController.navigate(nextAction)
+    }
   }
 
   /**
@@ -93,5 +107,10 @@ class AgeFragment : Fragment() {
       binding.nextBtn.text = getString(R.string.done)
       logger.debug("Age form invalid, user is under 13")
     }
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AlternateAddressFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AlternateAddressFragment.kt
@@ -18,12 +18,12 @@ import androidx.navigation.NavDirections
 import androidx.navigation.Navigation
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentAlternateAddressBinding
-import org.nypl.simplified.cardcreator.models.Address
-import org.nypl.simplified.cardcreator.models.AddressDetails
-import org.nypl.simplified.cardcreator.models.AddressType
+import org.nypl.simplified.cardcreator.model.Address
+import org.nypl.simplified.cardcreator.model.AddressDetails
+import org.nypl.simplified.cardcreator.model.AddressType
 import org.nypl.simplified.cardcreator.utils.Cache
 import org.nypl.simplified.cardcreator.utils.hideKeyboard
-import org.nypl.simplified.cardcreator.viewmodels.AddressViewModel
+import org.nypl.simplified.cardcreator.viewmodel.AddressViewModel
 import org.slf4j.LoggerFactory
 
 class AlternateAddressFragment : Fragment(), AdapterView.OnItemSelectedListener {
@@ -224,5 +224,10 @@ class AlternateAddressFragment : Fragment(), AdapterView.OnItemSelectedListener 
   override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
     logger.debug(parent!!.getItemAtPosition(position).toString())
     validateForm()
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmAlternateAddressFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmAlternateAddressFragment.kt
@@ -10,8 +10,8 @@ import androidx.navigation.NavDirections
 import androidx.navigation.Navigation
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentConfirmAlternateAddressBinding
-import org.nypl.simplified.cardcreator.models.AddressDetails
-import org.nypl.simplified.cardcreator.models.AddressType
+import org.nypl.simplified.cardcreator.model.AddressDetails
+import org.nypl.simplified.cardcreator.model.AddressType
 import org.nypl.simplified.cardcreator.utils.Cache
 import org.slf4j.LoggerFactory
 
@@ -70,5 +70,10 @@ class ConfirmAlternateAddressFragment : Fragment() {
     binding.prevBtn.setOnClickListener {
       navController.popBackStack()
     }
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmHomeAddressFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmHomeAddressFragment.kt
@@ -63,4 +63,9 @@ class ConfirmHomeAddressFragment : Fragment() {
       navController.popBackStack()
     }
   }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
+  }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmationFragment.kt
@@ -181,4 +181,9 @@ class ConfirmationFragment : Fragment() {
     Cache(requireContext()).clear()
     requireActivity().finish()
   }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
+  }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/EULAFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/EULAFragment.kt
@@ -1,0 +1,37 @@
+package org.nypl.simplified.cardcreator.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import org.nypl.simplified.cardcreator.databinding.FragmentEulaBinding
+import org.nypl.simplified.cardcreator.utils.Constants
+
+/**
+ * Screen for viewing the End User License Agreement
+ */
+class EULAFragment : Fragment() {
+
+  private var _binding: FragmentEulaBinding? = null
+  private val binding get() = _binding!!
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    _binding = FragmentEulaBinding.inflate(inflater, container, false)
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    binding.webview.loadUrl(Constants.EULA)
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
+  }
+}

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/HomeAddressFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/HomeAddressFragment.kt
@@ -18,11 +18,11 @@ import androidx.navigation.NavDirections
 import androidx.navigation.Navigation
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentHomeAddressBinding
-import org.nypl.simplified.cardcreator.models.Address
-import org.nypl.simplified.cardcreator.models.AddressDetails
+import org.nypl.simplified.cardcreator.model.Address
+import org.nypl.simplified.cardcreator.model.AddressDetails
 import org.nypl.simplified.cardcreator.utils.Cache
 import org.nypl.simplified.cardcreator.utils.hideKeyboard
-import org.nypl.simplified.cardcreator.viewmodels.AddressViewModel
+import org.nypl.simplified.cardcreator.viewmodel.AddressViewModel
 import org.slf4j.LoggerFactory
 
 class HomeAddressFragment : Fragment(), AdapterView.OnItemSelectedListener {
@@ -194,5 +194,10 @@ class HomeAddressFragment : Fragment(), AdapterView.OnItemSelectedListener {
   override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
     logger.debug(parent!!.getItemAtPosition(position).toString())
     validateForm()
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/JuvenileInformationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/JuvenileInformationFragment.kt
@@ -1,0 +1,95 @@
+package org.nypl.simplified.cardcreator.ui
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.NavDirections
+import androidx.navigation.Navigation
+import org.nypl.simplified.cardcreator.R
+import org.nypl.simplified.cardcreator.databinding.FragmentJuvenileInformationBinding
+import org.nypl.simplified.cardcreator.model.PersonalInformation
+import org.nypl.simplified.cardcreator.utils.Cache
+import org.nypl.simplified.cardcreator.utils.hideKeyboard
+import org.slf4j.LoggerFactory
+
+class JuvenileInformationFragment : Fragment() {
+
+  private val logger = LoggerFactory.getLogger(JuvenileInformationFragment::class.java)
+
+  private var _binding: FragmentJuvenileInformationBinding? = null
+  private val binding get() = _binding!!
+
+  private lateinit var navController: NavController
+  private lateinit var nextAction: NavDirections
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    _binding = FragmentJuvenileInformationBinding.inflate(inflater, container, false)
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
+    navController = Navigation.findNavController(requireActivity(), R.id.card_creator_nav_host_fragment)
+    nextAction = PersonalInformationFragmentDirections.actionNext()
+
+    binding.firstNameEt.addTextChangedListener(object : TextWatcher {
+      override fun afterTextChanged(s: Editable?) {
+        validateForm()
+      }
+
+      override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+      override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+    })
+
+    binding.lastNameEt.addTextChangedListener(object : TextWatcher {
+      override fun afterTextChanged(s: Editable?) {
+        validateForm()
+      }
+
+      override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+      override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+    })
+
+    // Go to next screen
+    binding.nextBtn.setOnClickListener {
+      logger.debug("User navigated to the next screen")
+      var lastName = binding.lastNameEt.text.trim().toString()
+      if (lastName.isEmpty()) {
+        lastName = Cache(requireContext()).getPersonalInformation().lastName
+      }
+      Cache(requireContext()).setPersonalInformation(PersonalInformation(
+        binding.firstNameEt.text.toString(),
+        "",
+        lastName,
+        Cache(requireContext()).getPersonalInformation().birthDate,
+        Cache(requireContext()).getPersonalInformation().email
+      ))
+      hideKeyboard()
+      navController.navigate(nextAction)
+    }
+
+    // Go to previous screen
+    binding.prevBtn.setOnClickListener {
+      navController.popBackStack()
+    }
+  }
+
+  private fun validateForm() {
+    binding.nextBtn.isEnabled = binding.firstNameEt.text.trim().isNotEmpty()
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
+  }
+}

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/JuvenilePolicyFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/JuvenilePolicyFragment.kt
@@ -1,0 +1,164 @@
+package org.nypl.simplified.cardcreator.ui
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.navigation.NavController
+import androidx.navigation.NavDirections
+import androidx.navigation.Navigation
+import org.nypl.simplified.cardcreator.R
+import org.nypl.simplified.cardcreator.databinding.FragmentJuvenilePolicyBinding
+import org.nypl.simplified.cardcreator.utils.getCache
+import org.nypl.simplified.cardcreator.viewmodel.PlatformViewModel
+import org.nypl.simplified.cardcreator.viewmodel.TokenViewModel
+import org.slf4j.LoggerFactory
+
+/**
+ * Screen the presents regulations surrounding creating juvenile cards
+ */
+class JuvenilePolicyFragment : Fragment() {
+
+  private val logger = LoggerFactory.getLogger(JuvenilePolicyFragment::class.java)
+
+  private var _binding: FragmentJuvenilePolicyBinding? = null
+  private val binding get() = _binding!!
+
+  private lateinit var navController: NavController
+  private lateinit var nextAction: NavDirections
+
+  private val viewModel: TokenViewModel by viewModels()
+  private val platformViewModel: PlatformViewModel by viewModels()
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    _binding = FragmentJuvenilePolicyBinding.inflate(inflater, container, false)
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
+    navController = Navigation.findNavController(requireActivity(), R.id.card_creator_nav_host_fragment)
+
+    binding.policyCheckbox.setOnCheckedChangeListener { _, _ ->
+      validateForm()
+    }
+
+    binding.eulaCheckbox.setOnCheckedChangeListener { _, _ ->
+      validateForm()
+    }
+
+    binding.eula.setOnClickListener {
+      nextAction = JuvenilePolicyFragmentDirections.actionEula()
+      navController.navigate(nextAction)
+    }
+
+    // Go to next screen
+    binding.nextBtn.setOnClickListener {
+      if (validateForm()) {
+        binding.progress.visibility = View.VISIBLE
+        getToken()
+      } else {
+        requireActivity().setResult(Activity.RESULT_CANCELED)
+        requireActivity().finish()
+      }
+    }
+
+    viewModel.issoTokenData.observe(viewLifecycleOwner, Observer {
+      getCache().token = it.access_token
+      getEligibility()
+    })
+
+    platformViewModel.dependentEligibilityData.observe(viewLifecycleOwner, Observer {
+      if (it.eligible) {
+        nextAction = JuvenilePolicyFragmentDirections.actionLocation()
+        navController.navigate(nextAction)
+      } else {
+        val dialogBuilder = AlertDialog.Builder(requireContext())
+        dialogBuilder.setMessage(it.description)
+          .setCancelable(false)
+          .setNegativeButton(getString(R.string.cancel)) { _, _ ->
+            requireActivity().setResult(Activity.RESULT_CANCELED)
+            requireActivity().finish()
+          }
+        val alert = dialogBuilder.create()
+        alert.show()
+      }
+    })
+
+    platformViewModel.apiError.observe(viewLifecycleOwner, Observer {
+      binding.progress.visibility = View.GONE
+      val dialogBuilder = AlertDialog.Builder(requireContext())
+      dialogBuilder.setMessage("$it Error")
+        .setCancelable(false)
+        .setPositiveButton(getString(R.string.try_again)) { _, _ ->
+          getToken()
+        }
+        .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
+          dialog.cancel()
+        }
+      val alert = dialogBuilder.create()
+      alert.show()
+    })
+
+    viewModel.apiError.observe(viewLifecycleOwner, Observer {
+      binding.progress.visibility = View.GONE
+      val dialogBuilder = AlertDialog.Builder(requireContext())
+      dialogBuilder.setMessage("$it Error")
+        .setCancelable(false)
+        .setPositiveButton(getString(R.string.try_again)) { _, _ ->
+          getToken()
+        }
+        .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
+          dialog.cancel()
+        }
+      val alert = dialogBuilder.create()
+      alert.show()
+    })
+  }
+
+  /**
+   * Check to see if the user is eligible to create child cards
+   */
+  private fun getEligibility() {
+    platformViewModel.getDependentEligibility(
+      requireActivity().intent.extras.getString("userIdentifier"),
+      getCache().token.toString()
+    )
+  }
+
+  /**
+   * Get token needed for platform API calls
+   */
+  private fun getToken() {
+    binding.progress.visibility = View.VISIBLE
+    viewModel.getToken(
+      requireActivity().intent.extras.getString("clientId"),
+      requireActivity().intent.extras.getString("clientSecret"))
+  }
+
+  /**
+   * Validates required user input enabling/disabling forward navigation
+   */
+  private fun validateForm(): Boolean {
+    return if (binding.eulaCheckbox.isChecked && binding.policyCheckbox.isChecked) {
+      binding.nextBtn.text = getString(R.string.next); true
+    } else {
+      binding.nextBtn.text = getString(R.string.cancel); false
+    }
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
+  }
+}

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
@@ -26,6 +26,7 @@ import androidx.navigation.Navigation
 import org.nypl.simplified.cardcreator.CardCreatorDebugging
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentLocationBinding
+import org.nypl.simplified.cardcreator.utils.getCache
 import org.nypl.simplified.cardcreator.utils.startEllipses
 import org.slf4j.LoggerFactory
 import java.util.Locale
@@ -81,8 +82,13 @@ class LocationFragment : Fragment(), LocationListener {
     binding.nextBtn.setOnClickListener {
       if (isNewYork || locationMock) {
         logger.debug("User navigated to the next screen")
-        nextAction = LocationFragmentDirections.actionNext()
-        navController.navigate(nextAction)
+        if (getCache().isJuvenileCard!!) {
+          nextAction = LocationFragmentDirections.actionJuvenileInformation()
+          navController.navigate(nextAction)
+        } else {
+          nextAction = LocationFragmentDirections.actionNext()
+          navController.navigate(nextAction)
+        }
       } else {
         val data = Intent()
         requireActivity().setResult(Activity.RESULT_CANCELED, data)
@@ -247,18 +253,18 @@ class LocationFragment : Fragment(), LocationListener {
       val address: Address?
 
       try {
-          address = geocoder.getFromLocation(location.latitude, location.longitude, maxResults)[0]
-          logger.debug("Region is: ${address.adminArea} ${address.countryCode} ")
-          binding.regionEt.setText("${address.adminArea} ${address.countryCode}", TextView.BufferType.EDITABLE)
+        address = geocoder.getFromLocation(location.latitude, location.longitude, maxResults)[0]
+        logger.debug("Region is: ${address.adminArea} ${address.countryCode} ")
+        binding.regionEt.setText("${address.adminArea} ${address.countryCode}", TextView.BufferType.EDITABLE)
 
-          if (address.countryCode == "US" && (address.adminArea == "New York" || address.adminArea == "NY")) {
-            logger.debug("User is in New York")
-            logger.debug("Stopping location updates")
-            locationManager.removeUpdates(this)
-            enableNext(true)
-          } else {
-            enableNext(false)
-          }
+        if (address.countryCode == "US" && (address.adminArea == "New York" || address.adminArea == "NY")) {
+          logger.debug("User is in New York")
+          logger.debug("Stopping location updates")
+          locationManager.removeUpdates(this)
+          enableNext(true)
+        } else {
+          enableNext(false)
+        }
       } catch (e: Exception) {
         logger.error("Error checking to see if user is in New York", e)
         enableNext(false)
@@ -286,7 +292,20 @@ class LocationFragment : Fragment(), LocationListener {
   }
 
   // These are not needed but were invited to the party by Google
-  override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) { logger.debug("location status changed") }
-  override fun onProviderEnabled(provider: String?) { logger.debug("location provider enabled") }
-  override fun onProviderDisabled(provider: String?) { logger.debug("location provider disabled") }
+  override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {
+    logger.debug("location status changed")
+  }
+
+  override fun onProviderEnabled(provider: String?) {
+    logger.debug("location provider enabled")
+  }
+
+  override fun onProviderDisabled(provider: String?) {
+    logger.debug("location provider disabled")
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
+  }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/OutOfStateFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/OutOfStateFragment.kt
@@ -10,7 +10,7 @@ import androidx.navigation.NavDirections
 import androidx.navigation.Navigation
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentOutOfStateBinding
-import org.nypl.simplified.cardcreator.models.AddressType
+import org.nypl.simplified.cardcreator.model.AddressType
 import org.slf4j.LoggerFactory
 
 class OutOfStateFragment : Fragment() {
@@ -61,5 +61,10 @@ class OutOfStateFragment : Fragment() {
     binding.prevBtn.setOnClickListener {
       navController.popBackStack()
     }
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/PersonalInformationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/PersonalInformationFragment.kt
@@ -17,7 +17,7 @@ import androidx.navigation.Navigation
 import org.joda.time.format.DateTimeFormat
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentPersonalInformationBinding
-import org.nypl.simplified.cardcreator.models.PersonalInformation
+import org.nypl.simplified.cardcreator.model.PersonalInformation
 import org.nypl.simplified.cardcreator.utils.Cache
 import org.nypl.simplified.cardcreator.utils.hideKeyboard
 import org.slf4j.LoggerFactory
@@ -155,7 +155,12 @@ class PersonalInformationFragment : Fragment(), DatePickerDialog.OnDateSetListen
   }
 
   override fun onDateSet(view: DatePicker, year: Int, month: Int, dayOfMonth: Int) {
-    birthDate = "$month/$dayOfMonth/$year"
+    birthDate = "${month + 1}/$dayOfMonth/$year"
     binding.birthDateEt.setText(birthDate, TextView.BufferType.EDITABLE)
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    _binding = null
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/Cache.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/Cache.kt
@@ -190,7 +190,7 @@ class Cache internal constructor(private val sharedPreferences: SharedPreference
     }
     set(value) {
       field = value
-      sharedPreferences.edit { putBoolean(KEY_JUVENILE_CARD, value!!) }
+      sharedPreferences.edit { putBoolean(KEY_JUVENILE_CARD, value ?: false) }
     }
 
   /**

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/Cache.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/Cache.kt
@@ -3,9 +3,9 @@ package org.nypl.simplified.cardcreator.utils
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import org.nypl.simplified.cardcreator.models.AccountInformation
-import org.nypl.simplified.cardcreator.models.AddressDetails
-import org.nypl.simplified.cardcreator.models.PersonalInformation
+import org.nypl.simplified.cardcreator.model.AccountInformation
+import org.nypl.simplified.cardcreator.model.AddressDetails
+import org.nypl.simplified.cardcreator.model.PersonalInformation
 
 /**
  * Util class for handling saving/retrieving address across card creator process
@@ -47,6 +47,8 @@ class Cache internal constructor(private val sharedPreferences: SharedPreference
 
     private const val KEY_USERNAME = "username"
     private const val KEY_PIN = "pin"
+    private const val KEY_JUVENILE_CARD = "juvenile_card"
+    private const val KEY_TOKEN = "token"
 
     private const val EMPTY = ""
   }
@@ -175,4 +177,34 @@ class Cache internal constructor(private val sharedPreferences: SharedPreference
       putString(KEY_PIN, pin)
     }
   }
+
+  /**
+   * Getter/Setter of whether or not we are creating a juvenile card
+   */
+  var isJuvenileCard: Boolean? = null
+    get() {
+      if (field == null) {
+        field = sharedPreferences.getBoolean(KEY_JUVENILE_CARD, false)
+      }
+      return field
+    }
+    set(value) {
+      field = value
+      sharedPreferences.edit { putBoolean(KEY_JUVENILE_CARD, value!!) }
+    }
+
+  /**
+   * Getter/Setter for ISSO token
+   */
+  var token: String? = null
+    get() {
+      if (field == null) {
+        field = sharedPreferences.getString(KEY_TOKEN, "")
+      }
+      return field
+    }
+    set(value) {
+      field = value
+      sharedPreferences.edit { putString(KEY_TOKEN, value) }
+    }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/Constants.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/Constants.kt
@@ -6,4 +6,11 @@ package org.nypl.simplified.cardcreator.utils
 object Constants {
   const val LIBRARY_SIMPLIFIED_BASE_URL = "http://patrons.librarysimplified.org/"
   const val LIBRARY_SIMPLIFIED_QA_BASE_URL = "http://qa.patrons.librarysimplified.org/"
+
+  const val EULA = "https://librarysimplified.org/EULA/"
+
+  const val NYPL_ISSO_BASE_URL = "https://isso.nypl.org/oauth/"
+
+  const val NYPL_PROD_PLATFORM_BASE_URL = "https://platform.nypl.org/api/v0.3/"
+  const val NYPL_QA_PLATFORM_BASE_URL = "https://qa-platform.nypl.org/api/v0.3/"
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/FragmentUtils.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/FragmentUtils.kt
@@ -1,7 +1,6 @@
 package org.nypl.simplified.cardcreator.utils
 
 import androidx.fragment.app.Fragment
-import java.lang.Double
 
 /**
  * Gets Cache object

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/FragmentUtils.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/FragmentUtils.kt
@@ -15,9 +15,5 @@ fun Fragment.getCache(): Cache {
  * Determines whether or not the user identifier is a barcode or username
  */
 fun Fragment.isBarcode(identifier: String): Boolean {
-  return try {
-    Double.parseDouble(identifier); true
-  } catch (e: NumberFormatException) {
-    false
-  }
+  return identifier.toDoubleOrNull() != null
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/FragmentUtils.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/utils/FragmentUtils.kt
@@ -1,0 +1,23 @@
+package org.nypl.simplified.cardcreator.utils
+
+import androidx.fragment.app.Fragment
+import java.lang.Double
+
+/**
+ * Gets Cache object
+ */
+
+fun Fragment.getCache(): Cache {
+  return Cache(this.requireActivity())
+}
+
+/**
+ * Determines whether or not the user identifier is a barcode or username
+ */
+fun Fragment.isBarcode(identifier: String): Boolean {
+  return try {
+    Double.parseDouble(identifier); true
+  } catch (e: NumberFormatException) {
+    false
+  }
+}

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/AddressViewModel.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/AddressViewModel.kt
@@ -1,11 +1,11 @@
-package org.nypl.simplified.cardcreator.viewmodels
+package org.nypl.simplified.cardcreator.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
-import org.nypl.simplified.cardcreator.models.Address
-import org.nypl.simplified.cardcreator.models.ValidateAddressResponse
+import org.nypl.simplified.cardcreator.model.Address
+import org.nypl.simplified.cardcreator.model.ValidateAddressResponse
 import org.nypl.simplified.cardcreator.network.CardCreatorService
 import org.slf4j.LoggerFactory
 import retrofit2.HttpException

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/PatronViewModel.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/PatronViewModel.kt
@@ -1,11 +1,11 @@
-package org.nypl.simplified.cardcreator.viewmodels
+package org.nypl.simplified.cardcreator.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
-import org.nypl.simplified.cardcreator.models.CreatePatronResponse
-import org.nypl.simplified.cardcreator.models.Patron
+import org.nypl.simplified.cardcreator.model.CreatePatronResponse
+import org.nypl.simplified.cardcreator.model.Patron
 import org.nypl.simplified.cardcreator.network.CardCreatorService
 import org.slf4j.LoggerFactory
 import retrofit2.HttpException

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/PlatformViewModel.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/PlatformViewModel.kt
@@ -10,7 +10,6 @@ import org.nypl.simplified.cardcreator.model.JuvenilePatronResponse
 import org.nypl.simplified.cardcreator.network.NYPLPlatformService
 import org.slf4j.LoggerFactory
 import retrofit2.HttpException
-import java.lang.Double.parseDouble
 import java.lang.Exception
 
 class PlatformViewModel : ViewModel() {

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/PlatformViewModel.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/PlatformViewModel.kt
@@ -1,0 +1,75 @@
+package org.nypl.simplified.cardcreator.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import org.nypl.simplified.cardcreator.model.DependentEligibilityData
+import org.nypl.simplified.cardcreator.model.JuvenilePatron
+import org.nypl.simplified.cardcreator.model.JuvenilePatronResponse
+import org.nypl.simplified.cardcreator.network.NYPLPlatformService
+import org.slf4j.LoggerFactory
+import retrofit2.HttpException
+import java.lang.Double.parseDouble
+import java.lang.Exception
+
+class PlatformViewModel : ViewModel() {
+
+  private val logger = LoggerFactory.getLogger(PlatformViewModel::class.java)
+
+  val dependentEligibilityData = MutableLiveData<DependentEligibilityData>()
+  val juvenilePatronResponse = MutableLiveData<JuvenilePatronResponse>()
+
+  val apiError = MutableLiveData<Int?>()
+
+  fun getDependentEligibility(identifier: String, token: String) {
+    viewModelScope.launch {
+      try {
+        val nyplPlatformService = NYPLPlatformService(token)
+        if (isBarcode(identifier)) {
+          val response =
+            nyplPlatformService.getDependentEligibilityWithBarcode(identifier)
+          dependentEligibilityData.postValue(response)
+        } else {
+          val response =
+            nyplPlatformService.getDependentEligibilityWithUsername(identifier)
+          dependentEligibilityData.postValue(response)
+        }
+      } catch (e: Exception) {
+        logger.error("attempt to check dependent eligibility call failed!", e)
+        when (e) {
+          is HttpException -> { apiError.postValue(e.code()) }
+          else -> { apiError.postValue(null) }
+        }
+      }
+    }
+  }
+
+  fun createJuvenileCard(juvenilePatron: JuvenilePatron, token: String) {
+    viewModelScope.launch {
+      try {
+        val nyplPlatformService = NYPLPlatformService(token)
+        val response =
+          nyplPlatformService.createJuvenilePatron(juvenilePatron)
+        juvenilePatronResponse.postValue(response)
+      } catch (e: Exception) {
+        logger.error("attempt to create a juvenile patron call failed!", e)
+        when (e) {
+          is HttpException -> { apiError.postValue(e.code()) }
+          else -> { apiError.postValue(null) }
+        }
+      }
+    }
+  }
+
+  /**
+   * Determines whether or not the user identifier is a barcode or username
+   */
+  fun isBarcode(identifier: String): Boolean {
+    return try {
+      parseDouble(identifier); true
+    } catch (e: NumberFormatException) {
+      false
+    }
+  }
+}

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/PlatformViewModel.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/PlatformViewModel.kt
@@ -65,11 +65,7 @@ class PlatformViewModel : ViewModel() {
   /**
    * Determines whether or not the user identifier is a barcode or username
    */
-  fun isBarcode(identifier: String): Boolean {
-    return try {
-      parseDouble(identifier); true
-    } catch (e: NumberFormatException) {
-      false
-    }
+  private fun isBarcode(identifier: String): Boolean {
+    return identifier.toDoubleOrNull() != null
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/TokenViewModel.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/TokenViewModel.kt
@@ -1,0 +1,40 @@
+package org.nypl.simplified.cardcreator.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import okhttp3.MultipartBody
+import org.nypl.simplified.cardcreator.model.ISSOTokenData
+import org.nypl.simplified.cardcreator.network.NYPLISSOService
+import org.slf4j.LoggerFactory
+import retrofit2.HttpException
+import java.lang.Exception
+
+class TokenViewModel : ViewModel() {
+
+  private val logger = LoggerFactory.getLogger(TokenViewModel::class.java)
+
+  val issoTokenData = MutableLiveData<ISSOTokenData>()
+  val apiError = MutableLiveData<Int?>()
+
+  fun getToken(clientId: String, clientSecret: String) {
+    viewModelScope.launch {
+      try {
+        val nyplISSOService = NYPLISSOService()
+        val response = nyplISSOService.getToken(
+          MultipartBody.Part.createFormData("grant_type", "client_credentials"),
+          MultipartBody.Part.createFormData("client_id", clientId),
+          MultipartBody.Part.createFormData("client_secret", clientSecret)
+        )
+        issoTokenData.postValue(response)
+      } catch (e: Exception) {
+        logger.error("attempt to get NYPL platform token call failed!", e)
+        when (e) {
+          is HttpException -> { apiError.postValue(e.code()) }
+          else -> { apiError.postValue(null) }
+        }
+      }
+    }
+  }
+}

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/UsernameViewModel.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/viewmodel/UsernameViewModel.kt
@@ -1,11 +1,11 @@
-package org.nypl.simplified.cardcreator.viewmodels
+package org.nypl.simplified.cardcreator.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
-import org.nypl.simplified.cardcreator.models.Username
-import org.nypl.simplified.cardcreator.models.ValidateUsernameResponse
+import org.nypl.simplified.cardcreator.model.Username
+import org.nypl.simplified.cardcreator.model.ValidateUsernameResponse
 import org.nypl.simplified.cardcreator.network.CardCreatorService
 import org.slf4j.LoggerFactory
 import retrofit2.HttpException

--- a/simplified-cardcreator/src/main/res/layout/fragment_eula.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_eula.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:orientation="vertical"
+    android:layout_height="match_parent"
+    tools:context=".ui.EULAFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/loading"
+        android:layout_width="match_parent"
+        android:clickable="true"
+        android:layout_height="match_parent"
+        android:background="@color/trans_white"
+        android:visibility="visible"
+        tools:ignore="KeyboardInaccessibleWidget">
+
+        <ProgressBar
+            android:id="@+id/progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <WebView
+            android:layout_width="match_parent"
+            android:id="@+id/webview"
+            android:layout_height="match_parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</LinearLayout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_juvenile_information.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_juvenile_information.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".ui.JuvenileInformationFragment">
+
+    <LinearLayout
+        android:id="@+id/header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/header_error_tv"
+            style="@style/WizardHeader"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/personal_information" />
+
+        <TextView
+            android:id="@+id/header_status_desc_tv"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="8dp"
+            android:layout_marginTop="16sp"
+            android:layout_marginRight="8dp"
+            android:layout_marginBottom="8dp"
+            android:fontFamily="sans-serif"
+            android:gravity="center"
+            android:textSize="16sp" />
+    </LinearLayout>
+
+    <ScrollView
+        android:id="@+id/form"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingLeft="16dp"
+        android:paddingTop="16dp"
+        android:paddingRight="16dp"
+        android:scrollbarStyle="outsideOverlay">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+
+            <TextView
+                style="@style/WizardFormLabel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/first_name" />
+
+            <EditText
+                android:id="@+id/first_name_et"
+                style="@style/WizardFormEditText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/required"
+                android:inputType="text" />
+
+            <TextView
+                style="@style/WizardFormLabel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/last_name" />
+
+            <EditText
+                android:id="@+id/last_name_et"
+                style="@style/WizardFormEditText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/optional"
+                android:inputType="text" />
+
+        </LinearLayout>
+    </ScrollView>
+
+    <LinearLayout
+        android:id="@+id/nav_buttons"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/prev_btn"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:layout_weight="1"
+            android:text="@string/previous"
+            android:textAllCaps="true" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/next_btn"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:layout_weight="1"
+            android:enabled="false"
+            android:text="@string/next"
+            android:textAllCaps="true" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/simplified-cardcreator/src/main/res/layout/fragment_juvenile_policy.xml
+++ b/simplified-cardcreator/src/main/res/layout/fragment_juvenile_policy.xml
@@ -4,50 +4,30 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.AgeFragment">
+    tools:context=".ui.JuvenilePolicyFragment">
 
     <TextView
         android:id="@+id/description_tv"
         style="@style/WizardDescription"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="64dp"
-        android:text="@string/age_description"
+        android:layout_marginTop="32dp"
+        android:gravity="start"
+        android:text="@string/juvenile_policy"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <RadioGroup
-        android:id="@+id/age_rg"
-        android:layout_width="match_parent"
+    <CheckBox
+        android:id="@+id/policy_checkbox"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp"
+        android:checked="false"
+        android:text="@string/juvenile_policy_checkbox"
+        android:textSize="12sp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/description_tv">
-
-        <RadioButton
-            android:id="@+id/under_13_rb"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="25dp"
-            android:layout_marginTop="20dp"
-            android:layout_marginRight="25dp"
-            android:layout_marginBottom="20dp"
-            android:layout_weight="1"
-            android:text="@string/under_13" />
-
-        <RadioButton
-            android:id="@+id/older_13_rb"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="25dp"
-            android:layout_marginTop="20dp"
-            android:layout_marginRight="25dp"
-            android:layout_marginBottom="20dp"
-            android:layout_weight="1"
-            android:text="@string/over_13" />
-    </RadioGroup>
+        app:layout_constraintTop_toBottomOf="@id/description_tv" />
 
     <CheckBox
         android:id="@+id/eula_checkbox"
@@ -55,10 +35,10 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="5dp"
         android:checked="false"
-        android:text="@string/eula_checkbox"
+        android:text="@string/read_eula"
         android:textSize="12sp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/age_rg" />
+        app:layout_constraintTop_toBottomOf="@id/policy_checkbox" />
 
     <TextView
         android:id="@+id/error"
@@ -76,23 +56,31 @@
         style="?android:attr/buttonBarButtonStyle"
         android:layout_width="match_parent"
         android:layout_height="50dp"
-        android:enabled="false"
         android:gravity="center"
-        android:text="@string/next"
+        android:text="@string/cancel"
         android:textAllCaps="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
     <TextView
+        android:id="@+id/eula"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:id="@+id/eula"
         android:gravity="center"
         android:text="@string/eula"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/eula_checkbox"
-        />
+        app:layout_constraintTop_toBottomOf="@id/eula_checkbox" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:visibility="gone"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-cardcreator/src/main/res/navigation/nav_graph.xml
+++ b/simplified-cardcreator/src/main/res/navigation/nav_graph.xml
@@ -15,6 +15,14 @@
             app:destination="@id/destination_location"
             app:enterAnim="@anim/enter_right"
             app:exitAnim="@anim/exit_left" />
+        <action
+            android:id="@+id/action_eula"
+            app:destination="@id/destination_eula"
+            app:enterAnim="@anim/enter_right"
+            app:exitAnim="@anim/exit_left" />
+        <action
+            android:id="@+id/action_juvenile_policy"
+            app:destination="@id/destination_juvenile_policy" />
     </fragment>
 
     <fragment
@@ -25,6 +33,11 @@
         <action
             android:id="@+id/action_next"
             app:destination="@id/destination_home_address"
+            app:enterAnim="@anim/enter_right"
+            app:exitAnim="@anim/exit_left" />
+        <action
+            android:id="@+id/action_juvenile_information"
+            app:destination="@id/destination_juvenile_information"
             app:enterAnim="@anim/enter_right"
             app:exitAnim="@anim/exit_left" />
     </fragment>
@@ -87,7 +100,7 @@
             app:exitAnim="@anim/exit_left" />
         <argument
             android:name="address_type"
-            app:argType="org.nypl.simplified.cardcreator.models.AddressType" />
+            app:argType="org.nypl.simplified.cardcreator.model.AddressType" />
 
     </fragment>
 
@@ -104,7 +117,7 @@
             app:exitAnim="@anim/exit_left" />
         <argument
             android:name="address_type"
-            app:argType="org.nypl.simplified.cardcreator.models.AddressType" />
+            app:argType="org.nypl.simplified.cardcreator.model.AddressType" />
 
     </fragment>
 
@@ -144,14 +157,14 @@
 
         <action
             android:id="@+id/action_next"
-            app:destination="@id/destination_confirrmation"
+            app:destination="@id/destination_confirmation"
             app:enterAnim="@anim/enter_right"
             app:exitAnim="@anim/exit_left" />
 
     </fragment>
 
     <fragment
-        android:id="@+id/destination_confirrmation"
+        android:id="@+id/destination_confirmation"
         android:name="org.nypl.simplified.cardcreator.ui.ConfirmationFragment"
         android:label="fragment_confirmation"
         tools:layout="@layout/fragment_confirmation">
@@ -177,6 +190,40 @@
         <argument
             android:name="name"
             app:argType="string" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/destination_eula"
+        android:name="org.nypl.simplified.cardcreator.ui.EULAFragment"
+        android:label="fragment_eula"
+        tools:layout="@layout/fragment_eula" />
+
+    <fragment
+        android:id="@+id/destination_juvenile_policy"
+        android:name="org.nypl.simplified.cardcreator.ui.JuvenilePolicyFragment"
+        android:label="fragment_juvenile_policy"
+        tools:layout="@layout/fragment_juvenile_policy">
+        <action
+            android:id="@+id/action_eula"
+            app:destination="@id/destination_eula"
+            app:enterAnim="@anim/enter_right"
+            app:exitAnim="@anim/exit_left" />
+        <action
+            android:id="@+id/action_location"
+            app:destination="@id/destination_location"
+            app:enterAnim="@anim/enter_right"
+            app:exitAnim="@anim/exit_left" />
+    </fragment>
+    <fragment
+        android:id="@+id/destination_juvenile_information"
+        android:name="org.nypl.simplified.cardcreator.ui.JuvenileInformationFragment"
+        android:label="fragment_juvenile_information"
+        tools:layout="@layout/fragment_juvenile_information">
+        <action
+            android:id="@+id/action_next"
+            app:destination="@id/destination_account_information"
+            app:enterAnim="@anim/enter_right"
+            app:exitAnim="@anim/exit_left" />
     </fragment>
 
 </navigation>

--- a/simplified-cardcreator/src/main/res/values/strings.xml
+++ b/simplified-cardcreator/src/main/res/values/strings.xml
@@ -131,6 +131,15 @@
     <string name="eula_checkbox">I agree to the terms of the End User License Agreement.</string>
     <string name="age_error">You are not old enough to sign up for a library card.</string>
     <string name="validating_location">Validating your location</string>
+    <string name="eula"><u>End User License Agreement</u></string>
+
+    <!-- Juvenile Policy -->
+    <string name="juvenile_policy">To apply for a card for your under-13 child, you must be the parent/legal guardian of the minor in question and be physically present in New York State at the time of sign-up.\n\n
+    Please check the box below to confirm you are the legal guardian of the minor child for whom the card will be used.
+    </string>
+    <string name="juvenile_policy_checkbox">By checking this box, I confirm that I am the parent / legal guardian of the minor for whom I am creating a library card account.</string>
+    <string name="read_eula">I have read and agree to the End User License Agreement.</string>
+    <string name="create_child_card">Create Card for your Child</string>
 
     <!-- Location -->
     <string name="checking_location">Checking location&#8230;</string>

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -126,6 +126,7 @@ class AccountFragment : Fragment() {
   private var cardCreatorService: CardCreatorServiceType? = null
   private var loginRequested: Boolean = false
   private var profileSubscription: Disposable? = null
+  private val nyplCardCreatorScheme = "nypl.card-creator"
 
   companion object {
 
@@ -409,13 +410,22 @@ class AccountFragment : Fragment() {
       if (cardCreator == null) {
         this.logger.error("Card creator not configured")
       } else {
-        cardCreator.openCardCreatorActivity(
-          this,
-          this.activity,
-          this.cardCreatorResultCode,
-          this.account.loginState is AccountLoggedIn,
-          this.authenticationBasicUser.text.toString().trim()
-        )
+        // Launch NYPL card creator
+        if (this.account.provider.cardCreatorURI?.scheme.equals(nyplCardCreatorScheme)) {
+          cardCreator.openCardCreatorActivity(
+            this,
+            this.activity,
+            this.cardCreatorResultCode,
+            this.account.loginState is AccountLoggedIn,
+            this.authenticationBasicUser.text.toString().trim()
+          )
+          // Launch external card creator
+        } else {
+          val webCardCreator = Intent(
+            Intent.ACTION_VIEW,
+            Uri.parse(this.account.provider.cardCreatorURI.toString()))
+          startActivity(webCardCreator)
+        }
       }
     }
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -26,9 +26,12 @@ import com.io7m.junreachable.UnreachableCodeException
 import io.reactivex.disposables.Disposable
 import org.joda.time.DateTime
 import org.librarysimplified.services.api.Services
-import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
+import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription
 import org.nypl.simplified.accounts.api.AccountEvent
+import org.nypl.simplified.accounts.api.AccountPassword
 import org.nypl.simplified.accounts.api.AccountEventLoginStateChanged
+import org.nypl.simplified.accounts.api.AccountUsername
+import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggedIn
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggingIn
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggingInWaitingForExternalAuthentication
@@ -36,10 +39,7 @@ import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggingOut
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoginFailed
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLogoutFailed
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountNotLoggedIn
-import org.nypl.simplified.accounts.api.AccountPassword
-import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription
 import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription.KeyboardInput
-import org.nypl.simplified.accounts.api.AccountUsername
 import org.nypl.simplified.accounts.database.api.AccountType
 import org.nypl.simplified.accounts.database.api.AccountsDatabaseNonexistentException
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
@@ -409,7 +409,13 @@ class AccountFragment : Fragment() {
       if (cardCreator == null) {
         this.logger.error("Card creator not configured")
       } else {
-        cardCreator.openCardCreatorActivity(this, this.activity, this.cardCreatorResultCode)
+        cardCreator.openCardCreatorActivity(
+          this,
+          this.activity,
+          this.cardCreatorResultCode,
+          this.account.loginState is AccountLoggedIn,
+          this.authenticationBasicUser.text.toString().trim()
+        )
       }
     }
 
@@ -862,11 +868,13 @@ class AccountFragment : Fragment() {
     return when (status) {
       is AsLoginButtonEnabled -> {
         this.loginButton.setText(R.string.accountLogin)
+        this.signUpLabel.text = getString(R.string.accountCardCreatorLabel)
         this.loginButton.isEnabled = true
         this.loginButton.setOnClickListener { status.onClick.invoke() }
       }
       AsLoginButtonDisabled -> {
         this.loginButton.setText(R.string.accountLogin)
+        this.signUpLabel.text = getString(R.string.accountCardCreatorLabel)
         this.loginButton.isEnabled = false
       }
       is AsCancelButtonEnabled -> {
@@ -876,11 +884,13 @@ class AccountFragment : Fragment() {
       }
       is AsLogoutButtonEnabled -> {
         this.loginButton.setText(R.string.accountLogout)
+        this.signUpLabel.text = "Want a card for your child?"
         this.loginButton.isEnabled = true
         this.loginButton.setOnClickListener { status.onClick.invoke() }
       }
       AsLogoutButtonDisabled -> {
         this.loginButton.setText(R.string.accountLogout)
+        this.signUpLabel.text = "Want a card for your child?"
         this.loginButton.isEnabled = false
       }
       AsCancelButtonDisabled -> {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -902,13 +902,13 @@ class AccountFragment : Fragment() {
     return when (status) {
       is AsLoginButtonEnabled -> {
         this.loginButton.setText(R.string.accountLogin)
-        this.signUpLabel.text = getString(R.string.accountCardCreatorLabel)
+        this.signUpLabel.setText(R.string.accountCardCreatorLabel)
         this.loginButton.isEnabled = true
         this.loginButton.setOnClickListener { status.onClick.invoke() }
       }
       AsLoginButtonDisabled -> {
         this.loginButton.setText(R.string.accountLogin)
-        this.signUpLabel.text = getString(R.string.accountCardCreatorLabel)
+        this.signUpLabel.setText(R.string.accountCardCreatorLabel)
         this.loginButton.isEnabled = false
       }
       is AsCancelButtonEnabled -> {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -884,13 +884,13 @@ class AccountFragment : Fragment() {
       }
       is AsLogoutButtonEnabled -> {
         this.loginButton.setText(R.string.accountLogout)
-        this.signUpLabel.text = "Want a card for your child?"
+        this.signUpLabel.setText(R.string.accountWantChildCard)
         this.loginButton.isEnabled = true
         this.loginButton.setOnClickListener { status.onClick.invoke() }
       }
       AsLogoutButtonDisabled -> {
         this.loginButton.setText(R.string.accountLogout)
-        this.signUpLabel.text = "Want a card for your child?"
+        this.signUpLabel.setText(R.string.accountWantChildCard)
         this.loginButton.isEnabled = false
       }
       AsCancelButtonDisabled -> {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -396,7 +396,14 @@ class AccountFragment : Fragment() {
      * Conditionally enable sign up button
      */
 
-    if (this.account.provider.cardCreatorURI != null && this.cardCreatorService != null) {
+    if (this.account.provider.cardCreatorURI != null &&
+      this.cardCreatorService != null &&
+      this.account.provider.cardCreatorURI?.scheme.equals(nyplCardCreatorScheme)
+    ) {
+      this.signUpButton.isEnabled = true
+      this.signUpLabel.isEnabled = true
+    } else if (this.account.provider.cardCreatorURI != null &&
+      !this.account.provider.cardCreatorURI?.scheme.equals(nyplCardCreatorScheme)) {
       this.signUpButton.isEnabled = true
       this.signUpLabel.isEnabled = true
     }
@@ -407,18 +414,21 @@ class AccountFragment : Fragment() {
 
     this.signUpButton.setOnClickListener {
       val cardCreator = this.cardCreatorService
-      if (cardCreator == null) {
-        this.logger.error("Card creator not configured")
-      } else {
-        // Launch NYPL card creator
         if (this.account.provider.cardCreatorURI?.scheme.equals(nyplCardCreatorScheme)) {
-          cardCreator.openCardCreatorActivity(
-            this,
-            this.activity,
-            this.cardCreatorResultCode,
-            this.account.loginState is AccountLoggedIn,
-            this.authenticationBasicUser.text.toString().trim()
-          )
+          if (cardCreator != null) {
+            // Launch NYPL card creator
+            cardCreator.openCardCreatorActivity(
+              this,
+              this.activity,
+              this.cardCreatorResultCode,
+              this.account.loginState is AccountLoggedIn,
+              this.authenticationBasicUser.text.toString().trim()
+            )
+          } else {
+            this.logger.error("Card creator not configured")
+            this.signUpButton.isEnabled = false
+            this.signUpLabel.isEnabled = false
+          }
           // Launch external card creator
         } else {
           val webCardCreator = Intent(
@@ -426,7 +436,6 @@ class AccountFragment : Fragment() {
             Uri.parse(this.account.provider.cardCreatorURI.toString()))
           startActivity(webCardCreator)
         }
-      }
     }
 
     /*

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -331,6 +331,53 @@ class AccountFragment : Fragment() {
     this.setLoginButtonStatus(this.determineLoginIsSatisfied())
   }
 
+  private fun shouldSignUpBeEnabled(): Boolean {
+    val cardCreatorURI = this.account.provider.cardCreatorURI
+
+    /*
+     * If there's any card creator URI, the button should be enabled...
+     */
+
+    return if (cardCreatorURI != null) {
+
+      /*
+       * Unless the URI refers to the NYPL Card Creator and we don't have that enabled
+       * in this build.
+       */
+
+      if (cardCreatorURI.scheme == this.nyplCardCreatorScheme) {
+        return this.cardCreatorService != null
+      }
+      true
+    } else {
+      false
+    }
+  }
+
+  private fun openCardCreator() {
+    val cardCreator = this.cardCreatorService
+    val cardCreatorURI = this.account.provider.cardCreatorURI
+    if (cardCreatorURI != null) {
+      if (cardCreatorURI.scheme == this.nyplCardCreatorScheme) {
+        if (cardCreator != null) {
+          cardCreator.openCardCreatorActivity(
+            this,
+            this.activity,
+            this.cardCreatorResultCode,
+            this.account.loginState is AccountLoggedIn,
+            this.authenticationBasicUser.text.toString().trim()
+          )
+        } else {
+          // We rely on [shouldSignUpBeEnabled] to have disabled the button
+          throw UnreachableCodeException()
+        }
+      } else {
+        val webCardCreator = Intent(Intent.ACTION_VIEW, Uri.parse(cardCreatorURI.toString()))
+        startActivity(webCardCreator)
+      }
+    }
+  }
+
   override fun onStart() {
     super.onStart()
 
@@ -396,47 +443,15 @@ class AccountFragment : Fragment() {
      * Conditionally enable sign up button
      */
 
-    if (this.account.provider.cardCreatorURI != null &&
-      this.cardCreatorService != null &&
-      this.account.provider.cardCreatorURI?.scheme.equals(nyplCardCreatorScheme)
-    ) {
-      this.signUpButton.isEnabled = true
-      this.signUpLabel.isEnabled = true
-    } else if (this.account.provider.cardCreatorURI != null &&
-      !this.account.provider.cardCreatorURI?.scheme.equals(nyplCardCreatorScheme)) {
-      this.signUpButton.isEnabled = true
-      this.signUpLabel.isEnabled = true
-    }
+    val signUpEnabled = this.shouldSignUpBeEnabled()
+    this.signUpButton.isEnabled = signUpEnabled
+    this.signUpLabel.isEnabled = signUpEnabled
 
     /*
      * Launch Card Creator
      */
 
-    this.signUpButton.setOnClickListener {
-      val cardCreator = this.cardCreatorService
-        if (this.account.provider.cardCreatorURI?.scheme.equals(nyplCardCreatorScheme)) {
-          if (cardCreator != null) {
-            // Launch NYPL card creator
-            cardCreator.openCardCreatorActivity(
-              this,
-              this.activity,
-              this.cardCreatorResultCode,
-              this.account.loginState is AccountLoggedIn,
-              this.authenticationBasicUser.text.toString().trim()
-            )
-          } else {
-            this.logger.error("Card creator not configured")
-            this.signUpButton.isEnabled = false
-            this.signUpLabel.isEnabled = false
-          }
-          // Launch external card creator
-        } else {
-          val webCardCreator = Intent(
-            Intent.ACTION_VIEW,
-            Uri.parse(this.account.provider.cardCreatorURI.toString()))
-          startActivity(webCardCreator)
-        }
-    }
+    this.signUpButton.setOnClickListener { this.openCardCreator() }
 
     /*
      * Configure a checkbox listener that shows and hides the password field. Note that

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
   <string name="accountAdd">Add account…</string>
   <string name="accountCancel">Cancel</string>
   <string name="accountCardCreatorLabel">Don\'t have a library card?</string>
-  <string name="accountCardCreatorSignUp">Sign up</string>
+  <string name="accountCardCreatorSignUp">Create Card</string>
   <string name="accountCOPPADeleteBooks">Delete books?</string>
   <string name="accountCOPPADeleteBooksConfirm">Changing your age will remove all books downloaded from the current account.</string>
   <string name="accountCOPPAOver13">I am over 13</string>
@@ -13,6 +13,8 @@
   <string name="accountDelete">Delete</string>
   <string name="accountEULAStatement">I agree to the terms of the End User License Agreement.</string>
   <string name="accountLogin">Log in</string>
+<!--  <string name="accountWantChildCard">Want a card for your child?</string>-->
+<!--  <string name="accountCreateCard">Create Card</string>-->
   <string name="accountLoginAlternatives">Alternative Login Methods</string>
   <string name="accountLoginRequired">Please log in to continue.</string>
   <string name="accountLoginWith">Log in with %1$s</string>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -13,8 +13,8 @@
   <string name="accountDelete">Delete</string>
   <string name="accountEULAStatement">I agree to the terms of the End User License Agreement.</string>
   <string name="accountLogin">Log in</string>
-<!--  <string name="accountWantChildCard">Want a card for your child?</string>-->
-<!--  <string name="accountCreateCard">Create Card</string>-->
+  <string name="accountWantChildCard">Want a card for your child?</string>
+  <string name="accountCreateCard">Create Card</string>
   <string name="accountLoginAlternatives">Alternative Login Methods</string>
   <string name="accountLoginRequired">Please log in to continue.</string>
   <string name="accountLoginWith">Log in with %1$s</string>


### PR DESCRIPTION
**What's this do?**
This adds the ability to create cards for a patron's dependents by adding new ISSO Token API calls and new NYPL Platforms to hit juvenile card creator endpoints. New views have been added to the existing navigation graph and the Accounts screen has been updated to reflect new juvenile card creator options.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2312: SA: Card creator](https://jira.nypl.org/browse/SIMPLY-2312)
[SIMPLY-2711: Allow an already-logged-in patron to create new juv-only cards](https://jira.nypl.org/browse/SIMPLY-2734)
[SIMPLY-2725: Restrict patron to 3 child cards](https://jira.nypl.org/browse/SIMPLY-2725)
[SIMPLY-2734: In SA Card creator, please animate loading messages](https://jira.nypl.org/browse/SIMPLY-2734)

**How should this be tested? / Do these changes have associated tests?**
To test this functionality, enable the bypass New York for the debugging menu. The simply login to any any adult account and attempt to create a juvenile account. Ensure you have properly include the `cardcreator.conf` file in the assets directory or the card creator functionality will not be enabled.

**Dependencies for merging? Releasing to production?**
One thing to watch out for is that when calling the endpoint to check if a patron is allowed to create juvenile cards, the call sometimes fails with a `502` error. This is something we need to discuss with the server team and could potential derail QA.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 