### PR TITLE
Fixes a crash in the card creator where a lateinit property could be read  before it was initialized.

### DIFF
--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/PersonalInformationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/PersonalInformationFragment.kt
@@ -33,7 +33,8 @@ class PersonalInformationFragment : Fragment(), DatePickerDialog.OnDateSetListen
 
   private lateinit var navController: NavController
   private lateinit var nextAction: NavDirections
-  private lateinit var birthDate: String
+
+  private var birthDate: String? = null
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -85,7 +86,7 @@ class PersonalInformationFragment : Fragment(), DatePickerDialog.OnDateSetListen
           binding.firstNameEt.text.toString(),
           binding.middleNameEt.text.toString(),
           binding.lastNameEt.text.toString(),
-          birthDate,
+          birthDate!!,
           binding.emailEt.text.toString()
         ))
         hideKeyboard()
@@ -122,7 +123,7 @@ class PersonalInformationFragment : Fragment(), DatePickerDialog.OnDateSetListen
    * Check to see if date is over 13 years
    */
   private fun isOver13(): Boolean {
-    return if (birthDate.isNotEmpty()) {
+    return if (!birthDate.isNullOrEmpty()) {
       val formatter = DateTimeFormat.forPattern("MM/dd/yy")
       val birthDateObj = formatter.parseDateTime(birthDate)
       if (birthDateObj.plusYears(13).isAfterNow) {


### PR DESCRIPTION
**What's this do?**
Changes a lateinit property to more appropriate nullable String.

**Why are we doing this? (w/ JIRA link if applicable)**
https://console.firebase.google.com/project/simplye-nypl/crashlytics/app/android:org.nypl.simplified.simplye/issues/dbe6fc937b18b102bbd45860519e1323

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
I haven't run this but it should be easy to verify.