### PR TITLE
Tolerate R2 bookmarks in R1

### DIFF
--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
@@ -1096,16 +1096,29 @@ public final class ReaderActivity extends AppCompatActivity implements
   private void navigateTo(final OptionType<Bookmark> location) {
     LOG.debug("navigateTo: {}", location);
 
-    OptionType<ReaderOpenPageRequestType> page_request = location.map((actual) -> {
-      LOG.debug("navigateTo: Creating Page Req for: {}", actual);
-      this.current_location = actual;
-      return ReaderOpenPageRequest.fromBookLocation(actual.getLocation());
-    });
+    OptionType<ReaderOpenPageRequestType> page_request;
+    if (location.isSome()) {
+      final Bookmark locReal = ((Some<Bookmark>) location).get();
+
+      try {
+        LOG.debug("navigateTo: Creating Page Req for: {}", locReal);
+        final ReaderOpenPageRequestType request =
+          ReaderOpenPageRequest.fromBookLocation(locReal.getLocation());
+        this.current_location = locReal;
+        page_request = Option.of(request);
+      } catch (Exception e) {
+        LOG.error("navigateTo: failed to create page request: ", e);
+        page_request = Option.none();
+      }
+    } else {
+      page_request = Option.none();
+    }
 
     this.readium_js_api.openBook(
       this.epub_container.getDefaultPackage(),
       this.viewer_settings,
-      page_request);
+      page_request
+    );
   }
 
   @Override


### PR DESCRIPTION
**What's this do?**
When switching between R1 and R2, it's possible that R2-specific
bookmarks will be passed to R1 and this will cause R1 to fail to open
the book. This change makes the R1 reader act as if no bookmark was
provided if the bookmark can't be parsed.

**Why are we doing this? (w/ JIRA link if applicable)**
Ran into this problem when switching between R1 and R2.

**How should this be tested? / Do these changes have associated tests?**
Try switching between R1 and R2 in the developer settings. Make sure you can
still open the same book in both readers.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m opened various books in the Vanilla app.