### PR TITLE
SIMPLY-3124: Fix incorrect pagination after changing reader settings.

### DIFF
--- a/simplified-viewer-epub-readium1/src/main/assets/fonts.css
+++ b/simplified-viewer-epub-readium1/src/main/assets/fonts.css
@@ -1,0 +1,5 @@
+@font-face {
+  font-family: 'OpenDyslexic3';
+  src: url('OpenDyslexic3-Regular.ttf');
+  font-weight: normal;
+}

--- a/simplified-viewer-epub-readium1/src/main/assets/host_app_feedback.js
+++ b/simplified-viewer-epub-readium1/src/main/assets/host_app_feedback.js
@@ -92,7 +92,21 @@ $(document).ready(function()
       var opts = {
         needsFixedLayoutScalerWorkAround: true,
         el: "#viewport",
-        annotationCSSUrl: '/readium_Annotations.css'
+        annotationCSSUrl: '/readium_Annotations.css',
+        fonts: [
+          {
+            fontFamily: "serif",
+            url: "/fonts.css"
+          },
+          {
+            fontFamily: "sans-serif",
+            url: "/fonts.css"
+          },
+          {
+            fontFamily: "OpenDyslexic3",
+            url: "/fonts.css"
+          }
+        ]
       };
 
       ReadiumSDK.reader = new ReaderView(opts);

--- a/simplified-viewer-epub-readium1/src/main/assets/simplified.js
+++ b/simplified-viewer-epub-readium1/src/main/assets/simplified.js
@@ -119,49 +119,15 @@ function Simplified() {
     contentDocument.addEventListener("touchstart", handleTouchStart, false);
     contentDocument.removeEventListener("touchend", handleTouchEnd);
     contentDocument.addEventListener("touchend", handleTouchEnd, false);
+    // SIMPLY-3124: Remove the page turn animation, as this interferes with Readium.
     // Set up the page turning animation. This works because Readium adjusts the
     // `left` property of its iframe document to advance pages.
-    contentDocument.documentElement.style["transition"] = "left 0.2s";
+    // contentDocument.documentElement.style["transition"] = "left 0.2s";
     // Tell the browser to expect the `left` property to change. This allows the
     // the browser to set things up in advance to achieve better performance
     // whenever the property is altered.
-    contentDocument.documentElement.style["will-change"] = "left";
-
-    // Load the font family if it's not already there when the new
-    // page gets rendered.
-    this.linkOpenDyslexicFonts(contentDocument);
+    // contentDocument.documentElement.style["will-change"] = "left";
   };
-
-  /**
-   * TODO:
-   * Even though the OpenDyslexic3 font is now added to the renderer,
-   * there are still underlying issues with rendering this font. Specifically,
-   * pages at the end of chapters get lost when using this
-   * (and only this) font.
-   */
-
-  /**
-   * linkOpenDyslexicFonts
-   * If the current Open Dyslexic font is loaded on the page, do not
-   * load it again. If there's a currently selected font by the user,
-   * update the style to reflect it. This is needed when going from
-   * chapter to chapter.
-   */
-  this.linkOpenDyslexicFonts = function(innerDocument) {
-    var id = 'simplified-opendyslexic';
-    if (innerDocument.getElementById(id)) {
-      return;
-    }
-    var styleElement = document.createElement('style');
-    styleElement.id = id;
-    styleElement.textContent =
-      "@font-face { \
-        font-family: 'OpenDyslexic3'; \
-        src: url('OpenDyslexic3-Regular.ttf'); \
-        font-weight: normal; \
-      }";
-    innerDocument.head.appendChild(styleElement);
-  }
 }
 
 simplified = new Simplified();

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumJavaScriptAPI.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumJavaScriptAPI.java
@@ -158,19 +158,6 @@ public final class ReaderReadiumJavaScriptAPI implements ReaderReadiumJavaScript
     this.evaluate("ReadiumSDK.reader.openPageLeft();");
   }
 
-  private static String fontFamilyName(
-    final ReaderFontSelection selection) {
-    switch (selection) {
-      case READER_FONT_SANS_SERIF:
-        return "sans-serif";
-      case READER_FONT_OPEN_DYSLEXIC:
-        return "OpenDyslexic3";
-      case READER_FONT_SERIF:
-        return "serif";
-    }
-    throw new UnreachableCodeException();
-  }
-
   @Override
   public void setBookStyles(
     final ReaderPreferences preferences) {
@@ -179,12 +166,10 @@ public final class ReaderReadiumJavaScriptAPI implements ReaderReadiumJavaScript
 
       final String foreground = ReaderColorSchemes.foregroundAsBrowserHex(cs);
       final String background = ReaderColorSchemes.backgroundAsBrowserHex(cs);
-      final String fontFamily = fontFamilyName(preferences.fontFamily());
 
       final JSONObject decls = new JSONObject();
       decls.put("color", foreground);
       decls.put("backgroundColor", background);
-      decls.put("font-family", fontFamily);
 
       final JSONObject o = new JSONObject();
       o.put("selector", "*");
@@ -217,6 +202,7 @@ public final class ReaderReadiumJavaScriptAPI implements ReaderReadiumJavaScript
         new ReaderReadiumViewerSettings(
           ReaderReadiumViewerSettings.SyntheticSpreadMode.SINGLE,
           ReaderReadiumViewerSettings.ScrollMode.AUTO,
+          preferences.fontFamily(),
           (int) preferences.fontScale(),
           20);
 

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumViewerSettings.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderReadiumViewerSettings.java
@@ -1,9 +1,11 @@
 package org.nypl.simplified.viewer.epub.readium1;
 
 import com.io7m.jnull.NullCheck;
+import com.io7m.junreachable.UnreachableCodeException;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.nypl.simplified.reader.api.ReaderFontSelection;
 
 /**
  * The current viewer settings.
@@ -13,6 +15,7 @@ public final class ReaderReadiumViewerSettings
   implements ReaderJSONSerializableType
 {
   private final int                 column_gap;
+  private final ReaderFontSelection font_selection;
   private final int                 font_size;
   private final ScrollMode          scroll_mode;
   private final SyntheticSpreadMode synthetic_spread;
@@ -22,6 +25,7 @@ public final class ReaderReadiumViewerSettings
    *
    * @param in_synthetic_spread The synthetic spread mode
    * @param in_scroll_mode      The scroll mode
+   * @param in_font_selection   The font selection
    * @param in_font_size        The font size
    * @param in_column_gap       The column gap
    */
@@ -29,11 +33,13 @@ public final class ReaderReadiumViewerSettings
   public ReaderReadiumViewerSettings(
     final SyntheticSpreadMode in_synthetic_spread,
     final ScrollMode in_scroll_mode,
+    final ReaderFontSelection in_font_selection,
     final int in_font_size,
     final int in_column_gap)
   {
     this.synthetic_spread = NullCheck.notNull(in_synthetic_spread);
     this.scroll_mode = NullCheck.notNull(in_scroll_mode);
+    this.font_selection = in_font_selection;
     this.font_size = in_font_size;
     this.column_gap = in_column_gap;
   }
@@ -45,6 +51,15 @@ public final class ReaderReadiumViewerSettings
   public int getColumnGap()
   {
     return this.column_gap;
+  }
+
+  /**
+   * @return The font selection
+   */
+
+  public ReaderFontSelection getFontSelection()
+  {
+    return this.font_selection;
   }
 
   /**
@@ -74,12 +89,31 @@ public final class ReaderReadiumViewerSettings
     return this.synthetic_spread;
   }
 
+  /**
+   * @return The Readium index number of the font.
+   */
+  private static int readiumFontIndex(
+    final ReaderFontSelection selection) {
+    switch (selection) {
+      // These index values must correspond to the ordering of the fonts passed to the ReaderView
+      // constructor in host_app_feedback.js.
+      case READER_FONT_SERIF:
+        return 1;
+      case READER_FONT_SANS_SERIF:
+        return 2;
+      case READER_FONT_OPEN_DYSLEXIC:
+        return 3;
+    }
+    throw new UnreachableCodeException();
+  }
+
   @Override public JSONObject toJSON()
     throws JSONException
   {
     final JSONObject json = new JSONObject();
     json.put("syntheticSpread", this.synthetic_spread.getValue());
     json.put("scroll", this.scroll_mode.getValue());
+    json.put("fontSelection", readiumFontIndex(this.font_selection));
     json.put("fontSize", this.font_size);
     json.put("columnGap", this.column_gap);
     return json;


### PR DESCRIPTION
**What's this do?**

Remove the page turn transition animation, refactor font handling, and refactor `applyReaderPreferences` to remove unnecessary Readium API calls.

The CSS transition to create the page turn animation is removed. When the transition is present, Readium can operate on the DOM when it is in a transitional state, causing it to calculate an incorrect page number/number of pages.

Font loading and changing are refactored to use Readium APIs instead of side-loading through CSS. This prevents Readium from doing DOM operations before a font has loaded.

`applyReaderPreferences` is refactored to remove unneeded calls that can cause race conditions. Currently, `applyReaderPreferences` does the following: https://github.com/NYPL-Simplified/Simplified-Android-Core/blob/c96815761016d0b4687c6781ead97acc58ae242c/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java#L524-L538

- `setBookStyles` and `applyViewerColorScheme` only need to be called if the color scheme is changed.
- `updateSettings` only needs to be called if the font family or font scale is changed.
- `getReadiumCFI` and `setReadiumCFI` don't need to be called, because when the font family or scale is changed, `updateSettings` already saves and restores the current reading position; and when the color scheme is changed, it can't cause a change in pagination.
- `getCurrentPage` and `mediaOverlayIsAvailable` don't need to be called here, because if the pagination changes, they will be called in `onReadiumFunctionPaginationChanged`.

Also, the call to `pageHasChanged` is moved from `onReadiumFunctionPaginationChanged` to `onReadiumContentDocumentLoaded`, which is more appropriate. I'm not sure if it was causing any problems, but it was doing extra work, because it only needs to be run when the content document has been loaded, not whenever its page layout changes.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-3124](https://jira.nypl.org/browse/SIMPLY-3124).

**How should this be tested? / Do these changes have associated tests?**

Open a book to the middle of a chapter. Change the font and font size. In the chapter progress at the bottom of the screen, the current page and number of pages may change, but they should reflect the actual page displayed, and the actual number of pages in the chapter. Change the color scheme. The current page and number of pages should not change.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.
