### PR TITLE
Migrate to Readium2 alpha branch and prepare DRM support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ ext.libraries = [
   nyplAudiobookManifestWebPub      : "org.librarysimplified.audiobook:org.librarysimplified.audiobook.manifest_parser.webpub:${nyplAudioBookAPIVersion}",
   nyplAudiobookOpenAccess          : "org.librarysimplified.audiobook:org.librarysimplified.audiobook.open_access:${nyplAudioBookAPIVersion}",
   nyplAudiobookViews               : "org.librarysimplified.audiobook:org.librarysimplified.audiobook.views:${nyplAudioBookAPIVersion}",
-  nyplDRMCore                      : "org.librarysimplified.drm:org.librarysimplified.drm.core:1.1.1",
+  nyplDRMCore                      : "org.librarysimplified.drm:org.librarysimplified.drm.core:1.1.2",
   nyplPDFAPI                       : "edu.umn.minitex.pdf:edu.umn.minitex.pdf.api:0.1.0",
   nyplPDFViewer                    : "edu.umn.minitex.pdf:edu.umn.minitex.pdf.pdfviewer:0.1.0",
   nyplR2API                        : "org.librarysimplified.r2:org.librarysimplified.r2.vanilla:${nyplR2Version}",

--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,8 @@ ext.libraries = [
   picasso                          : "com.squareup.picasso:picasso:2.71828",
   readium                          : "org.librarysimplified:org.librarysimplified.readium:0.30.0",
   readiumSharedJS                  : "org.librarysimplified:org.librarysimplified.readium.shared_js:0.30.0",
+  r2Shared                         : "com.github.qnga:r2-shared-kotlin:nypl-SNAPSHOT",
+  r2Streamer                       : "com.github.qnga:r2-streamer-kotlin:nypl-SNAPSHOT",
   rxjava2                          : "io.reactivex.rxjava2:rxjava:2.1.13",
   slf4j                            : "org.slf4j:slf4j-api:1.7.25",
 ]

--- a/simplified-viewer-epub-readium2/build.gradle
+++ b/simplified-viewer-epub-readium2/build.gradle
@@ -13,4 +13,6 @@ dependencies {
   implementation libraries.nyplR2API
   implementation libraries.nyplR2Vanilla
   implementation libraries.nyplR2Views
+  implementation libraries.r2Shared
+  implementation libraries.r2Streamer
 }

--- a/simplified-viewer-epub-readium2/build.gradle
+++ b/simplified-viewer-epub-readium2/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   implementation libraries.androidXLifecycle
   implementation libraries.androidXLifecycleViewmodel
   implementation libraries.kotlinStdlib
+  implementation libraries.nyplDRMCore
   implementation libraries.nyplR2API
   implementation libraries.nyplR2Vanilla
   implementation libraries.nyplR2Views

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/ReaderActivity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/ReaderActivity.kt
@@ -49,7 +49,6 @@ import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceType
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarks
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
-import org.readium.r2.shared.publication.ContentProtection
 import org.readium.r2.streamer.Streamer
 import org.readium.r2.streamer.parser.epub.EpubParser
 import org.slf4j.LoggerFactory

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/ReaderActivity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/ReaderActivity.kt
@@ -137,8 +137,8 @@ class ReaderActivity : AppCompatActivity(), SR2ControllerHostType {
 
     val contentProtections =
       ServiceLoader.load(ContentProtectionProvider::class.java)
-        .map {
-          it.create(this).also { cp ->
+        .mapNotNull {
+          it.create(this)?.also { cp ->
             this.logger.debug("created content protection of class ${cp::class.java.canonicalName}")
           }
         }

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/ReaderViewerR2.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/ReaderViewerR2.kt
@@ -44,6 +44,7 @@ class ReaderViewerR2 : ViewerProviderType {
   ) {
     val bookId = book.id
     val file = (format as BookFormat.BookFormatEPUB).file!!
+    val adobeRightsFile = format.adobeRightsFile
     val entry = FeedEntry.FeedEntryOPDS(book.account, book.entry)
 
     ReaderActivity.startActivity(
@@ -51,7 +52,8 @@ class ReaderViewerR2 : ViewerProviderType {
       bookId = bookId,
       context = activity,
       entry = entry,
-      file = file
+      file = file,
+      adobeRightsFile = adobeRightsFile
     )
   }
 }


### PR DESCRIPTION
**What's this do?**
Use the Readium 2 alpha API with DRM support.

**Why are we doing this? (w/ JIRA link if applicable)**
R2 opens publications with a `Streamer` that references `ContentProtection`s which depend on services from `simplified-main`.
Therefore, this streamer must be passed to the `SR2Controller` which is responsible for opening publications.
A special `DRMProtectedFile` must be used to pass along adobe rights path to the `AdobeAdeptContentProtection`.

**How should this be tested? / Do these changes have associated tests?**
This may be tested by checking ebooks can still be read.

**Dependencies for merging? Releasing to production?**
Add dependencies to some R2 modules.

**Has the application documentation been updated for these changes?** 
No.

**Did someone actually run this code to verify it works?**
Me.

See also
https://github.com/NYPL-Simplified/Simplified-R2-Android/pull/7
https://github.com/NYPL-Simplified/DRM-Android-Adobe/pull/8
https://github.com/NYPL-Simplified/DRM-Android-Core/pull/4