### PR TITLE
Mitigate a potential crash on startup by waiting for service directory creation to complete.

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
@@ -37,6 +37,7 @@ import org.nypl.simplified.ui.settings.SettingsNavigationControllerType
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
 import org.nypl.simplified.ui.toolbar.ToolbarHostType
 import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
 
 /**
  * The main application fragment.
@@ -66,7 +67,8 @@ class MainFragment : Fragment() {
     this.navigationControllerDirectory =
       NavigationControllers.findDirectory(this.requireActivity())
 
-    val services = Services.serviceDirectory()
+    val services =
+      Services.serviceDirectoryWaiting(30L, TimeUnit.SECONDS)
 
     this.accountProviders =
       services.requireService(AccountProviderRegistryType::class.java)


### PR DESCRIPTION
**What's this do?**
Wait up to 30 seconds for the service directory to finish spinning up. Ideally the service directory is initialized serially, but quickly; or lazily, when needed. Either way we should block until this process finishes. This fix is a bit of a hack but follows a pattern already used elsewhere within the application.

**Why are we doing this? (w/ JIRA link if applicable)**
https://console.firebase.google.com/project/simplye-nypl/crashlytics/app/android:org.nypl.simplified.simplye/issues/0da057da8867a50cf3d7de37b1cd6b84

**How should this be tested? / Do these changes have associated tests?**
Make sure the app starts up normally.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the vanilla app.