### PR TITLE
Honor mime type declared in manifest when serving epub resources.

### DIFF
--- a/simplified-viewer-epub-readium1/build.gradle
+++ b/simplified-viewer-epub-readium1/build.gradle
@@ -23,4 +23,7 @@ dependencies {
   implementation libraries.nyplDRMCore
   implementation libraries.readium
   implementation libraries.readiumSharedJS
+
+  testImplementation libraries.junit
+  testImplementation libraries.mockito
 }

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderHTTPServerAAsync.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderHTTPServerAAsync.java
@@ -18,6 +18,7 @@ import com.koushikdutta.async.http.server.HttpServerRequestCallback;
 
 import org.nypl.simplified.http.core.HTTPRangeType;
 import org.nypl.simplified.http.core.HTTPRanges;
+import org.readium.sdk.android.ManifestItem;
 import org.readium.sdk.android.Package;
 import org.readium.sdk.android.util.ResourceInputStream;
 import org.slf4j.Logger;
@@ -161,7 +162,7 @@ public final class ReaderHTTPServerAAsync
        */
 
       final String path = request.getPath();
-      final String type = this.mime.guessMimeTypeForURI(path);
+      String type = this.mime.guessMimeTypeForURI(path);
 
       /**
        * First, try looking at the available Android assets.
@@ -229,6 +230,19 @@ public final class ReaderHTTPServerAAsync
         }
 
         if (size >= 0) {
+          /**
+           * Try to get the mime type from the package manifest.
+           */
+
+          ManifestItem manifestItem = pack.getManifestItem(relative);
+
+          if (manifestItem != null) {
+            String manifestItemType = manifestItem.getMediaType();
+
+            if (manifestItemType != null) {
+              type = manifestItemType;
+            }
+          }
 
           /**
            * Return a byte range stream that allows for very fine-grained

--- a/simplified-viewer-epub-readium1/src/test/java/org/nypl/simplified/viewer/epub/readium1/ReaderHTTPServerAAsyncTest.java
+++ b/simplified-viewer-epub-readium1/src/test/java/org/nypl/simplified/viewer/epub/readium1/ReaderHTTPServerAAsyncTest.java
@@ -1,0 +1,126 @@
+package org.nypl.simplified.viewer.epub.readium1;
+
+import android.content.res.AssetManager;
+
+import com.koushikdutta.async.http.Headers;
+import com.koushikdutta.async.http.server.AsyncHttpServerRequest;
+import com.koushikdutta.async.http.server.AsyncHttpServerResponse;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.readium.sdk.android.ManifestItem;
+import org.readium.sdk.android.Package;
+import org.readium.sdk.android.util.ResourceInputStream;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ReaderHTTPServerAAsyncTest {
+  private static final String GUESSED_MIME_TYPE = "itsjust/aguess";
+  private static final String NULL_MANIFEST_ITEM_RELATIVE_PATH = "foo.bar";
+  private static final String NULL_TYPE_MANIFEST_ITEM_RELATIVE_PATH = "notype.nope";
+  private static final String XHTML_MANIFEST_ITEM_RELATIVE_PATH = "chapter1.xml";
+  private static final String XHTML_MANIFEST_ITEM_MIME_TYPE = "application/xhtml+xml";
+
+  private static ReaderHTTPServerAAsync httpServer;
+
+  private static AssetManager createAssetManager() throws IOException {
+    AssetManager mockAssetManager = mock(AssetManager.class);
+
+    when(mockAssetManager.open(anyString(), anyInt())).thenThrow(new FileNotFoundException());
+
+    return mockAssetManager;
+  }
+
+  private static ReaderHTTPMimeMapType createMimeMap() {
+    ReaderHTTPMimeMapType mockMimeMap = mock(ReaderHTTPMimeMapType.class);
+
+    when(mockMimeMap.guessMimeTypeForURI(anyString())).thenReturn(GUESSED_MIME_TYPE);
+
+    return mockMimeMap;
+  }
+
+  private static Package createPackage() {
+    Package mockPackage = mock(Package.class);
+
+    when(mockPackage.getManifestItem(XHTML_MANIFEST_ITEM_RELATIVE_PATH)).thenReturn(
+        new ManifestItem(XHTML_MANIFEST_ITEM_RELATIVE_PATH, XHTML_MANIFEST_ITEM_MIME_TYPE));
+
+    when(mockPackage.getManifestItem(NULL_MANIFEST_ITEM_RELATIVE_PATH)).thenReturn(null);
+
+    when(mockPackage.getManifestItem(NULL_TYPE_MANIFEST_ITEM_RELATIVE_PATH)).thenReturn(
+        new ManifestItem(XHTML_MANIFEST_ITEM_RELATIVE_PATH, null));
+
+    when(mockPackage.getInputStream(anyString(), anyBoolean())).thenReturn(
+        mock(ResourceInputStream.class));
+
+    return mockPackage;
+  }
+
+  private static ReaderHTTPServerStartListenerType createStartListener() {
+    ReaderHTTPServerStartListenerType mockStartListener = mock(
+        ReaderHTTPServerStartListenerType.class);
+
+    return mockStartListener;
+  }
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    httpServer = (ReaderHTTPServerAAsync) ReaderHTTPServerAAsync.newServer(
+        createAssetManager(), createMimeMap(), 8888);
+
+    httpServer.startIfNecessaryForPackage(createPackage(), createStartListener());
+  }
+
+  private AsyncHttpServerRequest createRequestForRelativePath(String relativePath) {
+    AsyncHttpServerRequest mockRequest = mock(AsyncHttpServerRequest.class);
+
+    when(mockRequest.getHeaders()).thenReturn(new Headers());
+    when(mockRequest.getPath()).thenReturn("/" + relativePath);
+
+    return mockRequest;
+  }
+
+  @Test
+  public void mimeTypeIsReadFromManifestItem() {
+    AsyncHttpServerRequest mockRequest = createRequestForRelativePath(
+        XHTML_MANIFEST_ITEM_RELATIVE_PATH);
+
+    AsyncHttpServerResponse mockResponse = mock(AsyncHttpServerResponse.class);
+
+    httpServer.onRequest(mockRequest, mockResponse);
+
+    verify(mockResponse).setContentType(XHTML_MANIFEST_ITEM_MIME_TYPE);
+  }
+
+  @Test
+  public void mimeTypeIsGuessedWhenManifestItemIsNull() {
+    AsyncHttpServerRequest mockRequest = createRequestForRelativePath(
+        NULL_MANIFEST_ITEM_RELATIVE_PATH);
+
+    AsyncHttpServerResponse mockResponse = mock(AsyncHttpServerResponse.class);
+
+    httpServer.onRequest(mockRequest, mockResponse);
+
+    verify(mockResponse).setContentType(GUESSED_MIME_TYPE);
+  }
+
+  @Test
+  public void mimeTypeIsGuessedWhenManifestItemTypeIsNull() {
+    AsyncHttpServerRequest mockRequest = createRequestForRelativePath(
+        NULL_TYPE_MANIFEST_ITEM_RELATIVE_PATH);
+
+    AsyncHttpServerResponse mockResponse = mock(AsyncHttpServerResponse.class);
+
+    httpServer.onRequest(mockRequest, mockResponse);
+
+    verify(mockResponse).setContentType(GUESSED_MIME_TYPE);
+  }
+}


### PR DESCRIPTION
**What's this do?**

When serving resources from an EPUB package, use the mime type declared in the package manifest, instead of guessing the mime type from the file extension. 

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes two bugs that occur when reading certain EPUB books, such as (in the SimplyE Collection):

- Children of the Frost by Jack London
- Salute to Adventurers by John Buchan
- A House-Boat on the Styx by John Kendrick Bangs

What these books have in common is that they contain XHTML content whose filenames have the extension `.xml`.

The bugs are:

1. When the white-on-black color scheme is selected, the text stays black, making it unreadable.
   To reproduce:
   1. Download and read one of the above books.
   1. Navigate to a page with text.
   1. Select the white-on-black color scheme from the reader settings dialog.
   
   Expect: The background becomes black, and the text becomes white.
   
   Observe: The background becomes black, and the text remains black.
   
   There is a JIRA for this, marked done: https://jira.nypl.org/browse/SIMPLY-1933. When running the build in which that issue was fixed, I'm able to reproduce this issue, so it may be something different.

   Why this happens:

   1. Readium requests content from an embedded web server, an instance of ReaderHTTPServerAAsync. In the affected books, the path to the content ends with `.xml`.
   1. The server sets the content-type header of the response by guessing the correct mime type from the file extension in the request: https://github.com/NYPL-Simplified/Simplified-Android-Core/blob/bae8f89af2047a86de5993102c54915d143c57d2/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderHTTPServerAAsync.java#L164
   1. This uses ReaderHTTPMimeMap, which maps the `xml` extension to the mime type `application/xml`: https://github.com/NYPL-Simplified/Simplified-Android-Core/blob/bae8f89af2047a86de5993102c54915d143c57d2/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderHTTPMimeMap.java#L50
   1. The WebView in which Readium runs looks at the content-type header, and determines that this is an XML document -- not an XHTML document. It is not apparent that anything is wrong, because the WebView attempts to render the document anyway, and it does a really good job, since it actually is all HTML. But calling `document.contentType` returns `application/xml`.
   1. When a color scheme is selected, Readium's `setBookStyles` function is called: https://github.com/NYPL-Simplified/Simplified-Android-Core/blob/bae8f89af2047a86de5993102c54915d143c57d2/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumJavaScriptAPI.java#L197
   1. Readium creates a `style` element containing the appropriate CSS using `document.createElement`, and injects it into the content document: https://github.com/readium/readium-shared-js/blob/8faaca00f1a6d991bab77140426c81b43769749a/js/helpers.js#L825-L829
   1. Because the WebView thinks this is an XML document, the newly created `style` is subtly different than it would be in an XHTML document. In an XML document, the resulting element has a `null` namespace. In an XHTML document, it is automatically created in the XHTML namespace (`http://www.w3.org/1999/xhtml`). So in the XML document, the `style` is not an HTML style; it's just a `style` in some other namespace. Therefore it is ignored when rendering the page. (In an XML document, using `document.createElementNS` and explicitly setting the XHTML namespace would work, but Readium is understandably just using `document.createElement`.)

   Why the fix works:

   In all of the above books, the EPUB manifest correctly declares the media type of the content as `application/xhtml+xml`, even though the filename has the `.xml` extension. The web server now honors this instead of guessing. This allows the WebView to know that the content is XHTML, not generic XML, and `document.createElement` works as expected.
  
1. Selecting a bookmark opens the first page of the chapter, instead of the page in the chapter that was bookmarked.
   To reproduce:
   1. Download and read one of the above books.
   1. Navigate to a page in the middle of a chapter (not the first page).
   1. Create a bookmark.
   1. Navigate to Table of Contents/Bookmarks, and select the bookmark.

   Expect: The bookmarked page opens.

   Observe: The first page of the chapter opens.

   Why the fix works:

   I wasn't actually trying to fix this, but in my research, found this comment that implicates incorrect mime type as the cause of a bookmarking problem: https://jira.nypl.org/browse/SIMPLY-324?focusedCommentId=24763&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24763. Separately, Lyrasis folks had noticed this bookmarking issue, so I checked to see if this change fixed it, and indeed it had. I would guess that some DOM operation is not working as expected because of the XML content type, as with the above issue.

**How should this be tested? / Do these changes have associated tests?**

Download and read the above books, and verify that the repro steps above no longer cause the issues. Some unit tests are included for corner cases (stuff being missing in the manifest, which I think would make it an invalid EPUB, but just to be safe).

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

Yes, I ran the vanilla app.
