### PR TITLE
Show the compiled version of Simplified Core in settings.

### DIFF
--- a/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
+++ b/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
@@ -17,6 +17,8 @@ class VanillaBuildConfigurationService : BuildConfigurationServiceType {
     get() = true
   override val vcsCommit: String
     get() = BuildConfig.GIT_COMMIT
+  override val simplifiedVersion: String
+    get() = BuildConfig.SIMPLIFIED_VERSION
   override val supportErrorReportEmailAddress: String
     get() = "simplyemigrationreports@nypl.org"
   override val supportErrorReportSubject: String

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationMetadataType.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationMetadataType.kt
@@ -12,6 +12,10 @@ interface BuildConfigurationMetadataType {
 
   val vcsCommit: String
 
+  /** The version of Simplified Core used in this build. */
+
+  val simplifiedVersion: String
+
   /**
    * The email address to which to send error reports. On most devices, users will be
    * able to override this as the address is passed to the external Android

--- a/simplified-main/build.gradle
+++ b/simplified-main/build.gradle
@@ -10,6 +10,7 @@ def getGitHash = { ->
 android {
   defaultConfig {
     buildConfigField "String", "GIT_COMMIT", "\"${getGitHash()}\""
+    buildConfigField "String", "SIMPLIFIED_VERSION", "\"${rootProject.ext["VERSION_NAME"]}\""
   }
 }
 

--- a/simplified-tests-sandbox/src/main/java/org/nypl/simplified/tests/sandbox/SettingsAccountActivity.kt
+++ b/simplified-tests-sandbox/src/main/java/org/nypl/simplified/tests/sandbox/SettingsAccountActivity.kt
@@ -100,6 +100,8 @@ class SettingsAccountActivity : AppCompatActivity(), ServiceDirectoryProviderTyp
         get() = true
       override val vcsCommit: String =
         "abcd"
+      override val simplifiedVersion: String
+        get() = "zyxw"
       override val supportErrorReportEmailAddress: String
         get() = "errors@example.com"
       override val supportErrorReportSubject: String

--- a/simplified-tests-sandbox/src/main/java/org/nypl/simplified/tests/sandbox/SettingsAccountsActivity.kt
+++ b/simplified-tests-sandbox/src/main/java/org/nypl/simplified/tests/sandbox/SettingsAccountsActivity.kt
@@ -100,6 +100,8 @@ class SettingsAccountsActivity : AppCompatActivity(), ServiceDirectoryProviderTy
         get() = true
       override val vcsCommit: String =
         "abcd"
+      override val simplifiedVersion: String
+        get() = "zyxw"
       override val supportErrorReportEmailAddress: String
         get() = "errors@example.com"
       override val supportErrorReportSubject: String

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentMain.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentMain.kt
@@ -70,6 +70,7 @@ class SettingsFragmentMain : PreferenceFragmentCompat() {
   private lateinit var settingsFaq: Preference
   private lateinit var settingsLicense: Preference
   private lateinit var settingsVersion: Preference
+  private lateinit var settingsVersionCore: Preference
 
   private var toast: Toast? = null
   private var tapToDebugSettings = 7
@@ -89,6 +90,7 @@ class SettingsFragmentMain : PreferenceFragmentCompat() {
     this.settingsFaq = this.findPreference("settingsFaq")!!
     this.settingsLicense = this.findPreference("settingsLicense")!!
     this.settingsVersion = this.findPreference("settingsVersion")!!
+    this.settingsVersionCore = this.findPreference("settingsVersionCore")!!
 
     this.configureAbout(this.settingsAbout)
     this.configureAcknowledgements(this.settingsAcknowledgements)
@@ -99,6 +101,7 @@ class SettingsFragmentMain : PreferenceFragmentCompat() {
     this.configureFaq(this.settingsFaq)
     this.configureLicense(this.settingsLicense)
     this.configureVersion(this.settingsVersion)
+    this.configureVersionCore(this.settingsVersionCore)
   }
 
   override fun onStart() {
@@ -134,6 +137,10 @@ class SettingsFragmentMain : PreferenceFragmentCompat() {
 
   private fun configureVersion(preference: Preference) {
     preference.setSummaryProvider { this.appVersion }
+  }
+
+  private fun configureVersionCore(preference: Preference) {
+    preference.setSummaryProvider { this.buildConfig.simplifiedVersion }
   }
 
   private fun configureBuild(preference: Preference) {

--- a/simplified-ui-settings/src/main/res/values/strings.xml
+++ b/simplified-ui-settings/src/main/res/values/strings.xml
@@ -60,6 +60,8 @@
   <string name="settingsSyncBookmarks">Sync bookmarks</string>
   <string name="settingsTapToDebug">Debug mode in %1$d&#8230;</string>
   <string name="settingsUserName">User Name</string>
-  <string name="settingsVersion">Version</string>
+  <string name="settingsVersion">App version</string>
   <string name="settingsVersionSummary" />
+  <string name="settingsVersionCore">Core version</string>
+  <string name="settingsVersionCoreSummary" />
 </resources>

--- a/simplified-ui-settings/src/main/res/xml/settings.xml
+++ b/simplified-ui-settings/src/main/res/xml/settings.xml
@@ -46,6 +46,13 @@
       tools:summary="5.0.1-debug (4164)" />
 
     <Preference
+      android:key="settingsVersionCore"
+      android:summary="@string/settingsVersionCoreSummary"
+      android:title="@string/settingsVersionCore"
+      app:enableCopying="true"
+      tools:summary="6.2.0-SNAPSHOT" />
+
+    <Preference
       android:icon="@drawable/ic_settings_build"
       android:key="settingsBuild"
       android:summary="@string/settingsBuildSummary"


### PR DESCRIPTION
**What's this do?**
Makes it easier for testers to discover what version of Simplified Core was used to build their app.

**Why are we doing this? (w/ JIRA link if applicable)**
Had a discussion about this with Mark and Jonathan Green in Slack.

**How should this be tested? / Do these changes have associated tests?**
Open settings and verify the right version is shown.

**Dependencies for merging? Releasing to production?**
Will need to make a small update to the SimplyE build configuration as the interface was updated with a new field.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the Vanilla app.