### PR TITLE
SIMPLY-2923: Filter the 'Books' and 'Holds' views by the default account until combined view is approved by UX.

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
@@ -944,9 +944,16 @@ class CatalogFragmentFeed : Fragment() {
      * bar.
      */
 
-    val remainingGroups = facetsByGroup.filter { entry ->
-      !FeedFacets.facetGroupIsEntryPointTyped(entry.value)
-    }
+    val remainingGroups = facetsByGroup
+      .filter { entry ->
+        /*
+         * SIMPLY-2923: Hide the 'Collection' Facet until approved by UX.
+         */
+        entry.key != "Collection"
+      }
+      .filter { entry ->
+        !FeedFacets.facetGroupIsEntryPointTyped(entry.value)
+      }
 
     if (remainingGroups.isEmpty()) {
       facetLayoutScroller.visibility = View.GONE

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -210,16 +210,6 @@ class CatalogPagedViewHolder(
         context.getString(R.string.catalogBookFormatPDF)
     }
 
-    when (this.ownership) {
-      is CollectedFromAccounts -> {
-        val accountProvider =
-          this.profilesController.profileCurrent()
-            .account(item.accountID)
-            .provider
-        this.idleMeta.text = "${this.idleMeta.text} from ${accountProvider.displayName}"
-      }
-    }
-
     val targetHeight =
       this.parent.resources.getDimensionPixelSize(R.dimen.cover_thumbnail_height)
     val targetWidth = 0

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -33,7 +33,6 @@ import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.nypl.simplified.taskrecorder.api.TaskStepResolution
 import org.nypl.simplified.ui.accounts.AccountFragmentParameters
-import org.nypl.simplified.ui.catalog.CatalogFeedOwnership.CollectedFromAccounts
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
 import org.slf4j.LoggerFactory

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
@@ -97,10 +97,20 @@ class TabbedNavigationController private constructor(
               )
             },
             R.id.tabBooks to {
-              this.createBooksFragment(activity, R.id.tabBooks)
+              this.createBooksFragment(
+                context = activity,
+                id = R.id.tabBooks,
+                profilesController = profilesController,
+                defaultProvider = accountProviders.defaultProvider
+              )
             },
             R.id.tabHolds to {
-              this.createHoldsFragment(activity, R.id.tabHolds)
+              this.createHoldsFragment(
+                context = activity,
+                id = R.id.tabHolds,
+                profilesController = profilesController,
+                defaultProvider = accountProviders.defaultProvider
+              )
             },
             R.id.tabSettings to {
               this.createSettingsFragment(R.id.tabSettings)
@@ -204,12 +214,20 @@ class TabbedNavigationController private constructor(
 
     private fun createHoldsFragment(
       context: Context,
-      id: Int
+      id: Int,
+      profilesController: ProfilesControllerType,
+      defaultProvider: AccountProviderType
     ): Fragment {
       this.logger.debug("[{}]: creating holds fragment", id)
+
+      /*
+       * SIMPLY-2923: Filter by the default account until 'All' view is approved by UX.
+       */
+
+      val account = pickDefaultAccount(profilesController, defaultProvider)
       return CatalogFragmentFeed.create(
         CatalogFeedArgumentsLocalBooks(
-          filterAccount = null,
+          filterAccount = account.id,
           ownership = CatalogFeedOwnership.CollectedFromAccounts,
           searchTerms = null,
           selection = FeedBooksSelection.BOOKS_FEED_HOLDS,
@@ -221,12 +239,20 @@ class TabbedNavigationController private constructor(
 
     private fun createBooksFragment(
       context: Context,
-      id: Int
+      id: Int,
+      profilesController: ProfilesControllerType,
+      defaultProvider: AccountProviderType
     ): Fragment {
       this.logger.debug("[{}]: creating books fragment", id)
+
+      /*
+       * SIMPLY-2923: Filter by the default account until 'All' view is approved by UX.
+       */
+
+      val account = pickDefaultAccount(profilesController, defaultProvider)
       return CatalogFragmentFeed.create(
         CatalogFeedArgumentsLocalBooks(
-          filterAccount = null,
+          filterAccount = account.id,
           ownership = CatalogFeedOwnership.CollectedFromAccounts,
           searchTerms = null,
           selection = FeedBooksSelection.BOOKS_FEED_LOANED,


### PR DESCRIPTION
**What's this do?**
Filter the 'Books' and 'Holds' views by the default account until combined view is approved by UX.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2923

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the vanilla app.