### PR TITLE
Use the private, internal, cache directory for writing logs instead of the external cache dir (world-readable).

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainApplication.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainApplication.kt
@@ -60,8 +60,8 @@ class MainApplication : Application() {
         while (index.hasNext()) {
           val appender = index.next()
           if (appender is RollingFileAppender<*>) {
-            externalCacheDir?.mkdirs()
-            val path = File(externalCacheDir, "log.txt").absolutePath
+            cacheDir?.mkdirs()
+            val path = File(cacheDir, "log.txt").absolutePath
             (appender as RollingFileAppender<*>).file = path
             appender.start()
           }

--- a/simplified-main/src/main/res/xml/provider_paths.xml
+++ b/simplified-main/src/main/res/xml/provider_paths.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-  <external-cache-path
-    name="external_files"
-    path="." />
-  <external-path
-    name="external_files"
+  <cache-path
+    name="reports"
     path="." />
 </paths>

--- a/simplified-reports/src/main/java/org/nypl/simplified/reports/Reports.kt
+++ b/simplified-reports/src/main/java/org/nypl/simplified/reports/Reports.kt
@@ -63,8 +63,8 @@ object Reports {
   ): Result {
 
     val directories = mutableListOf<File>()
-    context.externalCacheDir?.let { directories.add(it) }
-    context.externalCacheDir?.let { directories.add(File(it, "migrations")) }
+    context.cacheDir?.let { directories.add(it) }
+    context.cacheDir?.let { directories.add(File(it, "migrations")) }
 
     return sendReport(
       context = context,

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentVersion.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentVersion.kt
@@ -180,11 +180,11 @@ class SettingsFragmentVersion : Fragment() {
       val context = this.requireContext()
       val message = StringBuilder(128)
       message.append("Cache directory is: ")
-      message.append(context.externalCacheDir)
+      message.append(context.cacheDir)
       message.append("\n")
       message.append("\n")
       message.append("Exists: ")
-      message.append(context.externalCacheDir?.isDirectory ?: false)
+      message.append(context.cacheDir?.isDirectory ?: false)
       message.append("\n")
 
       AlertDialog.Builder(context)

--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
@@ -544,7 +544,7 @@ class SplashFragment : Fragment() {
 
   private fun processMigrationReportSaveToDisk(report: MigrationReport): File? {
     return try {
-      val cacheDir = this.requireContext().externalCacheDir
+      val cacheDir = this.requireContext().cacheDir
       if (cacheDir == null) {
         AlertDialog.Builder(this.requireContext())
           .setTitle("Could not save migration report.")


### PR DESCRIPTION
**What's this do?**
This patch updates all references of `externalCacheDir` to `cacheDir` (internal).

**Why are we doing this? (w/ JIRA link if applicable)**
In practice, `externalCacheDir` and `cacheDir` may return the same location.

> If a shared storage device is emulated (as determined by `Environment#isExternalStorageEmulated(File))`, its contents are backed by a private user data partition, which means there is little benefit to storing data here instead of the private directory returned by `getCacheDir()`.
>
> &mdash; https://developer.android.com/reference/kotlin/android/content/Context#getExternalCacheDir()

However, in some cases `externalCacheDir` may be a world-readable location.

> There is no security enforced with these files. For example, any application holding `android.Manifest.permission#WRITE_EXTERNAL_STORAGE` can write to these files.
> 
> &mdash; https://developer.android.com/reference/kotlin/android/content/Context#getExternalCacheDir()

While we shouldn't be logging any sensitive information to disk anyway, it would be prudent to default to the more secure internal cache directory.

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the Vanilla app.