### PR TITLE
[SIMPLY-2858] Maintain the order of account providers as returned by the server.

### DIFF
--- a/simplified-accounts-registry/src/main/java/org/nypl/simplified/accounts/registry/AccountProviderRegistry.kt
+++ b/simplified-accounts-registry/src/main/java/org/nypl/simplified/accounts/registry/AccountProviderRegistry.kt
@@ -43,7 +43,7 @@ class AccountProviderRegistry private constructor(
   @Volatile
   private var statusRef: AccountProviderRegistryStatus = Idle
 
-  private val descriptions = ConcurrentHashMap<URI, AccountProviderDescription>()
+  private val descriptions = Collections.synchronizedMap(LinkedHashMap<URI, AccountProviderDescription>())
   private val descriptionsReadOnly = Collections.unmodifiableMap(this.descriptions)
   private val resolved = ConcurrentHashMap<URI, AccountProviderType>()
   private val resolvedReadOnly = Collections.unmodifiableMap(this.resolved)

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountRegistryFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountRegistryFragment.kt
@@ -111,11 +111,6 @@ class AccountRegistryFragment : Fragment() {
         .toMutableList()
 
     availableAccountProviders.removeAll(usedAccountProviders)
-    availableAccountProviders.sortWith(Comparator { provider0, provider1 ->
-      val name0 = provider0.title.removePrefix("The ")
-      val name1 = provider1.title.removePrefix("The ")
-      name0.toUpperCase().compareTo(name1.toUpperCase())
-    })
 
     this.logger.debug("returning {} available providers", availableAccountProviders.size)
     return availableAccountProviders


### PR DESCRIPTION
**What's this do?**
The server may return account providers sorted with most relevant
results at the top. For example, provideres that are geographically
close to the patron's current location (as determined by IP Address).

This patch does two things:

1) Remove the local sorting of the providers in the account registry
fragment.
2) Use a LinkedHashMap wrapped with a synchronizedMap instead of the
ConcurrentHashMap that was used before.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2858

**How should this be tested? / Do these changes have associated tests?**
Manually update the URI(s) in `AccountProviderSourceNYPLRegistry` *or* use Charles Proxy to intercept the request to `https://libraryregistry.librarysimplified.org/libraries` and add the query string `?_location=40.7,-74`.

Verify that the NYPL appears at the top of the list as expected.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington