### PR TITLE
SIMPLY-3074: Remove unnecessary Readium API calls when a book is opened.

### DIFF
--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumJavaScriptAPI.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumJavaScriptAPI.java
@@ -172,7 +172,7 @@ public final class ReaderReadiumJavaScriptAPI implements ReaderReadiumJavaScript
   }
 
   @Override
-  public void setPageStyleSettings(
+  public void setBookStyles(
     final ReaderPreferences preferences) {
     try {
       final ReaderColorScheme cs = preferences.colorScheme();
@@ -204,7 +204,15 @@ public final class ReaderReadiumJavaScriptAPI implements ReaderReadiumJavaScript
       script.append(foreground);
       script.append("\";");
       this.evaluate(script.toString());
+    } catch (final JSONException e) {
+      LOG.error("error constructing json: {}", e.getMessage(), e);
+    }
+  }
 
+  @Override
+  public void updateSettings(
+    final ReaderPreferences preferences) {
+    try {
       final ReaderReadiumViewerSettings vs =
         new ReaderReadiumViewerSettings(
           ReaderReadiumViewerSettings.SyntheticSpreadMode.SINGLE,

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumJavaScriptAPIType.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumJavaScriptAPIType.java
@@ -83,11 +83,20 @@ public interface ReaderReadiumJavaScriptAPIType
   void pagePrevious();
 
   /**
-   * Configure the page style based on the given preferences.
+   * Configure book styles based on the given preferences.
    *
    * @param r The preferences
    */
 
-  void setPageStyleSettings(
+  void setBookStyles(
+    ReaderPreferences r);
+
+  /**
+   * Configure Readium settings based on the given preferences.
+   *
+   * @param r The preferences
+   */
+
+  void updateSettings(
     ReaderPreferences r);
 }


### PR DESCRIPTION
**What's this do?**

Remove unnecessary calls to the Readium API when a book is opened (`onReadiumContentDocumentLoaded`). Some of the calls are redundant with calls being made in other handlers. The rest can be moved into (`onReadiumFunctionInitialize`).

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-3074](https://jira.nypl.org/browse/SIMPLY-3074) (page turns not working when a book is opened).

Currently, SimplyE applies reader preferences (viewer settings and book styles) when a book is opened, in the `onReadiumContentDocumentLoaded` handler. This causes a race condition that can lead Readium to believe the book has no pages, so page turns don't work. Moving the calls into Readium initialization (before a book starts loading) allows Readium to have full control over when the settings and styles are applied, without the risk of SimplyE stepping on its feet.

See the comments in the JIRA issue for all the gory details.

**How should this be tested? / Do these changes have associated tests?**

When a book is opened, page turning should now consistently work. The user's style preferences (font face, font size, and colors) should continue to be applied, and the book should continue to open to the user's last position.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.