### PR TITLE
[SIMPLY-2856] Show the appropriate catalog according to the profile age.

### DIFF
--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
@@ -11,6 +11,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.bottomnavigation.LabelVisibilityMode
 import com.io7m.junreachable.UnreachableCodeException
 import com.pandora.bottomnavigator.BottomNavigator
+import org.joda.time.DateTime
 import org.nypl.simplified.accounts.database.api.AccountType
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookFormat
@@ -117,6 +118,18 @@ class TabbedNavigationController private constructor(
       )
     }
 
+    private fun currentAge(
+      profilesController: ProfilesControllerType
+    ): Int {
+      return try {
+        val profile = profilesController.profileCurrent()
+        profile.preferences().dateOfBirth?.yearsOld(DateTime.now()) ?: 1
+      } catch (e: Exception) {
+        this.logger.error("could not retrieve profile age: ", e)
+        1
+      }
+    }
+
     private fun pickDefaultAccount(
       profilesController: ProfilesControllerType
     ): AccountType {
@@ -138,11 +151,12 @@ class TabbedNavigationController private constructor(
     private fun catalogFeedArguments(
       profilesController: ProfilesControllerType
     ): CatalogFeedArguments.CatalogFeedArgumentsRemote {
+      val age = this.currentAge(profilesController)
       val account = this.pickDefaultAccount(profilesController)
       return CatalogFeedArguments.CatalogFeedArgumentsRemote(
         title = account.provider.displayName,
         ownership = CatalogFeedOwnership.OwnedByAccount(account.id),
-        feedURI = account.provider.catalogURI,
+        feedURI = account.provider.catalogURIForAge(age),
         isSearchResults = false
       )
     }


### PR DESCRIPTION
**What's this do?**
Hey @io7m, this appears to resolve an issue where SimplyE would always display the Children's catalog. Some of this code was removed in https://github.com/NYPL-Simplified/Simplified-Android-Core/commit/62e1f4d9842bbae12bd5e261fe38ec53bb45855a. Can you take a look and let me know if a different fix would be more appropriate?

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2856

**How should this be tested? / Do these changes have associated tests?**
1) Clear the vanilla app storage.
2) Launch the vanilla app.
3) Select "Add a Library Later".
4) Note that the age gate is displayed.
5) Select "13 or older".
6) Verify that the full catalog is displayed.
7) Repeat from Step 1 but select "Under 13" at the age gate and verify that the children's catalog is displayed.

**Did someone actually run this code to verify it works?**
@twaddington 