### PR TITLE
Update to audiobooks 6.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ ext {
     useNYPLNexusDepend = true
   }
 
-  nyplAudioBookAPIVersion = "6.0.0"
+  nyplAudioBookAPIVersion = "6.0.2"
   nyplR2Version = "0.0.5"
 }
 


### PR DESCRIPTION
Affects: https://jira.nypl.org/browse/SIMPLY-2947

**What's this do?**
Uses the latest audiobooks release.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2947

**How should this be tested? / Do these changes have associated tests?**
Open an Overdrive audio book and check:

1. Play an audiobook. The first second of audio should not be repeated. 
2. Navigate to a different spine item from the TOC. The first second of audio should not be repeated.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ray-lee on the original audiobooks PR