### PR TITLE
SIMPLY-3088: Fix chapter progress in Readium 1 bookmarks.

### DIFF
--- a/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookChapterProgress.kt
+++ b/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookChapterProgress.kt
@@ -1,5 +1,7 @@
 package org.nypl.simplified.books.api
 
+import java.io.Serializable
+
 /**
  * Progress through a specific chapter.
  */
@@ -17,4 +19,4 @@ data class BookChapterProgress(
    */
 
   val chapterProgress: Double
-)
+) : Serializable

--- a/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookmarkJSON.kt
+++ b/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookmarkJSON.kt
@@ -60,10 +60,26 @@ object BookmarkJSON {
     node: ObjectNode
   ): Bookmark {
 
+    // Older bookmarks store chapter progress in a top-level property, instead of inside
+    // location.progress.
+
+    val chapterProgress = JSONParserUtilities.getDouble(node, "chapterProgress")
+
+    val deserializedLocation = BookLocationJSON.deserializeFromJSON(
+      objectMapper, JSONParserUtilities.getObject(node, "location"))
+
+    val location =
+      if (deserializedLocation.progress == null && chapterProgress != null)
+        // If this is an older bookmark, move the chapter progress into location.progress. In this
+        // case the chapter index is unknown.
+        deserializedLocation.copy(progress = BookChapterProgress(0, chapterProgress))
+      else
+        deserializedLocation
+
     return Bookmark(
       opdsId = JSONParserUtilities.getString(node, "opdsId"),
       kind = kind,
-      location = BookLocationJSON.deserializeFromJSON(objectMapper, JSONParserUtilities.getObject(node, "location")),
+      location = location,
       time = LocalDateTime.parse(JSONParserUtilities.getString(node, "time")),
       chapterTitle = JSONParserUtilities.getString(node, "chapterTitle"),
       bookProgress = JSONParserUtilities.getDouble(node, "bookProgress"),

--- a/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookmarkJSON.kt
+++ b/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookmarkJSON.kt
@@ -69,12 +69,13 @@ object BookmarkJSON {
       objectMapper, JSONParserUtilities.getObject(node, "location"))
 
     val location =
-      if (deserializedLocation.progress == null && chapterProgress != null)
+      if (deserializedLocation.progress == null && chapterProgress != null) {
         // If this is an older bookmark, move the chapter progress into location.progress. In this
         // case the chapter index is unknown.
         deserializedLocation.copy(progress = BookChapterProgress(0, chapterProgress))
-      else
+      } else {
         deserializedLocation
+      }
 
     return Bookmark(
       opdsId = JSONParserUtilities.getString(node, "opdsId"),

--- a/simplified-tests/src/main/java/org/nypl/simplified/tests/books/api/BookmarkJSONContract.kt
+++ b/simplified-tests/src/main/java/org/nypl/simplified/tests/books/api/BookmarkJSONContract.kt
@@ -1,0 +1,71 @@
+package org.nypl.simplified.tests.books.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.Assert
+import org.junit.Test
+import org.nypl.simplified.books.api.BookmarkJSON
+import org.nypl.simplified.books.api.BookmarkKind
+
+abstract class BookmarkJSONContract {
+
+  /**
+   * Deserialize JSON representing a bookmark with a top-level chapterProgress prooperty. Older
+   * bookmarks had this structure. The top-level chapterProgress should be deserialized into
+   * location.progress.chapterProgress.
+   */
+  @Test
+  fun testDeserializeJSONWithTopLevelChapterProgress() {
+    val bookmark = BookmarkJSON.deserializeFromString(
+      objectMapper = ObjectMapper(),
+      kind = BookmarkKind.ReaderBookmarkExplicit,
+      serialized = """
+        {
+          "opdsId" : "urn:isbn:9781683609438",
+          "location" : {
+            "contentCFI" : "/4/2[is-that-you-walt-whitman]/4[is-that-you-walt-whitman-text]/78/1:287",
+            "idref" : "is-that-you-walt-whitman-xhtml"
+          },
+          "time" : "2020-09-16T14:51:46.238",
+          "chapterTitle" : "Is That You, Walt Whitman?",
+          "chapterProgress" : 0.4736842215061188,
+          "bookProgress" : 0.49,
+          "deviceID" : "null"
+        }
+      """
+    )
+
+    Assert.assertEquals(0.4736842215061188, bookmark.location.progress!!.chapterProgress, .0001)
+  }
+
+  /**
+   * Deserialize JSON representing a bookmark with chapterProgress nested in location.progress.
+   */
+  @Test
+  fun testDeserializeJSONWithNestedChapterProgress() {
+    val bookmark = BookmarkJSON.deserializeFromString(
+      objectMapper = ObjectMapper(),
+      kind = BookmarkKind.ReaderBookmarkExplicit,
+      serialized = """
+        {
+          "opdsId" : "urn:isbn:9781683601111",
+          "location" : {
+            "contentCFI" : "/4/2[the-end-of-coney-island-avenue]/4[the-end-of-coney-island-avenue-text]/84/1:325",
+            "idref" : "the-end-of-coney-island-avenue-xhtml",
+            "progress" : {
+              "chapterIndex" : 9,
+              "chapterProgress" : 0.4285714328289032
+            }
+          },
+          "time" : "2020-09-16T19:07:21.455",
+          "chapterTitle" : "The End of Coney Island Avenue",
+          "chapterProgress" : 0.4285714328289032,
+          "bookProgress" : 0.34,
+          "deviceID" : "null"
+        }
+      """
+    )
+
+    Assert.assertEquals(9, bookmark.location.progress!!.chapterIndex)
+    Assert.assertEquals(0.4285714328289032, bookmark.location.progress!!.chapterProgress, .0001)
+  }
+}

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/local/books/api/BookmarkJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/local/books/api/BookmarkJSONTest.kt
@@ -1,0 +1,5 @@
+package org.nypl.simplified.tests.local.books.api
+
+import org.nypl.simplified.tests.books.api.BookmarkJSONContract
+
+class BookmarkJSONTest : BookmarkJSONContract()

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
@@ -43,6 +43,7 @@ import org.nypl.simplified.accounts.database.api.AccountsDatabaseNonexistentExce
 import org.nypl.simplified.analytics.api.AnalyticsEvent;
 import org.nypl.simplified.analytics.api.AnalyticsType;
 import org.nypl.simplified.app.reader.ReaderColorSchemes;
+import org.nypl.simplified.books.api.BookChapterProgress;
 import org.nypl.simplified.books.api.BookDRMInformation;
 import org.nypl.simplified.books.api.BookFormat;
 import org.nypl.simplified.books.api.BookID;
@@ -557,10 +558,17 @@ public final class ReaderActivity extends AppCompatActivity implements
     Objects.requireNonNull(location);
     LOG.debug("onCurrentPageReceived: {}", location);
 
+    // Add the current chapter progress to the location.
+
+    BookLocation currentLocation = new BookLocation(
+      new BookChapterProgress(current_page_index, currentChapterProgress()),
+      location.getContentCFI(),
+      location.getIdRef());
+
     final Bookmark bookmark =
       new Bookmark(
         this.feed_entry.getID(),
-        location,
+        currentLocation,
         BookmarkKind.ReaderBookmarkLastReadLocation.INSTANCE,
         LocalDateTime.now(),
         this.current_chapter_title,


### PR DESCRIPTION
**What's this do?**

Fix chapter progress not being saved in newly created Readium 1 bookmarks, and saved bookmarks incorrectly showing "0% through chapter".

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-3088](https://jira.nypl.org/browse/SIMPLY-3088).

**How should this be tested? / Do these changes have associated tests?**

Create a bookmark that is not on the first page of a chapter. Open the bookmarks list. The bookmark should show the correct chapter progress % (not 0%). The bookmark should open to the correct page (not the first page).

In an older version of the app (before commit 15d8033851ad2bee28406457dcdb8bb58b2d14a4), create a bookmark that is not on the first page of the chapter. In the bookmarks list, verify that the correct chapter progress % is shown. Upgrade the app to a version after that commit. Open the bookmarks list. The bookmark created in the old version should continue to show the correct chapter progress % (not 0%).

Unit tests are included for deserializing saved bookmarks.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.