### PR TITLE
[SIMPLY-2934] Cache thumbnail images to disk for fulfilled feed items. 

### DIFF
--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookCoverFetchTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookCoverFetchTask.kt
@@ -8,6 +8,8 @@ import org.nypl.simplified.books.book_database.api.BookDatabaseEntryType
 import org.nypl.simplified.books.book_registry.BookStatusDownloadErrorDetails
 import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.bundled.api.BundledURIs.BUNDLED_CONTENT_SCHEME
+import org.nypl.simplified.books.controller.BookCoverFetchTask.Type.COVER
+import org.nypl.simplified.books.controller.BookCoverFetchTask.Type.THUMBNAIL
 import org.nypl.simplified.http.core.HTTPAuthType
 import org.nypl.simplified.http.core.HTTPResultError
 import org.nypl.simplified.http.core.HTTPResultException
@@ -20,6 +22,7 @@ import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.net.URI
+import java.util.Locale
 import java.util.concurrent.Callable
 
 /**
@@ -30,8 +33,17 @@ class BookCoverFetchTask(
   private val services: BookTaskRequiredServices,
   private val databaseEntry: BookDatabaseEntryType,
   private val feedEntry: OPDSAcquisitionFeedEntry,
+  private val type: Type,
   private val httpAuth: OptionType<HTTPAuthType>
 ) : Callable<TaskResult<BookStatusDownloadErrorDetails, Unit>> {
+
+  enum class Type {
+    COVER, THUMBNAIL;
+
+    override fun toString(): String {
+      return super.toString().toLowerCase(Locale.US)
+    }
+  }
 
   private val logger =
     LoggerFactory.getLogger(BookCoverFetchTask::class.java)
@@ -42,8 +54,11 @@ class BookCoverFetchTask(
     this.taskRecorder.beginNewStep(this.services.borrowStrings.borrowBookFetchingCover)
 
     return try {
-      val coverOpt = this.feedEntry.cover
-      this.logger.debug("fetching cover: {}", coverOpt)
+      val coverOpt = when (this.type) {
+        COVER -> feedEntry.cover
+        THUMBNAIL -> feedEntry.thumbnail
+      }
+      this.logger.debug("fetching ${this.type}: {}", coverOpt)
 
       if (coverOpt is Some<URI>) {
         val cover = coverOpt.get()
@@ -61,7 +76,7 @@ class BookCoverFetchTask(
         this.taskRecorder.finishSuccess(Unit)
       }
     } catch (e: Throwable) {
-      this.logger.error("failed to fetch cover: ", e)
+      this.logger.error("failed to fetch ${this.type}: ", e)
 
       this.taskRecorder.currentStepFailedAppending(
         this.services.borrowStrings.borrowBookCoverUnexpectedException,
@@ -144,7 +159,11 @@ class BookCoverFetchTask(
     val file = this.databaseEntry.temporaryFile()
     FileOutputStream(file).use { stream ->
       inputStream.copyTo(stream)
-      this.databaseEntry.setCover(file)
+
+      when (this.type) {
+        COVER -> this.databaseEntry.setCover(file)
+        THUMBNAIL -> this.databaseEntry.setThumbnail(file)
+      }
     }
     return this.taskRecorder.finishSuccess(Unit)
   }

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookCoverFetchTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookCoverFetchTask.kt
@@ -58,7 +58,7 @@ class BookCoverFetchTask(
         COVER -> feedEntry.cover
         THUMBNAIL -> feedEntry.thumbnail
       }
-      this.logger.debug("fetching ${this.type}: {}", coverOpt)
+      this.logger.debug("fetching {}: {}", this.type, coverOpt)
 
       if (coverOpt is Some<URI>) {
         val cover = coverOpt.get()
@@ -76,7 +76,7 @@ class BookCoverFetchTask(
         this.taskRecorder.finishSuccess(Unit)
       }
     } catch (e: Throwable) {
-      this.logger.error("failed to fetch ${this.type}: ", e)
+      this.logger.error("failed to fetch {}: ", this.type, e)
 
       this.taskRecorder.currentStepFailedAppending(
         this.services.borrowStrings.borrowBookCoverUnexpectedException,

--- a/simplified-books-database-api/src/main/java/org/nypl/simplified/books/book_database/api/BookDatabaseEntryType.kt
+++ b/simplified-books-database-api/src/main/java/org/nypl/simplified/books/book_database/api/BookDatabaseEntryType.kt
@@ -43,6 +43,16 @@ interface BookDatabaseEntryType {
   fun setCover(file: File)
 
   /**
+   * Copy the thumbnail file into the database.
+   *
+   * @param file The cover file
+   * @throws BookDatabaseException On errors
+   */
+
+  @Throws(BookDatabaseException::class)
+  fun setThumbnail(file: File)
+
+  /**
    * Copy the OPDS entry into the database.
    *
    * @param opdsEntry The OPDS entry

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/BookDatabase.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/BookDatabase.kt
@@ -160,7 +160,7 @@ class BookDatabase private constructor(
   companion object {
 
     private val LOG = LoggerFactory.getLogger(BookDatabase::class.java)
-    
+
     @Throws(BookDatabaseException::class)
     fun open(
       context: Context,

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/BookDatabase.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/BookDatabase.kt
@@ -47,6 +47,13 @@ class BookDatabase private constructor(
     internal val entries: ConcurrentSkipListMap<BookID, BookDatabaseEntry> =
       ConcurrentSkipListMap()
 
+    internal fun contains(key: BookID): Boolean {
+      synchronized(mapsLock) {
+        LOG.debug("BookMaps.contains")
+        return this.entries.containsKey(key)
+      }
+    }
+
     internal fun clear() {
       synchronized(this.mapsLock) {
         LOG.debug("BookMaps.clear")
@@ -97,12 +104,20 @@ class BookDatabase private constructor(
   ): BookDatabaseEntryType {
 
     synchronized(this.maps.mapsLock) {
+      if (this.maps.contains(id)) {
+        LOG.debug("Updating entry for {}", id)
+      } else {
+        LOG.debug("Adding entry for {}", id)
+      }
       try {
         val bookDir = File(this.directory, id.value())
         DirectoryUtilities.directoryCreate(bookDir)
 
         val fileMeta = File(bookDir, "meta.json")
         val fileMetaTmp = File(bookDir, "meta.json.tmp")
+
+        val cover = fileOrNull(directory, BookDatabaseEntry.COVER_FILENAME)
+        val thumb = fileOrNull(directory, BookDatabaseEntry.THUMB_FILENAME)
 
         FileUtilities.fileWriteUTF8Atomically(
           fileMeta,
@@ -113,8 +128,8 @@ class BookDatabase private constructor(
           Book(
             id = id,
             account = this.owner,
-            cover = null,
-            thumbnail = null,
+            cover = cover,
+            thumbnail = thumb,
             entry = entry,
             formats = listOf())
 
@@ -145,7 +160,7 @@ class BookDatabase private constructor(
   companion object {
 
     private val LOG = LoggerFactory.getLogger(BookDatabase::class.java)
-
+    
     @Throws(BookDatabaseException::class)
     fun open(
       context: Context,
@@ -233,18 +248,8 @@ class BookDatabase private constructor(
             parser.parseAcquisitionFeedEntryFromStream(stream)
           }
 
-        val fileCover = File(directory, "cover.jpg")
-        val cover = if (fileCover.isFile) {
-          fileCover
-        } else {
-          null
-        }
-        val fileThumb = File(directory, "thumb.jpg")
-        val thumb = if (fileThumb.isFile) {
-          fileThumb
-        } else {
-          null
-        }
+        val cover = fileOrNull(directory, BookDatabaseEntry.COVER_FILENAME)
+        val thumb = fileOrNull(directory, BookDatabaseEntry.THUMB_FILENAME)
 
         val book =
           Book(
@@ -268,3 +273,10 @@ class BookDatabase private constructor(
     }
   }
 }
+
+/** Return the file, or null if it does not exist or is not a file. */
+
+private fun fileOrNull(bookDir: File, filename: String) = File(bookDir, filename)
+  .run {
+    if (isFile) this else null
+  }

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/BookDatabaseEntry.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/BookDatabaseEntry.kt
@@ -191,13 +191,28 @@ internal class BookDatabaseEntry internal constructor(
     synchronized(this.bookLock) {
       Preconditions.checkArgument(!this.deleted, "Entry must not have been deleted")
 
-      val fileCover = File(this.bookDir, "cover.jpg")
-      val fileCoverTmp = File(this.bookDir, "cover.jpg.tmp")
+      val fileCover = File(this.bookDir, COVER_FILENAME)
+      val fileCoverTmp = File(this.bookDir, "$COVER_FILENAME.tmp")
 
       FileUtilities.fileCopy(file, fileCoverTmp)
       FileUtilities.fileRename(fileCoverTmp, fileCover)
 
       this.bookRef = this.bookRef.copy(cover = fileCover)
+    }
+  }
+
+  @Throws(IOException::class)
+  override fun setThumbnail(file: File) {
+    synchronized(this.bookLock) {
+      Preconditions.checkArgument(!this.deleted, "Entry must not have been deleted")
+
+      val fileThumb = File(this.bookDir, THUMB_FILENAME)
+      val fileThumbTmp = File(this.bookDir, "$THUMB_FILENAME.tmp")
+
+      FileUtilities.fileCopy(file, fileThumbTmp)
+      FileUtilities.fileRename(fileThumbTmp, fileThumb)
+
+      this.bookRef = this.bookRef.copy(thumbnail = fileThumb)
     }
   }
 
@@ -218,6 +233,8 @@ internal class BookDatabaseEntry internal constructor(
   }
 
   companion object {
+    const val COVER_FILENAME = "cover.jpg"
+    const val THUMB_FILENAME = "thumb.jpg"
 
     /**
      * Create a format handle if required. This checks to see if there is a content type that is


### PR DESCRIPTION
**What's this do?**
There is some existing code that downloads book cover images to disk for items you have checked out. While not causing any known issues, this code was fragile in places so I've cleaned some of that up. Additionally, covers were being cached but not thumbnails.

**Why are we doing this? (w/ JIRA link if applicable)**
Follow-up to https://github.com/NYPL-Simplified/Simplified-Android-Core/pull/762#discussion_r464542858.

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington tested with the vanilla app.