### PR TITLE
Fix a possible crash in the AudioBookPlayerActivity due to a lifecycle issue.

### DIFF
--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -404,12 +404,16 @@ class AudioBookPlayerActivity : AppCompatActivity(),
      */
 
     this.uiThread.runOnUIThread {
-      this.playerFragment = PlayerFragment.newInstance(PlayerFragmentParameters())
+      // Sanity check; Verify the state of the lifecycle before continuing as it's possible the
+      // activity could be finishing.
+      if (!this.isFinishing && !this.supportFragmentManager.isDestroyed) {
+        this.playerFragment = PlayerFragment.newInstance(PlayerFragmentParameters())
 
-      this.supportFragmentManager
-        .beginTransaction()
-        .replace(R.id.audio_book_player_fragment_holder, this.playerFragment, "PLAYER")
-        .commit()
+        this.supportFragmentManager
+          .beginTransaction()
+          .replace(R.id.audio_book_player_fragment_holder, this.playerFragment, "PLAYER")
+          .commit()
+      }
     }
   }
 


### PR DESCRIPTION
**Why are we doing this? (w/ JIRA link if applicable)**
- https://console.firebase.google.com/project/simplye-nypl/crashlytics/app/android:org.nypl.simplified.simplye/issues/da8d90f8c932177408a990b7511998bf

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
I haven't tested this but it should be easy to verify.