### PR TITLE
[SIMPLY-2924] Fix issue causing reservations to appear as if they have failed.

### DIFF
--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
@@ -107,6 +107,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
+import java.lang.IllegalStateException
 import java.net.URI
 import java.util.concurrent.Callable
 import java.util.concurrent.CancellationException
@@ -658,9 +659,7 @@ class BookBorrowTask(
          */
 
         override fun onHoldable(a: OPDSAvailabilityHoldable): Boolean {
-          this@BookBorrowTask.debug("book is holdable, cannot continue!")
-          this@BookBorrowTask.publishBookStatus(BookStatus.Holdable(this@BookBorrowTask.bookId))
-          return false
+          throw IllegalStateException("book is holdable, cannot continue!")
         }
 
         /**
@@ -672,8 +671,7 @@ class BookBorrowTask(
          */
 
         override fun onLoanable(a: OPDSAvailabilityLoanable): Boolean {
-          this@BookBorrowTask.debug("book is loanable, this is a server bug!")
-          return false
+          throw IllegalStateException("book is loanable, this is a server bug!")
         }
 
         /**

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
@@ -686,7 +686,7 @@ class BookBorrowTask(
           this@BookBorrowTask.publishBookStatus(
             BookStatus.RequestingDownload(this@BookBorrowTask.bookId)
           )
-          return java.lang.Boolean.TRUE
+          return true
         }
 
         /**
@@ -699,7 +699,7 @@ class BookBorrowTask(
           this@BookBorrowTask.publishBookStatus(
             BookStatus.RequestingDownload(this@BookBorrowTask.bookId)
           )
-          return java.lang.Boolean.TRUE
+          return true
         }
 
         /**
@@ -712,18 +712,10 @@ class BookBorrowTask(
         }
       })
 
-    return if (wantFulfill) {
+    if (wantFulfill) {
       this.runAcquisitionFulfill(feedEntry.feedEntry)
     } else {
-      val exception = IllegalStateException()
-      val message =
-        this.services.borrowStrings.borrowBookBorrowAvailabilityInappropriate(availability)
-      this.steps.currentStepFailed(
-        message = message,
-        errorValue = WrongAvailability(message, this.currentAttributesWith()),
-        exception = exception
-      )
-      throw exception
+      this.steps.currentStepSucceeded("Borrow succeeded with availability $availability.")
     }
   }
 

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
@@ -58,7 +58,6 @@ import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails.Un
 import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails.UnsupportedAcquisition
 import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails.UnsupportedType
 import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails.UnusableAcquisitions
-import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails.WrongAvailability
 import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.bundled.api.BundledURIs
 import org.nypl.simplified.books.controller.BookBorrowTask.DownloadResult.DownloadCancelled


### PR DESCRIPTION
**What's this do?**
Fix issue causing reservations to appear as if they have failed.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2924

**How should this be tested? / Do these changes have associated tests?**
1. Navigate to an NYPL book feed (e.g. Summer Reading).
2. Tap the "Availability" filter/facet and switch to "All"
3. Find a book to reserve (I've been using "Ash" since it appears at the top).
4. Verify that reserving the book succeeds and shows the right message about your queue state.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the vanilla app.