### PR TITLE
Pass OPDS entries into analytics API

### DIFF
--- a/simplified-analytics-api/build.gradle
+++ b/simplified-analytics-api/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   api project(":simplified-accounts-api")
   api project(":simplified-http-core")
+  api project(":simplified-opds-core")
 
   api libraries.jodaTime
 

--- a/simplified-analytics-api/src/main/java/org/nypl/simplified/analytics/api/AnalyticsEvent.kt
+++ b/simplified-analytics-api/src/main/java/org/nypl/simplified/analytics/api/AnalyticsEvent.kt
@@ -2,6 +2,7 @@ package org.nypl.simplified.analytics.api
 
 import org.joda.time.LocalDateTime
 import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
+import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import java.net.URI
 import java.util.SortedMap
 import java.util.UUID
@@ -270,16 +271,10 @@ sealed class AnalyticsEvent {
     val accountUUID: UUID,
 
     /**
-     * The OPDS ID of the book.
+     * The OPDS entry of the book.
      */
 
-    val bookOPDSId: String,
-
-    /**
-     * The title of the book.
-     */
-
-    val bookTitle: String,
+    val opdsEntry: OPDSAcquisitionFeedEntry,
 
     /**
      * A URI that should be used for submitting "book opened" events.
@@ -315,16 +310,10 @@ sealed class AnalyticsEvent {
     val accountUUID: UUID,
 
     /**
-     * The OPDS ID of the book.
+     * The OPDS entry of the book.
      */
 
-    val bookOPDSId: String,
-
-    /**
-     * The title of the book.
-     */
-
-    val bookTitle: String,
+    val opdsEntry: OPDSAcquisitionFeedEntry,
 
     /**
      * The current page of the book.
@@ -372,16 +361,10 @@ sealed class AnalyticsEvent {
     val accountUUID: UUID,
 
     /**
-     * The OPDS ID of the book.
+     * The OPDS entry of the book.
      */
 
-    val bookOPDSId: String,
-
-    /**
-     * The title of the book.
-     */
-
-    val bookTitle: String
+    val opdsEntry: OPDSAcquisitionFeedEntry
   ) : AnalyticsEvent()
 
   /**

--- a/simplified-analytics-circulation/src/main/java/org/nypl/simplified/analytics/circulation/CirculationAnalyticsSystem.kt
+++ b/simplified-analytics-circulation/src/main/java/org/nypl/simplified/analytics/circulation/CirculationAnalyticsSystem.kt
@@ -55,8 +55,8 @@ class CirculationAnalyticsSystem(
         } else {
           this.logger.debug(
             "no analytics URI available for book {} ({})",
-            event.bookOPDSId,
-            event.bookTitle)
+            event.opdsEntry.id,
+            event.opdsEntry.title)
         }
       }
     }

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
@@ -616,8 +616,7 @@ public final class ReaderActivity extends AppCompatActivity implements
             .getUuid(),
           this.current_account.getProvider().getId(),
           this.current_account.getId().getUuid(),
-          this.feed_entry.getID(),
-          this.feed_entry.getTitle()));
+          this.feed_entry));
     } catch (ProfileNoneCurrentException ex) {
       LOG.error("profile is not current: ", ex);
     }
@@ -915,8 +914,7 @@ public final class ReaderActivity extends AppCompatActivity implements
                 .getUuid(),
               this.current_account.getProvider().getId(),
               this.current_account.getId().getUuid(),
-              this.feed_entry.getID(),
-              this.feed_entry.getTitle(),
+              this.feed_entry,
               this.current_page_index,
               this.current_page_count,
               this.current_chapter_title));


### PR DESCRIPTION
**What's this do?**
This adjusts the analytics API so that full OPDS entries are passed
along with book-related events. This is primarily of use to LFA, who
need access to categories and other metadata.

Fix: https://jira.nypl.org/browse/SIMPLY-2939

**Why are we doing this? (w/ JIRA link if applicable)**
Needed by LFA.

**How should this be tested? / Do these changes have associated tests?**
If the analytics system continues to work as before, then this works. We're essentially passing an entire class instead of two specific fields from the class, so it's a purely internal change.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m ran the vanilla app.