### PR TITLE
Tweak the layout of the splash selection fragment to improve legibility.

### DIFF
--- a/simplified-ui-splash/src/main/res/layout/splash_selection.xml
+++ b/simplified-ui-splash/src/main/res/layout/splash_selection.xml
@@ -1,30 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:gravity="center"
+  android:orientation="vertical">
 
   <ImageView
     android:id="@+id/selectionImage"
-    android:layout_width="350dp"
-    android:layout_height="100dp"
-    android:layout_marginBottom="32dp"
-    app:layout_constraintBottom_toTopOf="@id/selectionTitle"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent" />
-
-  <TextView
-    android:id="@+id/selectionTitle"
-    android:layout_width="wrap_content"
+    android:layout_width="272dp"
     android:layout_height="wrap_content"
-    android:text="@string/selectionTitle"
-    android:textSize="18sp"
-    android:textStyle="bold"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+    android:layout_marginBottom="32dp"
+    android:adjustViewBounds="true"
+    android:contentDescription="@null"
+    android:scaleType="centerInside" />
 
   <Button
     android:id="@+id/selectionButton"
@@ -33,22 +23,15 @@
     android:layout_marginTop="16dp"
     android:text="@string/selectionButton"
     android:textSize="18sp"
-    android:textStyle="bold"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/selectionTitle" />
+    android:textStyle="bold" />
 
   <TextView
-    android:id="@+id/selectionAlternateTitle"
+    android:id="@+id/selectionTitle"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginTop="16dp"
-    android:text="@string/selectionAlternateTitle"
-    android:textSize="18sp"
-    android:textStyle="bold"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/selectionButton" />
+    android:layout_marginTop="4dp"
+    android:text="@string/selectionTitle"
+    android:textAppearance="@android:style/TextAppearance.Small" />
 
   <Button
     android:id="@+id/selectionAlternateButton"
@@ -57,9 +40,13 @@
     android:layout_marginTop="16dp"
     android:text="@string/selectionAlternateButton"
     android:textSize="18sp"
-    android:textStyle="bold"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/selectionAlternateTitle" />
+    android:textStyle="bold" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+  <TextView
+    android:id="@+id/selectionAlternateTitle"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="4dp"
+    android:text="@string/selectionAlternateTitle"
+    android:textAppearance="@android:style/TextAppearance.Small" />
+</LinearLayout>

--- a/simplified-ui-splash/src/main/res/values/strings.xml
+++ b/simplified-ui-splash/src/main/res/values/strings.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
   <!-- EULA strings -->
   <string name="eula_disagree">Disagree</string>
   <string name="eula_agree">Agree</string>
 
   <!-- Migration strings -->
-  <string name="migrationFailure">There were one or more problems migrating your data…</string>
+  <string name="migrationFailure">There were one or more problems migrating your data&#8230;</string>
   <string name="migrationSuccess">Your data was migrated successfully!</string>
   <string name="migrationSendReport">Send Report</string>
   <string name="migrationOK">OK</string>
@@ -13,7 +14,6 @@
   <!-- Library selection screen strings -->
   <string name="selectionTitle">Read E-Books from Your Library</string>
   <string name="selectionButton">Find Your Library</string>
-  <string name="selectionAlternateTitle">The SimplyE Collection</string>
+  <string name="selectionAlternateTitle">Browse the SimplyE Collection</string>
   <string name="selectionAlternateButton">Add a Library Later</string>
-
 </resources>


### PR DESCRIPTION
**What's this do?**
Adjust the layout of the splash selection fragment to improve legibility.

**Why are we doing this? (w/ JIRA link if applicable)**
n/a

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington 

**Screens**
- [splash-after](https://user-images.githubusercontent.com/107117/86529168-52e4fd80-be63-11ea-9036-2c8c4894cfe0.png)
- [splash-before](https://user-images.githubusercontent.com/107117/86529169-54162a80-be63-11ea-82de-6daa5878ba1f.png)
