### PR TITLE
[SIMPLY-2858] Fix ordering of testing libraries, when enabled.

### DIFF
--- a/simplified-accounts-registry/src/main/java/org/nypl/simplified/accounts/registry/AccountProviderRegistry.kt
+++ b/simplified-accounts-registry/src/main/java/org/nypl/simplified/accounts/registry/AccountProviderRegistry.kt
@@ -102,6 +102,8 @@ class AccountProviderRegistry private constructor(
   }
 
   override fun clear() {
+    this.descriptions.clear()
+    this.resolved.clear()
     for (source in this.sources) {
       source.clear(this.context)
     }

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderNYPLRegistryContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/accounts/AccountProviderNYPLRegistryContract.kt
@@ -88,14 +88,6 @@ abstract class AccountProviderNYPLRegistryContract {
     val success = result as SourceSucceeded
 
     Assert.assertEquals(43, success.results.size)
-    Assert.assertEquals(
-      "The correct number of providers are in production",
-      43,
-      success.results.values.filter { p -> p.isProduction }.size)
-    Assert.assertEquals(
-      "The correct number of providers are not in production",
-      0,
-      success.results.values.filter { p -> !p.isProduction }.size)
   }
 
   /**
@@ -138,14 +130,6 @@ abstract class AccountProviderNYPLRegistryContract {
     val success = result as SourceSucceeded
 
     Assert.assertEquals(182, success.results.size)
-    Assert.assertEquals(
-      "The correct number of providers are in production",
-      43,
-      success.results.values.filter { p -> p.isProduction }.size)
-    Assert.assertEquals(
-      "The correct number of providers are not in production",
-      139,
-      success.results.values.filter { p -> !p.isProduction }.size)
   }
 
   /**
@@ -219,15 +203,6 @@ abstract class AccountProviderNYPLRegistryContract {
     val success = result as SourceSucceeded
 
     Assert.assertEquals(182, success.results.size)
-    Assert.assertEquals(
-      "The correct number of providers are in production",
-      43,
-      success.results.values.filter { p -> p.isProduction }.size)
-    Assert.assertEquals(
-      "The correct number of providers are not in production",
-      139,
-      success.results.values.filter { p -> !p.isProduction }.size)
-
     Assert.assertNotEquals("Nonsense!", cacheFile.readText())
   }
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountRegistryFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountRegistryFragment.kt
@@ -24,7 +24,6 @@ import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryStatus
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.navigation.api.NavigationControllers
-import org.nypl.simplified.profiles.api.ProfilePreferences
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.threads.NamedThreadPools
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
@@ -97,37 +96,22 @@ class AccountRegistryFragment : Fragment() {
    */
 
   private fun determineAvailableAccountProviderDescriptions(): List<AccountProviderDescription> {
-
-    val profileCurrent =
-      this.profilesController.profileCurrent()
-    val preferences =
-      profileCurrent.preferences()
-
     val usedAccountProviders =
       this.profilesController
         .profileCurrentlyUsedAccountProviders()
         .map { p -> p.toDescription() }
 
-    this.logger.debug("should show testing providers: {}", preferences.showTestingLibraries)
     this.logger.debug("profile is using {} providers", usedAccountProviders.size)
 
     val availableAccountProviders =
       this.accountRegistry.accountProviderDescriptions()
         .values
-        .filter { provider -> this.shouldShowProvider(provider, preferences) }
         .toMutableList()
-
     availableAccountProviders.removeAll(usedAccountProviders)
 
     this.logger.debug("returning {} available providers", availableAccountProviders.size)
     return availableAccountProviders
   }
-
-  private fun shouldShowProvider(
-    provider: AccountProviderDescription,
-    preferences: ProfilePreferences
-  ) =
-    provider.isProduction || preferences.showTestingLibraries
 
   @UiThread
   private fun onAccountClicked(account: AccountProviderDescription) {


### PR DESCRIPTION
**What's this do?**
The list of testing libraries already includes the production libraries, so only load one or the other. This means the testing libraries are no longer just appended to the end of the list (making them difficult to find).

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2858

**How should this be tested? / Do these changes have associated tests?**
Make sure enabling testing libraries in debug settings works as expected.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the Vanilla app.