### PR TITLE
Feature/bundled covers

### DIFF
--- a/simplified-books-covers/build.gradle
+++ b/simplified-books-covers/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+  api project(':simplified-books-bundled-api')
   api project(':simplified-feeds-api')
   api project(':simplified-http-core')
   api project(':simplified-opds-core')

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverBundledRequestHandler.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverBundledRequestHandler.kt
@@ -5,6 +5,7 @@ import com.squareup.picasso.Picasso
 import com.squareup.picasso.Request
 import com.squareup.picasso.RequestHandler
 import org.nypl.simplified.books.bundled.api.BundledContentResolverType
+import org.nypl.simplified.books.bundled.api.BundledURIs
 import java.io.IOException
 import java.net.URI
 
@@ -15,8 +16,7 @@ class BookCoverBundledRequestHandler(
   override fun canHandleRequest(
     data: Request
   ): Boolean {
-    val uri = URI.create(data.uri.toString())
-    return "simplified-bundled" == uri.scheme
+    return BundledURIs.isBundledURI(URI.create(data.uri.toString()))
   }
 
   override fun load(

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverBundledRequestHandler.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverBundledRequestHandler.kt
@@ -1,0 +1,35 @@
+package org.nypl.simplified.books.covers
+
+import android.graphics.BitmapFactory
+import com.squareup.picasso.Picasso
+import com.squareup.picasso.Request
+import com.squareup.picasso.RequestHandler
+import org.nypl.simplified.books.bundled.api.BundledContentResolverType
+import java.io.IOException
+import java.net.URI
+
+class BookCoverBundledRequestHandler(
+  private val bundledContentResolver: BundledContentResolverType
+) : RequestHandler() {
+
+  override fun canHandleRequest(
+    data: Request
+  ): Boolean {
+    val uri = URI.create(data.uri.toString())
+    return "simplified-bundled" == uri.scheme
+  }
+
+  override fun load(
+    request: Request,
+    networkPolicy: Int
+  ): Result =
+    try {
+      val uri = URI.create(request.uri.toString())
+      this.bundledContentResolver.resolve(uri).use { stream ->
+        val bitmap = BitmapFactory.decodeStream(stream)
+        return Result(bitmap, Picasso.LoadedFrom.MEMORY)
+      }
+    } catch (e: Throwable) {
+      throw IOException(e)
+    }
+}

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
@@ -10,6 +10,7 @@ import com.io7m.jfunctional.Some
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 import org.nypl.simplified.books.book_registry.BookRegistryReadableType
+import org.nypl.simplified.books.bundled.api.BundledContentResolverType
 import org.nypl.simplified.feeds.api.FeedEntry
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -192,6 +193,7 @@ class BookCoverProvider private constructor(
      *
      * @param context The application context
      * @param badgeLookup A function used to look up badge images
+     * @param bundledContentResolver A bundled content resolver
      * @param bookRegistry The book registry
      * @param coverGenerator A cover generator
      * @param executor An executor
@@ -204,6 +206,7 @@ class BookCoverProvider private constructor(
       bookRegistry: BookRegistryReadableType,
       coverGenerator: BookCoverGeneratorType,
       badgeLookup: BookCoverBadgeLookupType,
+      bundledContentResolver: BundledContentResolverType,
       executor: ExecutorService,
       debugCacheIndicators: Boolean,
       debugLogging: Boolean
@@ -214,6 +217,7 @@ class BookCoverProvider private constructor(
       picassoBuilder.indicatorsEnabled(debugCacheIndicators)
       picassoBuilder.loggingEnabled(debugLogging)
       picassoBuilder.addRequestHandler(BookCoverGeneratorRequestHandler(coverGenerator))
+      picassoBuilder.addRequestHandler(BookCoverBundledRequestHandler(bundledContentResolver))
       picassoBuilder.executor(executor)
 
       val picasso = picassoBuilder.build()

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -502,6 +502,7 @@ internal object MainServices {
   private fun createCoverProvider(
     context: Context,
     bookRegistry: BookRegistryReadableType,
+    bundledContentResolver: BundledContentResolverType,
     coverGenerator: BookCoverGeneratorType,
     badgeLookup: BookCoverBadgeLookupType
   ): BookCoverProviderType {
@@ -512,6 +513,7 @@ internal object MainServices {
       bookRegistry = bookRegistry,
       coverGenerator = coverGenerator,
       badgeLookup = badgeLookup,
+      bundledContentResolver = bundledContentResolver,
       executor = execCovers,
       debugCacheIndicators = false,
       debugLogging = false)
@@ -955,6 +957,7 @@ internal object MainServices {
         this.createCoverProvider(
           context = context,
           bookRegistry = bookRegistry,
+          bundledContentResolver = bundledContent,
           coverGenerator = coverGenerator,
           badgeLookup = badgeLookup
         )


### PR DESCRIPTION
**What's this do?**
This adds a request handler to load cover images from bundled content
(that is, content included directly into the APK file accessed using
a `simplified-bundled://` URI scheme). This is a feature that LFA
still use that had been accidentally removed.

**Why are we doing this? (w/ JIRA link if applicable)**
We had this for ages but it was accidentally removed.

**How should this be tested? / Do these changes have associated tests?**
It's not used by anyone outside of LFA. I've tested that it doesn't affect existing cover loading.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m 