### PR TITLE
[SIMPLY-2970]: Trigger BookSyncTask before ProfileFeedTask when reloading a local feed.

### DIFF
--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountReadableType.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountReadableType.kt
@@ -53,6 +53,6 @@ interface AccountReadableType {
       is AccountProviderAuthenticationDescription.COPPAAgeGate -> false
       is AccountProviderAuthenticationDescription.Basic -> true
       is AccountProviderAuthenticationDescription.OAuthWithIntermediary -> true
-      AccountProviderAuthenticationDescription.Anonymous -> false
+      is AccountProviderAuthenticationDescription.Anonymous -> false
     }
 }

--- a/simplified-futures/src/main/java/org/nypl/simplified/futures/FluentFutureExtensions.kt
+++ b/simplified-futures/src/main/java/org/nypl/simplified/futures/FluentFutureExtensions.kt
@@ -63,7 +63,7 @@ object FluentFutureExtensions {
    */
 
   fun <A> fluentFutureOfAll(futures: List<FluentFuture<A>>) =
-    FluentFuture.from(Futures.allAsList(futures))
+    FluentFuture.from(Futures.successfulAsList(futures))
 
   /**
    * A future that completes immediately with the given value.

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -114,7 +114,6 @@ class CatalogFeedViewModel(
         uri = booksUri
       )
 
-
     val profile =
       this.profilesController.profileCurrent()
     val accountsToSync =

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -16,6 +16,7 @@ import org.nypl.simplified.accounts.api.AccountEventLoginStateChanged
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.accounts.api.AccountLoginState
 import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription
+import org.nypl.simplified.books.controller.api.BooksControllerType
 import org.nypl.simplified.feeds.api.Feed
 import org.nypl.simplified.feeds.api.FeedFacet
 import org.nypl.simplified.feeds.api.FeedFacet.FeedFacetPseudo
@@ -25,6 +26,8 @@ import org.nypl.simplified.feeds.api.FeedFacetPseudoTitleProviderType
 import org.nypl.simplified.feeds.api.FeedLoaderResult
 import org.nypl.simplified.feeds.api.FeedLoaderType
 import org.nypl.simplified.feeds.api.FeedSearch
+import org.nypl.simplified.futures.FluentFutureExtensions.flatMap
+import org.nypl.simplified.futures.FluentFutureExtensions.fluentFutureOfAll
 import org.nypl.simplified.futures.FluentFutureExtensions.map
 import org.nypl.simplified.futures.FluentFutureExtensions.onAnyError
 import org.nypl.simplified.profiles.controller.api.ProfileFeedRequest
@@ -57,6 +60,8 @@ class CatalogFeedViewModel(
 
   private val feedLoader: FeedLoaderType =
     this.services.requireService(FeedLoaderType::class.java)
+  private val booksController: BooksControllerType =
+    this.services.requireService(BooksControllerType::class.java)
   private val profilesController: ProfilesControllerType =
     this.services.requireService(ProfilesControllerType::class.java)
   private val instanceId =
@@ -109,14 +114,30 @@ class CatalogFeedViewModel(
         uri = booksUri
       )
 
-    val future =
-      this.profilesController.profileFeed(request)
-        .map { f -> FeedLoaderResult.FeedLoaderSuccess(f) as FeedLoaderResult }
-        .onAnyError { ex -> FeedLoaderResult.wrapException(booksUri, ex) }
+
+    val profile =
+      this.profilesController.profileCurrent()
+    val accountsToSync =
+      if (request.filterByAccountID == null) {
+        // Sync all accounts
+        profile.accounts()
+      } else {
+        // Sync the account we're filtering on
+        profile.accounts().filterKeys { it == request.filterByAccountID }
+      }
+
+    val syncFuture =
+      fluentFutureOfAll(accountsToSync.values.map { account ->
+        this.booksController.booksSync(account)
+      })
+
+    val future = this.profilesController.profileFeed(request)
+      .map { f -> FeedLoaderResult.FeedLoaderSuccess(f) as FeedLoaderResult }
+      .onAnyError { ex -> FeedLoaderResult.wrapException(booksUri, ex) }
 
     return this.createNewStatus(
       arguments = arguments,
-      future = future
+      future = syncFuture.flatMap { future }
     )
   }
 


### PR DESCRIPTION
**What's this do?**
This patch updates the local 'Books' and 'Holds' feeds to actually kick off the book sync task when reloading instead of just reparsing the cached local feed.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2970

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the Vanilla app.