### PR TITLE
Fix possible crash when presenting the EULA from the splash fragment.

### DIFF
--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
@@ -220,6 +220,11 @@ class SplashFragment : Fragment() {
   }
 
   private fun configureViewsForEULA(eula: EULAType) {
+    val activity = this.activity ?: return
+
+    // If the activity is finishing for some reason; return
+    if (activity.isFinishing) return
+
     this.viewsForEULA.eulaAgree.setOnClickListener {
       eula.eulaSetHasAgreed(true)
       this.onFinishEULASuccessfully()
@@ -240,7 +245,7 @@ class SplashFragment : Fragment() {
     this.viewsForEULA.eulaWebView.settings.allowUniversalAccessFromFileURLs = false
     this.viewsForEULA.eulaWebView.settings.javaScriptEnabled = false
 
-    this.viewsForEULA.eulaWebView.webViewClient = object : MailtoWebViewClient(requireActivity()) {
+    this.viewsForEULA.eulaWebView.webViewClient = object : MailtoWebViewClient(activity) {
       override fun onReceivedError(
         view: WebView?,
         errorCode: Int,


### PR DESCRIPTION
**Why are we doing this? (w/ JIRA link if applicable)**
https://console.firebase.google.com/project/simplye-nypl/crashlytics/app/android:org.nypl.simplified.simplye/issues/93b863064e8c994a5b125b3bad5e445e

**How should this be tested? / Do these changes have associated tests?**
Make sure the EULA displays normally.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the SimplyE app.