### PR TITLE
Add dependency on org.librarysimplified.audiobook.rbdigital

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,7 @@ ext.libraries = [
   nyplAudiobookManifestParserAPI   : "org.librarysimplified.audiobook:org.librarysimplified.audiobook.manifest_parser.api:${nyplAudioBookAPIVersion}",
   nyplAudiobookManifestWebPub      : "org.librarysimplified.audiobook:org.librarysimplified.audiobook.manifest_parser.webpub:${nyplAudioBookAPIVersion}",
   nyplAudiobookOpenAccess          : "org.librarysimplified.audiobook:org.librarysimplified.audiobook.open_access:${nyplAudioBookAPIVersion}",
+  nyplAudiobookRBDigital           : "org.librarysimplified.audiobook:org.librarysimplified.audiobook.rbdigital:${nyplAudioBookAPIVersion}",
   nyplAudiobookViews               : "org.librarysimplified.audiobook:org.librarysimplified.audiobook.views:${nyplAudioBookAPIVersion}",
   nyplDRMCore                      : "org.librarysimplified.drm:org.librarysimplified.drm.core:1.1.1",
   nyplPDFAPI                       : "edu.umn.minitex.pdf:edu.umn.minitex.pdf.api:0.1.0",

--- a/simplified-tests/build.gradle
+++ b/simplified-tests/build.gradle
@@ -60,6 +60,7 @@ dependencies {
   api libraries.nyplAudiobookManifestFulfillBasic
   api libraries.nyplAudiobookManifestWebPub
   api libraries.nyplAudiobookOpenAccess
+  api libraries.nyplAudiobookRBDigital
   api libraries.nyplAudiobookViews
 
   implementation libraries.io7mJFunctional

--- a/simplified-viewer-audiobook/build.gradle
+++ b/simplified-viewer-audiobook/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   api libraries.nyplAudiobookManifestParserAPI
   api libraries.nyplAudiobookManifestWebPub
   api libraries.nyplAudiobookOpenAccess
+  api libraries.nyplAudiobookRBDigital
   api libraries.nyplAudiobookViews
 
   implementation libraries.androidXActivity


### PR DESCRIPTION
**What's this do?**

Add the `org.librarysimplified.audiobook.rbdigital` package as a dependency.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-2965](https://jira.nypl.org/browse/SIMPLY-2965). It makes the `org.librarysimplified.audiobook.rbdigital.RBDigitialPlayerExtension` class available to ServiceLoader, so that RBDigital audiobooks are handled properly.

**How should this be tested? / Do these changes have associated tests?**

Download and play an RBDigital audiobook (an example is specified in the above JIRA issue). The audio should play, instead of immediately skipping to the next spine item.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

Yes, @ray-lee ran the vanilla app.