### PR TITLE
[SIMPLY-2863] Fix an issue where the age checkbox in account settings was not functional.

### DIFF
--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLogoutTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLogoutTask.kt
@@ -6,7 +6,6 @@ import org.nypl.drm.core.AdobeAdeptExecutorType
 import org.nypl.simplified.accounts.api.AccountAuthenticatedHTTP
 import org.nypl.simplified.accounts.api.AccountAuthenticationAdobePreActivationCredentials
 import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
-import org.nypl.simplified.accounts.api.AccountLoginState
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggedIn
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggingIn
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggingInWaitingForExternalAuthentication

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLogoutTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLogoutTask.kt
@@ -7,7 +7,11 @@ import org.nypl.simplified.accounts.api.AccountAuthenticatedHTTP
 import org.nypl.simplified.accounts.api.AccountAuthenticationAdobePreActivationCredentials
 import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
 import org.nypl.simplified.accounts.api.AccountLoginState
+import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggedIn
+import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggingIn
+import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggingInWaitingForExternalAuthentication
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggingOut
+import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoginFailed
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLogoutErrorData
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLogoutErrorData.AccountLogoutDRMFailure
 import org.nypl.simplified.accounts.api.AccountLoginState.AccountLogoutErrorData.AccountLogoutUnexpectedException
@@ -68,12 +72,12 @@ class ProfileAccountLogoutTask(
 
     this.credentials =
       when (val state = this.account.loginState) {
-        is AccountLoginState.AccountLoggedIn -> state.credentials
+        is AccountLoggedIn -> state.credentials
         is AccountLogoutFailed -> state.credentials
-        AccountNotLoggedIn,
-        is AccountLoginState.AccountLoggingIn,
-        is AccountLoginState.AccountLoginFailed,
-        is AccountLoginState.AccountLoggingInWaitingForExternalAuthentication,
+        is AccountNotLoggedIn,
+        is AccountLoggingIn,
+        is AccountLoginFailed,
+        is AccountLoggingInWaitingForExternalAuthentication,
         is AccountLoggingOut -> {
           this.warn("attempted to log out with account in state {}", state.javaClass.canonicalName)
           this.steps.currentStepSucceeded(this.logoutStrings.logoutNotLoggedIn)

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -1139,27 +1139,20 @@ class AccountFragment : Fragment() {
 
   /**
    * A click listener for the age checkbox. If the user wants to change their age, then
-   * this must trigger an account logout. If the user cancels the dialog, the checkbox must
-   * be set to the opposite of what it was previously set to. This looks strange but it's actually
-   * because the checkbox will be checked/unchecked when the user initially clicks it, and then
-   * when the dialog is cancelled, the checkbox must be unchecked/checked again to return it to
-   * the original state it was in.
+   * this must trigger an account logout.
    */
 
   private fun onAgeCheckboxClicked(): (View) -> Unit = {
+    val isOver13 = this.isOver13()
     AlertDialog.Builder(this.requireContext())
       .setTitle(R.string.accountCOPPADeleteBooks)
       .setMessage(R.string.accountCOPPADeleteBooksConfirm)
       .setNegativeButton(R.string.accountCancel) { _, _ ->
-        this.authenticationCOPPAOver13.isChecked = !this.authenticationCOPPAOver13.isChecked
+        this.authenticationCOPPAOver13.isChecked = isOver13
       }
       .setPositiveButton(R.string.accountDelete) { _, _ ->
         this.loginFormLock()
-        if (this.authenticationCOPPAOver13.isChecked) {
-          this.setOver13()
-        } else {
-          this.setUnder13()
-        }
+        if (!isOver13) this.setOver13() else this.setUnder13()
         this.tryLogout()
       }
       .create()


### PR DESCRIPTION
**What's this do?**
[Description of what this PR does goes here]

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2863

**How should this be tested? / Do these changes have associated tests?**
1. Navigate to account settings for SimplyE.
2. Click the "I am over 13" toggle to change the age setting.
3. Try the various dialog buttons and ensure the toggle works as expected.

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@twaddington 