### PR TITLE
Allow patrons to add a new account directly from the account picker dialog.

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountPickerDialogFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountPickerDialogFragment.kt
@@ -1,5 +1,8 @@
 package org.nypl.simplified.ui.accounts
 
+import android.graphics.Color
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.graphics.Typeface
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -13,6 +16,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.librarysimplified.services.api.Services
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.accounts.database.api.AccountType
+import org.nypl.simplified.navigation.api.NavigationControllers
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.ui.accounts.AccountPickerAdapter.OnAccountClickListener
 import org.nypl.simplified.ui.images.ImageAccountIcons
@@ -74,11 +78,12 @@ class AccountPickerDialogFragment : BottomSheetDialogFragment(), OnAccountClickL
     recyclerView.apply {
       setHasFixedSize(true)
       layoutManager = LinearLayoutManager(requireContext())
-      adapter = AccountPickerAdapter(accounts, currentId, imageLoader, this@AccountPickerDialogFragment)
+      adapter =
+        AccountPickerAdapter(accounts, currentId, imageLoader, this@AccountPickerDialogFragment)
     }
   }
 
-  override fun onClick(account: AccountType) {
+  override fun onAccountClick(account: AccountType) {
     this.logger.debug("selected account id={}, name={}", account.id, account.provider.displayName)
 
     // Note: In the future consider refactoring this dialog to return a result via
@@ -92,9 +97,18 @@ class AccountPickerDialogFragment : BottomSheetDialogFragment(), OnAccountClickL
     profilesController.profileUpdate { it.copy(preferences = newPreferences) }
     dismiss()
   }
+
+  override fun onAddAccountClick() {
+    val navigationController = NavigationControllers.find(
+      activity = this.requireActivity(),
+      interfaceType = AccountNavigationControllerType::class.java
+    )
+    navigationController.openSettingsAccountRegistry()
+    dismiss()
+  }
 }
 
-class AccountPickerViewHolder(
+class AccountViewHolder(
   view: View,
   private val imageLoader: ImageLoaderType,
   private val listener: OnAccountClickListener
@@ -106,7 +120,7 @@ class AccountPickerViewHolder(
 
   init {
     view.setOnClickListener {
-      account?.let { listener.onClick(it) }
+      account?.let { listener.onAccountClick(it) }
     }
   }
 
@@ -129,29 +143,65 @@ class AccountPickerViewHolder(
   }
 }
 
+class FooterViewHolder(
+  view: View,
+  private val listener: OnAccountClickListener
+) : RecyclerView.ViewHolder(view) {
+
+  init {
+    val titleView: TextView = view.findViewById(R.id.accountTitle)
+    titleView.setText(R.string.accountAdd)
+
+    val iconView: ImageView = view.findViewById(R.id.accountIcon)
+    iconView.colorFilter =
+      PorterDuffColorFilter(Color.GRAY, PorterDuff.Mode.SRC_IN)
+    iconView.setImageResource(R.drawable.ic_add)
+
+    view.setOnClickListener {
+      listener.onAddAccountClick()
+    }
+  }
+}
+
 class AccountPickerAdapter(
   private val accounts: List<AccountType>,
   private val currentId: AccountID,
   private val imageLoader: ImageLoaderType,
   private val listener: OnAccountClickListener
-) : RecyclerView.Adapter<AccountPickerViewHolder>() {
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-  // TODO: Show an '+ Add account' footer view.
-
-  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AccountPickerViewHolder {
-    val inflater = LayoutInflater.from(parent.context)
-    val view = inflater.inflate(R.layout.account_picker_item, parent, false)
-    return AccountPickerViewHolder(view, imageLoader, listener)
+  companion object {
+    private const val LIST_ITEM = 1
+    private const val LIST_FOOTER = 2
   }
 
-  override fun getItemCount() = accounts.size
+  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+    val inflater = LayoutInflater.from(parent.context)
+    val view = inflater.inflate(R.layout.account_picker_item, parent, false)
+    return when (viewType) {
+      LIST_FOOTER -> FooterViewHolder(view, listener)
+      else -> AccountViewHolder(view, imageLoader, listener)
+    }
+  }
 
-  override fun onBindViewHolder(holder: AccountPickerViewHolder, position: Int) {
-    val item = accounts[position]
-    holder.bind(item, item.id == currentId)
+  override fun getItemCount() = accounts.size + 1 // Include the 'add account' footer
+
+  override fun getItemViewType(position: Int) = when (position) {
+    accounts.size -> LIST_FOOTER
+    else -> LIST_ITEM
+  }
+
+  override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+    when (holder.itemViewType) {
+      LIST_ITEM -> {
+        val item = accounts[position]
+        (holder as AccountViewHolder).bind(item, item.id == currentId)
+      }
+    }
   }
 
   interface OnAccountClickListener {
-    fun onClick(account: AccountType)
+    fun onAccountClick(account: AccountType)
+    fun onAddAccountClick()
   }
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountPickerDialogFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountPickerDialogFragment.kt
@@ -114,6 +114,7 @@ class AccountViewHolder(
   private val listener: OnAccountClickListener
 ) : RecyclerView.ViewHolder(view) {
   private val titleView: TextView = view.findViewById(R.id.accountTitle)
+  private val activeView: View = view.findViewById(R.id.activeAccount)
   private val iconView: ImageView = view.findViewById(R.id.accountIcon)
 
   var account: AccountType? = null
@@ -128,10 +129,13 @@ class AccountViewHolder(
     this.account = account
 
     titleView.text = account.provider.displayName
-    titleView.typeface = if (isCurrent) {
-      Typeface.DEFAULT_BOLD
+
+    if (isCurrent) {
+      titleView.typeface = Typeface.DEFAULT_BOLD
+      activeView.visibility = View.VISIBLE
     } else {
-      Typeface.DEFAULT
+      titleView.typeface = Typeface.DEFAULT
+      activeView.visibility = View.GONE
     }
 
     ImageAccountIcons.loadAccountLogoIntoView(

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountPickerDialogFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountPickerDialogFragment.kt
@@ -38,13 +38,16 @@ class AccountPickerDialogFragment : BottomSheetDialogFragment(), OnAccountClickL
 
   companion object {
     private const val ARG_CURRENT_ID = "org.nypl.simplified.ui.accounts.CURRENT_ID"
+    private const val ARG_ADD_ACCOUNT = "org.nypl.simplified.ui.accounts.ADD_ACCOUNT"
 
     fun create(
-      currentId: AccountID
+      currentId: AccountID,
+      showAddAccount: Boolean
     ): AccountPickerDialogFragment {
       return AccountPickerDialogFragment().apply {
         arguments = Bundle().apply {
           putSerializable(ARG_CURRENT_ID, currentId)
+          putBoolean(ARG_ADD_ACCOUNT, showAddAccount)
         }
       }
     }
@@ -73,13 +76,19 @@ class AccountPickerDialogFragment : BottomSheetDialogFragment(), OnAccountClickL
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     val currentId = requireArguments().getSerializable(ARG_CURRENT_ID) as AccountID
+    val showAddAccount = requireArguments().getBoolean(ARG_ADD_ACCOUNT, false)
 
     recyclerView = view.findViewById(R.id.recyclerView)
     recyclerView.apply {
       setHasFixedSize(true)
       layoutManager = LinearLayoutManager(requireContext())
-      adapter =
-        AccountPickerAdapter(accounts, currentId, imageLoader, this@AccountPickerDialogFragment)
+      adapter = AccountPickerAdapter(
+        accounts,
+        currentId,
+        imageLoader,
+        showAddAccount,
+        this@AccountPickerDialogFragment
+      )
     }
   }
 
@@ -171,6 +180,7 @@ class AccountPickerAdapter(
   private val accounts: List<AccountType>,
   private val currentId: AccountID,
   private val imageLoader: ImageLoaderType,
+  private val showAddAccount: Boolean,
   private val listener: OnAccountClickListener
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -188,7 +198,11 @@ class AccountPickerAdapter(
     }
   }
 
-  override fun getItemCount() = accounts.size + 1 // Include the 'add account' footer
+  override fun getItemCount() = if (showAddAccount) {
+    accounts.size + 1 // Show the 'add account' footer
+  } else {
+    accounts.size
+  }
 
   override fun getItemViewType(position: Int) = when (position) {
     accounts.size -> LIST_FOOTER

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountRegistryFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountRegistryFragment.kt
@@ -248,7 +248,7 @@ class AccountRegistryFragment : Fragment() {
     if (host is ToolbarHostType) {
       host.toolbarClearMenu()
       host.toolbarSetTitleSubtitle(
-        title = this.requireContext().getString(R.string.accounts),
+        title = this.requireContext().getString(R.string.accountAdd),
         subtitle = ""
       )
       host.toolbarSetBackArrowConditionally(

--- a/simplified-ui-accounts/src/main/res/drawable/ic_add.xml
+++ b/simplified-ui-accounts/src/main/res/drawable/ic_add.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/simplified-ui-accounts/src/main/res/layout/account_picker.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_picker.xml
@@ -12,7 +12,7 @@
     android:gravity="center_vertical"
     android:paddingStart="16dp"
     android:paddingEnd="16dp"
-    android:text="@string/accountPick"
+    android:text="@string/accountPickerTitle"
     android:textAppearance="@style/TextAppearance.AppCompat.Caption"
     android:textSize="14sp" />
 

--- a/simplified-ui-accounts/src/main/res/layout/account_picker_item.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_picker_item.xml
@@ -6,6 +6,7 @@
   android:background="?attr/selectableItemBackground"
   android:clickable="true"
   android:focusable="true"
+  android:orientation="horizontal"
   android:paddingStart="16dp"
   android:paddingEnd="16dp"
   tools:ignore="UseCompoundDrawables">
@@ -19,13 +20,31 @@
     android:contentDescription="@null"
     android:src="@drawable/account_default" />
 
-  <TextView
-    android:id="@+id/accountTitle"
+  <LinearLayout
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_gravity="center_vertical"
-    android:ellipsize="end"
-    android:maxLines="2"
-    android:textAppearance="@style/TextAppearance.AppCompat.Small"
-    tools:text="New York Public Library" />
+    android:layout_height="match_parent"
+    android:gravity="center_vertical"
+    android:orientation="vertical">
+
+    <TextView
+      android:id="@+id/accountTitle"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:ellipsize="end"
+      android:maxLines="1"
+      android:singleLine="true"
+      android:textAppearance="@style/TextAppearance.AppCompat.Small"
+      tools:text="New York Public Library" />
+
+    <TextView
+      android:id="@+id/activeAccount"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/currentlyBrowsing"
+      android:textAppearance="@style/TextAppearance.AppCompat.Small"
+      android:textSize="12sp"
+      android:textStyle="italic"
+      android:visibility="gone"
+      tools:visibility="visible" />
+  </LinearLayout>
 </LinearLayout>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -38,4 +38,5 @@
   <string name="accountsDetails">Details</string>
   <string name="accountSyncBookmarks">Sync bookmarks</string>
   <string name="accountUserName">User Name</string>
+  <string name="currentlyBrowsing">You\'re currently browsing</string>
 </resources>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <resources>
-  <string name="accountAdd">Add account…</string>
+  <string name="accountAdd">Add account</string>
   <string name="accountCancel">Cancel</string>
   <string name="accountCardCreatorLabel">Don\'t have a library card?</string>
   <string name="accountCardCreatorSignUp">Create Card</string>
@@ -21,6 +21,7 @@
   <string name="accountLogout">Log out</string>
   <string name="accountPassword">Password</string>
   <string name="accountPasswordShow">Show password</string>
+  <string name="accountPickerTitle">Switch account</string>
   <string name="accountPlaceholder">Lorem ipsum dolor sit amet, probatus volutpat has at, vis adhuc iuvaret omittantur an, sadipscing conclusionemque his ad. Eam ut simul tempor. Primis consetetur appellantur vim eu, eum an iudico dolorum. Ad vis utamur honestatis, sanctus debitis referrentur an eam.</string>
   <string name="accountRegistryCreating">Creating an account…</string>
   <string name="accountRegistryEmpty">No accounts are available.</string>
@@ -28,7 +29,6 @@
   <string name="accountRegistryRetrieving">Retrieving accounts from registry…</string>
   <string name="accountRegistrySelect">Please select a library…</string>
   <string name="accountReportIssue">Report an issue…</string>
-  <string name="accountPick">Pick account</string>
   <string name="accounts">Accounts</string>
   <string name="accountsDelete">@string/accountDelete</string>
   <string name="accountsDeleteConfirm">Are you sure you want to remove your \"%1$s\" account from this device?</string>

--- a/simplified-ui-catalog/build.gradle
+++ b/simplified-ui-catalog/build.gradle
@@ -17,6 +17,7 @@ dependencies {
   implementation project(":simplified-ui-images")
   implementation project(":simplified-ui-navigation-api")
   implementation project(":simplified-ui-screen")
+  implementation project(":simplified-ui-settings")
   implementation project(":simplified-ui-theme")
   implementation project(":simplified-ui-thread-api")
   implementation project(":simplified-ui-toolbar")

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
@@ -74,6 +74,7 @@ import org.nypl.simplified.ui.catalog.CatalogFeedState.CatalogFeedLoading
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.nypl.simplified.ui.images.ImageLoaderType
 import org.nypl.simplified.ui.screen.ScreenSizeInformationType
+import org.nypl.simplified.ui.settings.SettingsConfigurationServiceType
 import org.nypl.simplified.ui.theme.ThemeControl
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
 import org.nypl.simplified.ui.toolbar.ToolbarHostType
@@ -143,6 +144,7 @@ class CatalogFragmentFeed : Fragment() {
   private lateinit var parameters: CatalogFeedArguments
   private lateinit var profilesController: ProfilesControllerType
   private lateinit var screenInformation: ScreenSizeInformationType
+  private lateinit var settingsController: SettingsConfigurationServiceType
   private lateinit var uiThread: UIThreadServiceType
   private val logger = LoggerFactory.getLogger(CatalogFragmentFeed::class.java)
   private val parametersId = PARAMETERS_ID
@@ -176,6 +178,8 @@ class CatalogFragmentFeed : Fragment() {
       services.requireService(UIThreadServiceType::class.java)
     this.imageLoader =
       services.requireService(ImageLoaderType::class.java)
+    this.settingsController =
+      services.requireService(SettingsConfigurationServiceType::class.java)
   }
 
   override fun onCreateView(
@@ -854,7 +858,7 @@ class CatalogFragmentFeed : Fragment() {
   ) {
     val fm = requireActivity().supportFragmentManager
     val dialog = AccountPickerDialogFragment.create(
-      currentId
+      currentId, settingsController.allowAccountsAccess
     )
     dialog.show(fm, dialog.tag)
   }

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
@@ -254,7 +254,7 @@ class TabbedNavigationController private constructor(
           shouldShowLibraryRegistryMenu = this.settingsConfiguration.allowAccountsRegistryAccess
         )
       ),
-      tab = this.navigator.currentTab()
+      tab = R.id.tabSettings
     )
   }
 
@@ -273,7 +273,7 @@ class TabbedNavigationController private constructor(
   override fun openSettingsVersion() {
     this.navigator.addFragment(
       fragment = SettingsFragmentVersion(),
-      tab = this.navigator.currentTab()
+      tab = R.id.tabSettings
     )
   }
 
@@ -302,7 +302,7 @@ class TabbedNavigationController private constructor(
   override fun openSettingsAccount(parameters: AccountFragmentParameters) {
     this.navigator.addFragment(
       fragment = AccountFragment.create(parameters),
-      tab = this.navigator.currentTab()
+      tab = R.id.tabSettings
     )
   }
 
@@ -332,7 +332,7 @@ class TabbedNavigationController private constructor(
   override fun openSettingsAccountRegistry() {
     this.navigator.addFragment(
       fragment = AccountRegistryFragment(),
-      tab = this.navigator.currentTab()
+      tab = R.id.tabSettings
     )
   }
 


### PR DESCRIPTION
**What's this do?**
Adds an 'Add new account' option to the account switcher and makes the currently active account more obvious.

**Why are we doing this? (w/ JIRA link if applicable)**
Improved Patron experience.

**How should this be tested? / Do these changes have associated tests?**
1. Tap the account icon in the upper left of the catalog.
2. Verify that the 'Add new account' option is shown at the bottom of the list.
3. Tap 'Add new account' and verify the account registry fragment is displayed, as expected.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington

**Screens**
- [Screenshot_1595529410](https://user-images.githubusercontent.com/107117/88324631-d4001980-ccd8-11ea-90e5-ca207952a5c7.png)