### PR TITLE
SIMPLY-3089: Follow 303 (see other) redirects.

### DIFF
--- a/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTPRedirectFollower.java
+++ b/simplified-http-core/src/main/java/org/nypl/simplified/http/core/HTTPRedirectFollower.java
@@ -168,6 +168,7 @@ public final class HTTPRedirectFollower
     switch (code) {
       case HttpURLConnection.HTTP_MOVED_PERM:
       case HttpURLConnection.HTTP_MOVED_TEMP:
+      case HttpURLConnection.HTTP_SEE_OTHER:
       case 307:
       case 308: {
 


### PR DESCRIPTION
**What's this do?**

Follow 303 (see other) redirects when downloading content.

**Why are we doing this? (w/ JIRA link if applicable)**

This is needed to fulfill content from Internet Archive, which sends 303 redirects.

**How should this be tested? / Do these changes have associated tests?**

Download a book from Internet Archive, e.g. from Montana State Library (account info available from Lyrasis), "Montana cassette catalog update, June 1993 - September 1995". The download should succeed.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.