### PR TITLE
Ensure DPLA audio books are used correctly

### DIFF
--- a/simplified-books-formats-api/src/main/java/org/nypl/simplified/books/formats/api/StandardFormatNames.kt
+++ b/simplified-books-formats-api/src/main/java/org/nypl/simplified/books/formats/api/StandardFormatNames.kt
@@ -42,6 +42,13 @@ object StandardFormatNames {
     this.mimeOf("application/vnd.overdrive.circulation.api+json;profile=audiobook")
 
   /**
+   * The standard format name for DPLA audio books.
+   */
+
+  val dplaAudioBooks =
+    this.mimeOf("application/audiobook+json;profile=http://www.feedbooks.com/audiobooks/access-restriction")
+
+  /**
    * Various standard format names used for generic, unencrypted audio books.
    */
 
@@ -60,6 +67,7 @@ object StandardFormatNames {
       val types = mutableSetOf<MIMEType>()
       types.add(this.findawayAudioBooks)
       types.add(this.overdriveAudioBooks)
+      types.add(this.dplaAudioBooks)
       types.addAll(this.genericAudioBooks)
       types.toSet()
     }

--- a/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupport.kt
+++ b/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupport.kt
@@ -62,6 +62,9 @@ class BookFormatSupport private constructor(
       if (audio.supportsOverdriveAudioBooks) {
         types.add(StandardFormatNames.overdriveAudioBooks)
       }
+      if (audio.supportsDPLAAudioBooks) {
+        types.add(StandardFormatNames.dplaAudioBooks)
+      }
     }
   }
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/formats/BookFormatSupportContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/formats/BookFormatSupportContract.kt
@@ -151,6 +151,135 @@ abstract class BookFormatSupportContract {
   }
 
   /**
+   * DPLA audio book support is correctly handled.
+   */
+
+  @Test
+  fun testAudioSupportedDPLA() {
+    val supportWith =
+      BookFormatSupport.create(
+        BookFormatSupportParameters(
+          supportsPDF = false,
+          supportsAdobeDRM = false,
+          supportsAudioBooks = BookFormatAudioSupportParameters(
+            supportsFindawayAudioBooks = false,
+            supportsOverdriveAudioBooks = false,
+            supportsDPLAAudioBooks = true
+          )
+        )
+      )
+    val supportWithout =
+      BookFormatSupport.create(
+        BookFormatSupportParameters(
+          supportsPDF = false,
+          supportsAdobeDRM = false,
+          supportsAudioBooks = null
+        )
+      )
+
+    Assert.assertTrue(
+      supportWith.isSupportedPath(
+        listOf(
+          StandardFormatNames.dplaAudioBooks
+        )
+      )
+    )
+    Assert.assertFalse(
+      supportWithout.isSupportedPath(
+        listOf(
+          StandardFormatNames.dplaAudioBooks
+        )
+      )
+    )
+  }
+
+  /**
+   * Overdrive audio book support is correctly handled.
+   */
+
+  @Test
+  fun testAudioSupportedOverdrive() {
+    val supportWith =
+      BookFormatSupport.create(
+        BookFormatSupportParameters(
+          supportsPDF = false,
+          supportsAdobeDRM = false,
+          supportsAudioBooks = BookFormatAudioSupportParameters(
+            supportsFindawayAudioBooks = false,
+            supportsOverdriveAudioBooks = true,
+            supportsDPLAAudioBooks = false
+          )
+        )
+      )
+    val supportWithout =
+      BookFormatSupport.create(
+        BookFormatSupportParameters(
+          supportsPDF = false,
+          supportsAdobeDRM = false,
+          supportsAudioBooks = null
+        )
+      )
+
+    Assert.assertTrue(
+      supportWith.isSupportedPath(
+        listOf(
+          StandardFormatNames.overdriveAudioBooks
+        )
+      )
+    )
+    Assert.assertFalse(
+      supportWithout.isSupportedPath(
+        listOf(
+          StandardFormatNames.overdriveAudioBooks
+        )
+      )
+    )
+  }
+
+  /**
+   * Findaway audio book support is correctly handled.
+   */
+
+  @Test
+  fun testAudioSupportedFindaway() {
+    val supportWith =
+      BookFormatSupport.create(
+        BookFormatSupportParameters(
+          supportsPDF = false,
+          supportsAdobeDRM = false,
+          supportsAudioBooks = BookFormatAudioSupportParameters(
+            supportsFindawayAudioBooks = true,
+            supportsOverdriveAudioBooks = false,
+            supportsDPLAAudioBooks = false
+          )
+        )
+      )
+    val supportWithout =
+      BookFormatSupport.create(
+        BookFormatSupportParameters(
+          supportsPDF = false,
+          supportsAdobeDRM = false,
+          supportsAudioBooks = null
+        )
+      )
+
+    Assert.assertTrue(
+      supportWith.isSupportedPath(
+        listOf(
+          StandardFormatNames.findawayAudioBooks
+        )
+      )
+    )
+    Assert.assertFalse(
+      supportWithout.isSupportedPath(
+        listOf(
+          StandardFormatNames.findawayAudioBooks
+        )
+      )
+    )
+  }
+
+  /**
    * Some types can't be final types.
    */
 


### PR DESCRIPTION

**What's this do?**
DPLA audio books use a content type that uses a custom profile. These
changes ensure that we handle all of the possible types correctly.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/SIMPLY-2301

**How should this be tested? / Do these changes have associated tests?**
Ensure that books in the DPLA Audiobook Test collection can be downloaded and read.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m tested the two books in the collection.