### PR TITLE
SIMPLY-2964: Juvenile card creator shows up after login for Brooklyn Public Library

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -922,6 +922,7 @@ class AccountFragment : Fragment() {
       AsLoginButtonDisabled -> {
         this.loginButton.setText(R.string.accountLogin)
         this.signUpLabel.setText(R.string.accountCardCreatorLabel)
+        this.signUpLabel.isEnabled = true
         this.loginButton.isEnabled = false
       }
       is AsCancelButtonEnabled -> {
@@ -931,13 +932,16 @@ class AccountFragment : Fragment() {
       }
       is AsLogoutButtonEnabled -> {
         this.loginButton.setText(R.string.accountLogout)
-        this.signUpLabel.setText(R.string.accountWantChildCard)
         this.loginButton.isEnabled = true
+        this.signUpButton.isEnabled = isNypl()
+        this.signUpLabel.isEnabled = isNypl()
+        if (isNypl()) this.signUpLabel.setText(R.string.accountWantChildCard)
+        this.signUpLabel.isEnabled = isNypl()
         this.loginButton.setOnClickListener { status.onClick.invoke() }
       }
       AsLogoutButtonDisabled -> {
         this.loginButton.setText(R.string.accountLogout)
-        this.signUpLabel.setText(R.string.accountWantChildCard)
+        if (isNypl()) this.signUpLabel.setText(R.string.accountWantChildCard)
         this.loginButton.isEnabled = false
       }
       AsCancelButtonDisabled -> {
@@ -945,6 +949,18 @@ class AccountFragment : Fragment() {
         this.loginButton.isEnabled = false
       }
     }
+  }
+
+  /**
+   * Returns if the user is viewing the NYPL account
+   */
+  private fun isNypl(): Boolean {
+    var isNypl = false
+    val cardCreatorURI = this.account.provider.cardCreatorURI
+    if (cardCreatorURI != null) {
+      isNypl = cardCreatorURI.scheme == this.nyplCardCreatorScheme
+    }
+    return isNypl
   }
 
   private fun loadAuthenticationLogoIfNecessary(
@@ -1020,6 +1036,7 @@ class AccountFragment : Fragment() {
     val loginSatisfied = this.determineLoginIsSatisfied()
     this.setLoginButtonStatus(loginSatisfied)
     this.authenticationAlternativesShow()
+    this.signUpButton.isEnabled = true
   }
 
   private fun authenticationAlternativesMake() {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -1037,6 +1037,7 @@ class AccountFragment : Fragment() {
     this.setLoginButtonStatus(loginSatisfied)
     this.authenticationAlternativesShow()
     this.signUpButton.isEnabled = true
+    this.signUpLabel.isEnabled = true
   }
 
   private fun authenticationAlternativesMake() {


### PR DESCRIPTION
**What's this do?**
Adds missing logic to enable/disable buttons and card creator based on account

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-2964: Juvenile card creator shows up after login for Brooklyn Public Library](https://jira.nypl.org/browse/SIMPLY-2964)

**How should this be tested? / Do these changes have associated tests?**
Login to an NYPL account and any other library account and ensure that the juvenile card creator is not launched for non-NYPL acccount

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 