### PR TITLE
SIMPLY-3086: Various Card Creator Related bugs

### DIFF
--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AccountInformationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AccountInformationFragment.kt
@@ -40,6 +40,8 @@ class AccountInformationFragment : Fragment() {
 
   private val viewModel: UsernameViewModel by viewModels()
 
+  private var dialog: AlertDialog? = null
+
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
@@ -123,8 +125,10 @@ class AccountInformationFragment : Fragment() {
         .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
           dialog.cancel()
         }
-      val alert = dialogBuilder.create()
-      alert.show()
+      if (dialog == null) {
+        dialog = dialogBuilder.create()
+      }
+      dialog?.show()
     })
     viewModel.validateUsername(
       binding.usernameEt.text.toString(),
@@ -162,5 +166,10 @@ class AccountInformationFragment : Fragment() {
     val accountInformation = Cache(requireContext()).getAccountInformation()
     binding.pinEt.setText(accountInformation.pin, TextView.BufferType.EDITABLE)
     binding.usernameEt.setText(accountInformation.username, TextView.BufferType.EDITABLE)
+  }
+
+  override fun onPause() {
+    super.onPause()
+    dialog?.dismiss()
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AlternateAddressFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/AlternateAddressFragment.kt
@@ -45,6 +45,8 @@ class AlternateAddressFragment : Fragment(), AdapterView.OnItemSelectedListener 
 
   private val viewModel: AddressViewModel by viewModels()
 
+  private var dialog: AlertDialog? = null
+
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
@@ -170,8 +172,10 @@ class AlternateAddressFragment : Fragment(), AdapterView.OnItemSelectedListener 
         .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
           dialog.cancel()
         }
-      val alert = dialogBuilder.create()
-      alert.show()
+      if (dialog == null) {
+        dialog = dialogBuilder.create()
+      }
+      dialog?.show()
     })
     viewModel.validateAddress(
       Address(
@@ -248,5 +252,10 @@ class AlternateAddressFragment : Fragment(), AdapterView.OnItemSelectedListener 
       binding.etStreet1.setText(alternateAddress.line_1, TextView.BufferType.EDITABLE)
       binding.etCity.setText(alternateAddress.city, TextView.BufferType.EDITABLE)
     }
+  }
+
+  override fun onPause() {
+    super.onPause()
+    dialog?.dismiss()
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/HomeAddressFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/HomeAddressFragment.kt
@@ -38,6 +38,7 @@ class HomeAddressFragment : Fragment(), AdapterView.OnItemSelectedListener {
   private val addressCharsMin = 5
   private val validAddress = "valid-address"
   private val alternateAddress = "alternate-addresses"
+  private var dialog: AlertDialog? = null
 
   private val viewModel: AddressViewModel by viewModels()
 
@@ -120,6 +121,7 @@ class HomeAddressFragment : Fragment(), AdapterView.OnItemSelectedListener {
           response.address.zip)
         )
         nextAction = HomeAddressFragmentDirections.actionNext()
+
         navController.navigate(nextAction)
       } else {
         Toast.makeText(activity, response.message, Toast.LENGTH_SHORT).show()
@@ -141,8 +143,10 @@ class HomeAddressFragment : Fragment(), AdapterView.OnItemSelectedListener {
         .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
           dialog.cancel()
         }
-      val alert = dialogBuilder.create()
-      alert.show()
+      if (dialog == null) {
+          dialog = dialogBuilder.create()
+      }
+      dialog?.show()
     })
     viewModel.validateAddress(Address(AddressDetails(binding.etCity.text.toString(),
       binding.etStreet1.text.toString(),
@@ -210,5 +214,10 @@ class HomeAddressFragment : Fragment(), AdapterView.OnItemSelectedListener {
     binding.etZip.setText(homeAddress.zip, TextView.BufferType.EDITABLE)
     binding.etStreet1.setText(homeAddress.line_1, TextView.BufferType.EDITABLE)
     binding.etCity.setText(homeAddress.city, TextView.BufferType.EDITABLE)
+  }
+
+  override fun onPause() {
+    super.onPause()
+    dialog?.dismiss()
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/JuvenilePolicyFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/JuvenilePolicyFragment.kt
@@ -43,6 +43,8 @@ class JuvenilePolicyFragment : Fragment() {
   private val viewModel: TokenViewModel by viewModels()
   private val platformViewModel: PlatformViewModel by viewModels()
 
+  private var dialog: AlertDialog? = null
+
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
@@ -118,8 +120,10 @@ class JuvenilePolicyFragment : Fragment() {
             requireActivity().setResult(Activity.RESULT_CANCELED)
             requireActivity().finish()
           }
-        val alert = dialogBuilder.create()
-        alert.show()
+        if (dialog == null) {
+          dialog = dialogBuilder.create()
+        }
+        dialog?.show()
       }
     })
 
@@ -134,8 +138,10 @@ class JuvenilePolicyFragment : Fragment() {
         .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
           dialog.cancel()
         }
-      val alert = dialogBuilder.create()
-      alert.show()
+      if (dialog == null) {
+        dialog = dialogBuilder.create()
+      }
+      dialog?.show()
     })
 
     platformViewModel.apiError.observe(viewLifecycleOwner, Observer {
@@ -149,8 +155,10 @@ class JuvenilePolicyFragment : Fragment() {
         .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
           dialog.cancel()
         }
-      val alert = dialogBuilder.create()
-      alert.show()
+      if (dialog == null) {
+        dialog = dialogBuilder.create()
+      }
+      dialog?.show()
     })
 
     viewModel.apiError.observe(viewLifecycleOwner, Observer {
@@ -164,8 +172,10 @@ class JuvenilePolicyFragment : Fragment() {
         .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
           dialog.cancel()
         }
-      val alert = dialogBuilder.create()
-      alert.show()
+      if (dialog == null) {
+        dialog = dialogBuilder.create()
+      }
+      dialog?.show()
     })
 
     val callback = requireActivity().onBackPressedDispatcher.addCallback(this) {
@@ -209,5 +219,10 @@ class JuvenilePolicyFragment : Fragment() {
   override fun onDestroyView() {
     super.onDestroyView()
     _binding = null
+  }
+
+  override fun onPause() {
+    super.onPause()
+    dialog?.dismiss()
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
@@ -52,6 +52,8 @@ class LocationFragment : Fragment(), LocationListener {
 
   private val locationRequestCode = 102
 
+  private var dialog: AlertDialog? = null
+
   override fun onAttach(context: Context) {
     super.onAttach(context)
     locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
@@ -76,6 +78,7 @@ class LocationFragment : Fragment(), LocationListener {
   override fun onPause() {
     super.onPause()
     locationManager.removeUpdates(this)
+    dialog?.dismiss()
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -139,8 +142,10 @@ class LocationFragment : Fragment(), LocationListener {
         initialLocationCheckCompleted = true
         dialog.cancel()
       }
-    val alert = dialogBuilder.create()
-    alert.show()
+    if (dialog == null) {
+      dialog = dialogBuilder.create()
+    }
+    dialog?.show()
   }
 
   /**
@@ -157,8 +162,10 @@ class LocationFragment : Fragment(), LocationListener {
       .setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
         dialog.cancel()
       }
-    val alert = dialogBuilder.create()
-    alert.show()
+    if (dialog == null) {
+      dialog = dialogBuilder.create()
+    }
+    dialog?.show()
   }
 
   /**

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ReviewFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ReviewFragment.kt
@@ -45,6 +45,8 @@ class ReviewFragment : Fragment() {
   private val viewModel: PatronViewModel by viewModels()
   private val platformViewModel: PlatformViewModel by viewModels()
 
+  private var dialog: AlertDialog? = null
+
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
@@ -133,8 +135,10 @@ class ReviewFragment : Fragment() {
           requireActivity().setResult(Activity.RESULT_CANCELED)
           requireActivity().finish()
         }
-      val alert = dialogBuilder.create()
-      alert.show()
+      if (dialog == null) {
+        dialog = dialogBuilder.create()
+      }
+      dialog?.show()
     })
 
     platformViewModel.apiError.observe(viewLifecycleOwner, Observer {
@@ -154,8 +158,10 @@ class ReviewFragment : Fragment() {
           requireActivity().setResult(Activity.RESULT_CANCELED)
           requireActivity().finish()
         }
-      val alert = dialogBuilder.create()
-      alert.show()
+      if (dialog == null) {
+        dialog = dialogBuilder.create()
+      }
+      dialog?.show()
     })
 
     val callback = requireActivity().onBackPressedDispatcher.addCallback(this) {
@@ -300,5 +306,10 @@ class ReviewFragment : Fragment() {
   override fun onDestroyView() {
     super.onDestroyView()
     _binding = null
+  }
+
+  override fun onPause() {
+    super.onPause()
+    dialog?.dismiss()
   }
 }

--- a/simplified-cardcreator/src/main/res/navigation/nav_graph.xml
+++ b/simplified-cardcreator/src/main/res/navigation/nav_graph.xml
@@ -175,10 +175,12 @@
 
         <argument
             android:name="username"
-            app:argType="string" />
+            app:argType="string"
+            android:defaultValue='""' />
         <argument
             android:name="barcode"
-            app:argType="string" />
+            app:argType="string"
+            android:defaultValue='""' />
         <argument
             android:name="pin"
             app:argType="string" />


### PR DESCRIPTION
**What's this do?**
Various bugs have been seen in Crashlytics associated with the card creator. Most of them are related to the user exiting the app and returning and attempting to interact with dialogs. This changes how dialogs are instantiated and dismissed to relieve the crashes. Additionally, default values are setup for the barcode and username in the confirmation screen.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-3086: Various Card Creator Related bugs](https://jira.nypl.org/browse/SIMPLY-3086)

**How should this be tested? / Do these changes have associated tests?**
1. Access the card creator and enter a valid home address in airplane mode. A dialog will be presented.
2. Background the app and turn networking back on.
3. The dialog should be dismissed

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly @twaddington has also seen this working.