### PR TITLE
SIMPLY-2507: Upgrade audiobook-android to 6.0.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ ext {
     useNYPLNexusDepend = true
   }
 
-  nyplAudioBookAPIVersion = "5.0.2"
+  nyplAudioBookAPIVersion = "6.0.0"
   nyplR2Version = "0.0.5"
 }
 

--- a/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookManifestRequest.kt
+++ b/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookManifestRequest.kt
@@ -10,6 +10,7 @@ import org.librarysimplified.audiobook.manifest_parser.api.ManifestParsers
 import org.librarysimplified.audiobook.manifest_parser.api.ManifestParsersType
 import org.librarysimplified.audiobook.manifest_parser.extension_spi.ManifestParserExtensionType
 import org.librarysimplified.services.api.ServiceDirectoryType
+import java.io.File
 import java.net.URI
 import java.util.ServiceLoader
 
@@ -96,5 +97,11 @@ data class AudioBookManifestRequest(
    */
 
   val manifestParsers: ManifestParsersType =
-    ManifestParsers
+    ManifestParsers,
+
+  /**
+   * The directory in which to store cache files.
+   */
+
+  val cacheDirectory: File
 )

--- a/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookManifestStrategy.kt
+++ b/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookManifestStrategy.kt
@@ -349,7 +349,8 @@ class AudioBookManifestStrategy(
         LicenseCheckParameters(
           manifest = manifest,
           userAgent = this.request.userAgent,
-          checks = this.request.licenseChecks
+          checks = this.request.licenseChecks,
+          cacheDirectory = this.request.cacheDirectory
         )
       )
 

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookBorrowTask.kt
@@ -1013,7 +1013,8 @@ class BookBorrowTask(
           contentType = targetContentType,
           userAgent = PlayerUserAgent(HTTP.userAgent()),
           credentials = audioBookCredentials,
-          services = this.services.services
+          services = this.services.services,
+          cacheDirectory = this.cacheDirectory
         )
       )
 

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookLoadingFragment.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookLoadingFragment.kt
@@ -134,7 +134,8 @@ class AudioBookLoadingFragment : Fragment() {
       this.playerParameters.toManifestStrategy(
         this.strategies,
         this.listener::onLoadingFragmentIsNetworkConnectivityAvailable,
-        credentials
+        credentials,
+        this.requireContext().cacheDir
       )
     return when (val strategyResult = strategy.execute()) {
       is TaskResult.Success -> {

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -425,7 +425,8 @@ class AudioBookPlayerActivity : AppCompatActivity(),
       this.parameters.toManifestStrategy(
         strategies = this.strategies,
         isNetworkAvailable = { this.networkConnectivity.isNetworkAvailable },
-        credentials = credentials
+        credentials = credentials,
+        cacheDirectory = this.cacheDir
       )
     return when (val strategyResult = strategy.execute()) {
       is TaskResult.Success -> {

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerParameters.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerParameters.kt
@@ -72,7 +72,8 @@ data class AudioBookPlayerParameters(
   fun toManifestStrategy(
     strategies: AudioBookManifestStrategiesType,
     isNetworkAvailable: () -> Boolean,
-    credentials: AccountAuthenticationCredentials?
+    credentials: AccountAuthenticationCredentials?,
+    cacheDirectory: File
   ): AudioBookManifestStrategyType {
 
     val manifestContentType =
@@ -103,7 +104,8 @@ data class AudioBookPlayerParameters(
         isNetworkAvailable = isNetworkAvailable,
         loadFallbackData = {
           ManifestFulfilled(manifestContentType, this.manifestFile.readBytes())
-        }
+        },
+        cacheDirectory = cacheDirectory
       )
 
     return strategies.createStrategy(request)


### PR DESCRIPTION
**What's this do?**

Upgrade audiobook-android to 6.0.0. This requires passing the `cacheDirectory` parameter to `LicenseCheckParameters` in order to configure caching for the signature check. This, in turn, requires adding a `cacheDirectory` parameter to `AudioBookManifestRequest`.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-2507](https://jira.nypl.org/browse/SIMPLY-2507).

**How should this be tested? / Do these changes have associated tests?**

Audiobook manifests containing an invalid signature should fail to download. All other audiobooks should continue to download successfully.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.