### PR TITLE
SIMPLY-2400: Wait for book content to load before applying reader preferences.

### DIFF
--- a/simplified-viewer-epub-readium1/src/main/assets/host_app_feedback.js
+++ b/simplified-viewer-epub-readium1/src/main/assets/host_app_feedback.js
@@ -49,6 +49,7 @@ $(document).ready(function()
             ReadiumSDK.reader.on(ReadiumSDK.Events.MEDIA_OVERLAY_TTS_STOP, this.onMediaOverlayTTSStop, this);
             ReadiumSDK.reader.on(ReadiumSDK.Events.PAGINATION_CHANGED, this.onPaginationChanged, this);
             ReadiumSDK.reader.on(ReadiumSDK.Events.SETTINGS_APPLIED, this.onSettingsApplied, this);
+            ReadiumSDK.reader.on(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, this.onContentDocumentLoaded, this);
 
             window.location.href = "readium:initialize";
           },
@@ -81,6 +82,10 @@ $(document).ready(function()
         this.onMediaOverlayTTSStop = function()
         {
           window.location.href = "readium:media-overlay-tts-stop";
+        };
+
+        this.onContentDocumentLoaded = function() {
+          window.location.href = "readium:content-document-loaded";
         };
       }();
 

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumFeedbackDispatcher.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumFeedbackDispatcher.java
@@ -48,6 +48,20 @@ public final class ReaderReadiumFeedbackDispatcher
     }
   }
 
+  private static void onContentDocumentLoaded(
+    final ReaderReadiumFeedbackListenerType l)
+  {
+    try {
+      l.onReadiumContentDocumentLoaded();
+    } catch (final Throwable e) {
+      try {
+        l.onReadiumContentDocumentLoadedError(e);
+      } catch (final Throwable x1) {
+        ReaderReadiumFeedbackDispatcher.LOG.error("{}", x1.getMessage(), x1);
+      }
+    }
+  }
+
   private static void onMediaOverlayStatusChanged(
     final ReaderReadiumFeedbackListenerType l,
     final String[] parts)
@@ -142,6 +156,11 @@ public final class ReaderReadiumFeedbackDispatcher
         final String function = NullCheck.notNull(parts[0]);
         if ("initialize".equals(function)) {
           ReaderReadiumFeedbackDispatcher.onInitialize(l);
+          return;
+        }
+
+        if ("content-document-loaded".equals(function)) {
+          ReaderReadiumFeedbackDispatcher.onContentDocumentLoaded(l);
           return;
         }
 

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumFeedbackListenerType.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumFeedbackListenerType.java
@@ -32,6 +32,21 @@ public interface ReaderReadiumFeedbackListenerType
     Throwable e);
 
   /**
+   * Called on receipt of a {@code readium:content-document-loaded} request.
+   */
+
+  void onReadiumContentDocumentLoaded();
+
+  /**
+   * Called when {@link #onReadiumContentDocumentLoaded()} raises an exception.
+   *
+   * @param e The raised exception
+   */
+
+  void onReadiumContentDocumentLoadedError(
+    Throwable e);
+
+  /**
    * Called on receipt of a {@code readium:pagination-changed} request.
    *
    * @param e The pagination event


### PR DESCRIPTION
**What's this do?**

Wait until Readium indicates that book content has loaded before attempting to apply the user's reader preferences (font and color scheme). Currently, the app attempts to apply the preferences at an arbitrary 300 ms delay after Readium has initialized.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-2400](https://jira.nypl.org/browse/SIMPLY-2400).

Readium loads book content into an iframe in its WebView. While the content is loading, the iframe is [hidden with css `opacity: 0.01`](https://github.com/readium/readium-shared-js/blob/master/js/views/reflowable_view.js#L260). When the content is complete (the `load` event of the iframe is fired), Readium [unhides the iframe](https://github.com/readium/readium-shared-js/blob/7f245beba1ed97eaabce0aa5e9cf2f3b23e8f8f6/js/views/reflowable_view.js#L376). Meanwhile, SimplyE is currently [waiting 300 ms](https://github.com/NYPL-Simplified/Simplified-Android-Core/blob/fab8a31da8d19776518c39a0594a39091ee21ce4/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java#L515-L532) before [calling Readium's `setBookStyles`](https://github.com/NYPL-Simplified/Simplified-Android-Core/blob/fab8a31da8d19776518c39a0594a39091ee21ce4/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumJavaScriptAPI.java#L197) function to set the book styles. That function attempts to modify the document in the iframe by [injecting a `style` element](https://github.com/readium/readium-shared-js/blob/7f245beba1ed97eaabce0aa5e9cf2f3b23e8f8f6/js/helpers.js#L825-L829). On slower devices and/or with larger content, the iframe may not have finished loading in that 300 ms window. The resulting modification of the iframe's document while it is still loading can interfere with the `load` event being fired, so the iframe is never unhidden, and the content fails to appear.

This changes the app to wait for Readium to dispatch its `CONTENT_DOCUMENT_LOADED` event before applying book styles. [`CONTENT_DOCUMENT_LOADED` is dispatched](https://github.com/readium/readium-shared-js/blob/7f245beba1ed97eaabce0aa5e9cf2f3b23e8f8f6/js/views/reflowable_view.js#L303) after the iframe has fired its `load` event.

**How should this be tested? / Do these changes have associated tests?**

A slower device is necessary to reproduce the problem. I've been able to do it on the Android emulator on a MacBook, as follows:

- Run the vanilla app
- In the SimplyE collection, open "Rosehead" by Ksenia Anske to the cover
- In Chrome, open chrome://inspect and click the Inspect link on the WebView
- In the inspector, click the reload button (or command/ctrl + R) repeatedly until the cover fails to render (usually within 10 tries)

After applying the fix, the book should appear every time, with the user's last selected font/color scheme. Changing the font/color scheme should continue to work.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.