### PR TITLE
SIMPLY-2925: mailto: links in EULA don't work

### DIFF
--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/MailtoWebViewClient.java
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/MailtoWebViewClient.java
@@ -25,19 +25,15 @@ public class MailtoWebViewClient extends WebViewClient {
         if (url.startsWith(MailTo.MAILTO_SCHEME)) {
             final Activity activity = mActivityRef.get();
             if (activity != null) {
-                try {
-                    MailTo mt = MailTo.parse(url);
-                    Intent i = newEmailIntent(activity, mt.getTo(), mt.getSubject());
-                    if (i.resolveActivity(activity.getPackageManager()) != null) {
-                        activity.startActivity(i);
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
+                MailTo mt = MailTo.parse(url);
+                Intent i = newEmailIntent(activity, mt.getTo(), mt.getSubject());
+                if (i.resolveActivity(activity.getPackageManager()) != null) {
+                    activity.startActivity(i);
                 }
                 return true;
             }
         } else {
-            view.loadUrl(url);
+            return false;
         }
         return true;
     }

--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/MailtoWebViewClient.java
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/MailtoWebViewClient.java
@@ -1,0 +1,48 @@
+package org.nypl.simplified.ui.splash;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.net.MailTo;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Used to handle mailto: links in the eula.html
+ */
+public class MailtoWebViewClient extends WebViewClient {
+    private final WeakReference<Activity> mActivityRef;
+
+    public MailtoWebViewClient(Activity activity) {
+        mActivityRef = new WeakReference<>(activity);
+    }
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        if (url.startsWith("mailto:")) {
+            final Activity activity = mActivityRef.get();
+            if (activity != null) {
+                MailTo mt = MailTo.parse(url);
+                Intent i = newEmailIntent(activity, mt.getTo(), mt.getSubject(), mt.getBody(), mt.getCc());
+                activity.startActivity(i);
+                view.reload();
+                return true;
+            }
+        } else {
+            view.loadUrl(url);
+        }
+        return true;
+    }
+
+    private Intent newEmailIntent(Context context, String address, String subject, String body, String cc) {
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.putExtra(Intent.EXTRA_EMAIL, new String[] { address });
+        intent.putExtra(Intent.EXTRA_TEXT, body);
+        intent.putExtra(Intent.EXTRA_SUBJECT, subject);
+        intent.putExtra(Intent.EXTRA_CC, cc);
+        intent.setType("message/rfc822");
+        return intent;
+    }
+}

--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/MailtoWebViewClient.java
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/MailtoWebViewClient.java
@@ -29,13 +29,11 @@ public class MailtoWebViewClient extends WebViewClient {
                 Intent i = newEmailIntent(activity, mt.getTo(), mt.getSubject());
                 if (i.resolveActivity(activity.getPackageManager()) != null) {
                     activity.startActivity(i);
+                    return true;
                 }
-                return true;
             }
-        } else {
-            return false;
         }
-        return true;
+        return false;
     }
 
     private Intent newEmailIntent(Context context, String address, String subject) {

--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
@@ -12,7 +12,6 @@ import android.view.animation.AnimationUtils
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
-import android.webkit.WebViewClient
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.ProgressBar

--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
@@ -241,7 +241,7 @@ class SplashFragment : Fragment() {
     this.viewsForEULA.eulaWebView.settings.allowUniversalAccessFromFileURLs = false
     this.viewsForEULA.eulaWebView.settings.javaScriptEnabled = false
 
-    this.viewsForEULA.eulaWebView.webViewClient = object : WebViewClient() {
+    this.viewsForEULA.eulaWebView.webViewClient = object : MailtoWebViewClient(requireActivity()) {
       override fun onReceivedError(
         view: WebView?,
         errorCode: Int,


### PR DESCRIPTION
**What's this do?**
This adds a new custom WebViewClient that can handle `mailto:` inside of a webview

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2925

**How should this be tested? / Do these changes have associated tests?**
Launch the app fresh, and click on the email link in the EULA.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 