### PR TITLE
[SIMPLY-2943] Be more lenient about content types when creating format handles for book db entries.

### DIFF
--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
@@ -1184,9 +1184,20 @@ class BookBorrowTask(
     )
 
     /*
-     * SIMPLY-2928: Overdrive may return a type of 'application/json' instead of
-     *   the expected 'application/vnd.overdrive.circulation.api+json' type. Handle this
-     *   as an override.
+     * Attempt to find our received type in our set of expected types.
+     */
+
+    for (expectedContentType in expectedContentTypes) {
+      if (expectedContentType.fullType == receivedContentType.fullType) {
+        return receivedContentType
+      }
+    }
+
+    /*
+     * Handle the 'application/json' type as an exception.
+     *
+     * SIMPLY-2928: Overdrive may return 'application/json' instead of
+     * the expected 'application/vnd.overdrive.circulation.api+json' type.
      */
 
     val isAudiobook = expectedContentTypes
@@ -1209,7 +1220,7 @@ class BookBorrowTask(
     }
 
     /*
-     * Handle the type 'application/octet-stream' as an override.
+     * Handle the 'application/octet-stream' type as an exception.
      */
 
     if (receivedContentType == this.contentTypeOctetStream) {
@@ -1223,11 +1234,9 @@ class BookBorrowTask(
       return expectedContentTypes.first()
     }
 
-    for (expectedContentType in expectedContentTypes) {
-      if (expectedContentType.fullType == receivedContentType.fullType) {
-        return receivedContentType
-      }
-    }
+    /*
+     * No match found!
+     */
 
     this.debug(
       "expected {} but received {} (unacceptable)",

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
@@ -1189,11 +1189,11 @@ class BookBorrowTask(
      *   as an override.
      */
 
-    val isOverdrive = expectedContentTypes
-      .intersect(BookFormats.audioBookOverdriveMimeTypes())
+    val isAudiobook = expectedContentTypes
+      .intersect(BookFormats.audioBookMimeTypes())
       .isNotEmpty()
 
-    if (isOverdrive) {
+    if (isAudiobook) {
       when (receivedContentType.fullType) {
         this.contentTypeJson.fullType -> {
           this.debug(

--- a/simplified-books-database-api/src/main/java/org/nypl/simplified/books/book_database/api/BookFormats.kt
+++ b/simplified-books-database-api/src/main/java/org/nypl/simplified/books/book_database/api/BookFormats.kt
@@ -123,9 +123,8 @@ object BookFormats {
   fun inferFormat(entry: OPDSAcquisitionFeedEntry): BookFormatDefinition? {
     for (acquisition in entry.acquisitions) {
       for (format in formats) {
-        val formatContentTypes = format.supportedContentTypes()
-        val bookAvailable = acquisition.availableFinalContentTypes()
-        if (formatContentTypes.intersect(bookAvailable).isNotEmpty()) {
+        val available = acquisition.availableFinalContentTypes()
+        if (available.any { format.supports(it) }) {
           return format
         }
       }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -355,13 +355,13 @@ class CatalogFragmentBookDetail : Fragment() {
 
     val context = this.requireContext()
     this.format.text = when (feedEntry.probableFormat) {
-      null,
       BookFormats.BookFormatDefinition.BOOK_FORMAT_EPUB ->
         context.getString(R.string.catalogBookFormatEPUB)
       BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO ->
         context.getString(R.string.catalogBookFormatAudioBook)
       BookFormats.BookFormatDefinition.BOOK_FORMAT_PDF ->
         context.getString(R.string.catalogBookFormatPDF)
+      else -> ""
     }
 
     this.cover.contentDescription =

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -24,7 +24,6 @@ import org.joda.time.format.DateTimeFormatterBuilder
 import org.librarysimplified.services.api.Services
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookFormat
-import org.nypl.simplified.books.book_database.api.BookFormats
 import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO
 import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_EPUB
 import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_PDF

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -25,6 +25,9 @@ import org.librarysimplified.services.api.Services
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookFormat
 import org.nypl.simplified.books.book_database.api.BookFormats
+import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO
+import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_EPUB
+import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_PDF
 import org.nypl.simplified.books.book_registry.BookRegistryReadableType
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookStatusEvent
@@ -49,6 +52,7 @@ import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.nypl.simplified.taskrecorder.api.TaskStepResolution.TaskStepFailed
 import org.nypl.simplified.taskrecorder.api.TaskStepResolution.TaskStepSucceeded
 import org.nypl.simplified.ui.accounts.AccountFragmentParameters
+import org.nypl.simplified.ui.catalog.R.string
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.nypl.simplified.ui.screen.ScreenSizeInformationType
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
@@ -355,13 +359,13 @@ class CatalogFragmentBookDetail : Fragment() {
 
     val context = this.requireContext()
     this.format.text = when (feedEntry.probableFormat) {
-      BookFormats.BookFormatDefinition.BOOK_FORMAT_EPUB ->
-        context.getString(R.string.catalogBookFormatEPUB)
-      BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO ->
-        context.getString(R.string.catalogBookFormatAudioBook)
-      BookFormats.BookFormatDefinition.BOOK_FORMAT_PDF ->
-        context.getString(R.string.catalogBookFormatPDF)
-      else -> ""
+      BOOK_FORMAT_EPUB ->
+        context.getString(string.catalogBookFormatEPUB)
+      BOOK_FORMAT_AUDIO ->
+        context.getString(string.catalogBookFormatAudioBook)
+      BOOK_FORMAT_PDF ->
+        context.getString(string.catalogBookFormatPDF)
+      null -> ""
     }
 
     this.cover.contentDescription =

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -18,6 +18,9 @@ import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookFormat
 import org.nypl.simplified.books.book_database.api.BookFormats
+import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO
+import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_EPUB
+import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_PDF
 import org.nypl.simplified.books.book_registry.BookRegistryReadableType
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookStatusEvent
@@ -33,6 +36,7 @@ import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.nypl.simplified.taskrecorder.api.TaskStepResolution
 import org.nypl.simplified.ui.accounts.AccountFragmentParameters
+import org.nypl.simplified.ui.catalog.R.string
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
 import org.slf4j.LoggerFactory
@@ -202,13 +206,13 @@ class CatalogPagedViewHolder(
     this.errorTitle.text = item.feedEntry.title
 
     this.idleMeta.text = when (item.probableFormat) {
-      BookFormats.BookFormatDefinition.BOOK_FORMAT_EPUB ->
-        context.getString(R.string.catalogBookFormatEPUB)
-      BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO ->
-        context.getString(R.string.catalogBookFormatAudioBook)
-      BookFormats.BookFormatDefinition.BOOK_FORMAT_PDF ->
-        context.getString(R.string.catalogBookFormatPDF)
-      else -> ""
+      BOOK_FORMAT_EPUB ->
+        context.getString(string.catalogBookFormatEPUB)
+      BOOK_FORMAT_AUDIO ->
+        context.getString(string.catalogBookFormatAudioBook)
+      BOOK_FORMAT_PDF ->
+        context.getString(string.catalogBookFormatPDF)
+      null -> ""
     }
 
     val targetHeight =

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -17,7 +17,6 @@ import org.librarysimplified.services.api.ServiceDirectoryType
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookFormat
-import org.nypl.simplified.books.book_database.api.BookFormats
 import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO
 import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_EPUB
 import org.nypl.simplified.books.book_database.api.BookFormats.BookFormatDefinition.BOOK_FORMAT_PDF

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -202,13 +202,13 @@ class CatalogPagedViewHolder(
     this.errorTitle.text = item.feedEntry.title
 
     this.idleMeta.text = when (item.probableFormat) {
-      null,
       BookFormats.BookFormatDefinition.BOOK_FORMAT_EPUB ->
         context.getString(R.string.catalogBookFormatEPUB)
       BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO ->
         context.getString(R.string.catalogBookFormatAudioBook)
       BookFormats.BookFormatDefinition.BOOK_FORMAT_PDF ->
         context.getString(R.string.catalogBookFormatPDF)
+      else -> ""
     }
 
     val targetHeight =


### PR DESCRIPTION
**What's this do?**
Fixes an issue where Feedbook audiobooks would fail with a "database entry does not have a format handle for {}" error.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2943

**How should this be tested? / Do these changes have associated tests?**
An account for "St. Mary's County Library" should be used.

Ask Leonard or Tristan for test credentials.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Yes, @twaddington ran the Vanilla app.