### PR TITLE
Refactor custom OPDS creation to use new HTTP client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
 
   nyplAudioBookAPIVersion = "6.1.0"
   nyplR2Version = "0.0.5"
-  nyplHTTPVersion = "0.0.13"
+  nyplHTTPVersion = "0.0.14"
   irradiaMimeVersion = "1.1.1"
 }
 

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowHTTP.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowHTTP.kt
@@ -5,7 +5,6 @@ import one.irradia.mime.api.MIMEType
 import org.librarysimplified.http.api.LSHTTPAuthorizationBasic
 import org.librarysimplified.http.api.LSHTTPAuthorizationBearerToken
 import org.librarysimplified.http.api.LSHTTPAuthorizationType
-import org.librarysimplified.http.api.LSHTTPProblemReport
 import org.librarysimplified.http.downloads.LSHTTPDownloadRequest
 import org.librarysimplified.http.downloads.LSHTTPDownloadState
 import org.librarysimplified.http.downloads.LSHTTPDownloadState.DownloadReceiving
@@ -34,26 +33,6 @@ import java.net.URI
  */
 
 object BorrowHTTP {
-
-  /**
-   * Encode the given problem report as a set of presentable attributes.
-   */
-
-  fun problemReportAsAttributes(
-    problemReport: LSHTTPProblemReport?
-  ): Map<String, String> {
-    return when (problemReport) {
-      null -> mapOf()
-      else -> {
-        val attributes = mutableMapOf<String, String>()
-        attributes["HTTP problem detail"] = problemReport.detail ?: ""
-        attributes["HTTP problem status"] = problemReport.status.toString()
-        attributes["HTTP problem title"] = problemReport.title ?: ""
-        attributes["HTTP problem type"] = problemReport.type.toString()
-        attributes.toMap()
-      }
-    }
-  }
 
   /**
    * Create a download request for the given URI, downloading content to the given output file.
@@ -148,7 +127,7 @@ object BorrowHTTP {
     result: DownloadFailedServer
   ): BorrowSubtaskFailed {
     val status = result.responseStatus
-    context.taskRecorder.addAttributes(BorrowHTTP.problemReportAsAttributes(status.problemReport))
+    context.taskRecorder.addAttributes(status.problemReport?.toMap() ?: emptyMap())
     context.taskRecorder.currentStepFailed(
       message = "HTTP request failed: ${status.originalStatus} ${status.message}",
       errorCode = BorrowErrorCodes.httpRequestFailed,

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLoanCreate.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLoanCreate.kt
@@ -117,10 +117,10 @@ class BorrowLoanCreate private constructor() : BorrowSubtaskType {
     context: BorrowContextType,
     status: LSHTTPResponseStatus.Responded.Error
   ) {
-    context.taskRecorder.addAttributes(BorrowHTTP.problemReportAsAttributes(status.problemReport))
-
     val report = status.problemReport
     if (report != null) {
+      context.taskRecorder.addAttributes(report.toMap())
+
       if (report.type == "http://librarysimplified.org/terms/problem/loan-already-exists") {
         context.taskRecorder.currentStepSucceeded("It turns out we already had a loan for this book.")
         context.bookPublishStatus(

--- a/simplified-books-controller/build.gradle
+++ b/simplified-books-controller/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
   implementation libraries.kotlinStdlib
   implementation libraries.nyplAudiobookManifestFulfillAPI
+  implementation libraries.nyplHttpAPI
   implementation libraries.slf4j
 
   compileOnly libraries.autoValue

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
@@ -11,6 +11,7 @@ import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import io.reactivex.subjects.Subject
 import org.joda.time.Instant
+import org.librarysimplified.http.api.LSHTTPClientType
 import org.librarysimplified.services.api.ServiceDirectoryType
 import org.nypl.drm.core.AdobeAdeptExecutorType
 import org.nypl.simplified.accounts.api.AccountEvent
@@ -112,6 +113,8 @@ class Controller private constructor(
     this.services.requireService(OPDSFeedParserType::class.java)
   private val http =
     this.services.requireService(HTTPType::class.java)
+  private val lsHttp =
+    this.services.requireService(LSHTTPClientType::class.java)
   private val patronUserProfileParsers =
     this.services.requireService(PatronUserProfileParsersType::class.java)
   private val profileAccountCreationStringResources =
@@ -366,7 +369,7 @@ class Controller private constructor(
       ProfileAccountCreateCustomOPDSTask(
         accountEvents = this.accountEvents,
         accountProviderRegistry = this.accountProviders,
-        http = this.http,
+        httpClient = this.lsHttp,
         opdsURI = opdsFeed,
         opdsFeedParser = this.feedParser,
         profiles = this.profiles,

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/ProfileAccountCreateCustomOPDSContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/ProfileAccountCreateCustomOPDSContract.kt
@@ -3,9 +3,9 @@ package org.nypl.simplified.tests.books.controller
 import android.content.Context
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.google.common.util.concurrent.MoreExecutors
-import com.io7m.jfunctional.Option
 import io.reactivex.subjects.PublishSubject
-import org.joda.time.DateTime
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.joda.time.Instant
 import org.junit.After
 import org.junit.Assert
@@ -13,6 +13,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
+import org.librarysimplified.http.api.LSHTTPClientConfiguration
+import org.librarysimplified.http.api.LSHTTPClientType
+import org.librarysimplified.http.vanilla.LSHTTPClients
 import org.mockito.Mockito
 import org.nypl.simplified.accounts.api.AccountEvent
 import org.nypl.simplified.accounts.api.AccountID
@@ -29,20 +32,13 @@ import org.nypl.simplified.books.bundled.api.BundledContentResolverType
 import org.nypl.simplified.books.controller.ProfileAccountCreateCustomOPDSTask
 import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import org.nypl.simplified.content.api.ContentResolverType
-import org.nypl.simplified.feeds.api.FeedHTTPTransport
-import org.nypl.simplified.feeds.api.FeedLoader
 import org.nypl.simplified.feeds.api.FeedLoaderType
 import org.nypl.simplified.files.DirectoryUtilities
-import org.nypl.simplified.http.core.HTTPResultError
-import org.nypl.simplified.http.core.HTTPResultException
-import org.nypl.simplified.http.core.HTTPResultOK
 import org.nypl.simplified.opds.auth_document.api.AuthenticationDocumentParsersType
-import org.nypl.simplified.opds.core.OPDSAcquisitionFeed
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntryParser
 import org.nypl.simplified.opds.core.OPDSFeedParser
 import org.nypl.simplified.opds.core.OPDSFeedParserType
 import org.nypl.simplified.opds.core.OPDSParseException
-import org.nypl.simplified.opds.core.OPDSSearchParser
 import org.nypl.simplified.profiles.api.ProfileType
 import org.nypl.simplified.profiles.api.ProfilesDatabaseType
 import org.nypl.simplified.taskrecorder.api.TaskResult
@@ -50,14 +46,12 @@ import org.nypl.simplified.tests.MockAccountCreationStringResources
 import org.nypl.simplified.tests.MockAccountProviderRegistry
 import org.nypl.simplified.tests.MockAccountProviderResolutionStrings
 import org.nypl.simplified.tests.MockAccountProviders
-import org.nypl.simplified.tests.http.MockingHTTP
 import org.slf4j.Logger
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
-import java.net.URI
 import java.util.ArrayList
 import java.util.Collections
 import java.util.UUID
@@ -97,16 +91,17 @@ abstract class ProfileAccountCreateCustomOPDSContract {
   private lateinit var executorFeeds: ListeningExecutorService
   private lateinit var executorTimer: ListeningExecutorService
   private lateinit var feedLoader: FeedLoaderType
-  private lateinit var http: MockingHTTP
+  private lateinit var http: LSHTTPClientType
   private lateinit var opdsFeedParser: OPDSFeedParserType
   private lateinit var profileAccountCreationStrings: MockAccountCreationStringResources
   private lateinit var profilesDatabase: ProfilesDatabaseType
+  private lateinit var server: MockWebServer
 
   @Before
   @Throws(Exception::class)
   fun setUp() {
-    this.http = MockingHTTP()
     this.context = Mockito.mock(Context::class.java)
+    this.http = LSHTTPClients().create(this.context, LSHTTPClientConfiguration("test", "1.0.0"))
     this.defaultProvider = MockAccountProviders.fakeProvider("urn:fake:0")
     this.accountProviderRegistry = AccountProviderRegistry.createFrom(this.context, listOf(), this.defaultProvider)
     this.accountEvents = PublishSubject.create()
@@ -124,12 +119,13 @@ abstract class ProfileAccountCreateCustomOPDSContract {
     this.cacheDirectory = File.createTempFile("book-borrow-tmp", "dir")
     this.cacheDirectory.delete()
     this.cacheDirectory.mkdirs()
-    this.feedLoader = this.createFeedLoader(this.executorFeeds)
     this.opdsFeedParser = Mockito.mock(OPDSFeedParserType::class.java)
     this.profilesDatabase = Mockito.mock(ProfilesDatabaseType::class.java)
     this.accountProviderResolutionStrings = MockAccountProviderResolutionStrings()
     this.profileAccountCreationStrings = MockAccountCreationStringResources()
     this.clock = { Instant.now() }
+    this.server = MockWebServer()
+    this.server.start()
   }
 
   @After
@@ -138,30 +134,25 @@ abstract class ProfileAccountCreateCustomOPDSContract {
     this.executorBooks.shutdown()
     this.executorFeeds.shutdown()
     this.executorTimer.shutdown()
+    this.server.close()
   }
 
   @Test
   fun testOPDSFeedFails() {
-    val opdsURI = URI("urn:test:0")
+    val opdsURI = this.server.url("/").toUri()
 
-    this.http.addResponse(
-      "urn:test:0",
-      HTTPResultError(
-        400,
-        "BAD!",
-        0L,
-        mutableMapOf(),
-        0L,
-        ByteArrayInputStream(ByteArray(0)),
-        Option.none()
-      )
+    this.server.enqueue(
+      MockResponse()
+        .setResponseCode(400)
+        .setStatus("BAD!")
+        .setBody("")
     )
 
     val task =
       ProfileAccountCreateCustomOPDSTask(
         accountEvents = this.accountEvents,
         accountProviderRegistry = this.accountProviderRegistry,
-        http = this.http,
+        httpClient = this.http,
         opdsURI = opdsURI,
         opdsFeedParser = this.opdsFeedParser,
         profiles = this.profilesDatabase,
@@ -175,21 +166,13 @@ abstract class ProfileAccountCreateCustomOPDSContract {
 
   @Test
   fun testOPDSFeedFailsExceptional() {
-    val opdsURI = URI("urn:test:0")
-
-    this.http.addResponse(
-      "urn:test:0",
-      HTTPResultException(
-        opdsURI,
-        java.lang.Exception()
-      )
-    )
+    val opdsURI = this.server.url("/").toUri()
 
     val task =
       ProfileAccountCreateCustomOPDSTask(
         accountEvents = this.accountEvents,
         accountProviderRegistry = this.accountProviderRegistry,
-        http = this.http,
+        httpClient = this.http,
         opdsURI = opdsURI,
         opdsFeedParser = this.opdsFeedParser,
         profiles = this.profilesDatabase,
@@ -203,21 +186,14 @@ abstract class ProfileAccountCreateCustomOPDSContract {
 
   @Test
   fun testOPDSFeedUnparseable() {
-    val opdsURI = URI("urn:test:0")
+    val opdsURI = this.server.url("/").toUri()
 
     val stream =
       ByteArrayInputStream(ByteArray(0))
 
-    this.http.addResponse(
-      "urn:test:0",
-      HTTPResultOK<InputStream>(
-        "OK",
-        200,
-        stream,
-        0L,
-        mutableMapOf(),
-        0L
-      )
+    this.server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
     )
 
     Mockito.`when`(this.opdsFeedParser.parse(opdsURI, stream))
@@ -227,7 +203,7 @@ abstract class ProfileAccountCreateCustomOPDSContract {
       ProfileAccountCreateCustomOPDSTask(
         accountEvents = this.accountEvents,
         accountProviderRegistry = this.accountProviderRegistry,
-        http = this.http,
+        httpClient = this.http,
         opdsURI = opdsURI,
         opdsFeedParser = this.opdsFeedParser,
         profiles = this.profilesDatabase,
@@ -241,30 +217,25 @@ abstract class ProfileAccountCreateCustomOPDSContract {
 
   @Test
   fun testOPDSFeedNoAuthentication() {
-    val opdsURI = URI("urn:test:0")
+    this.opdsFeedParser =
+      OPDSFeedParser.newParser(OPDSAcquisitionFeedEntryParser.newParser())
+
+    val opdsURI = this.server.url("/").toUri()
     val accountId = AccountID.generate()
 
-    val stream =
-      ByteArrayInputStream(ByteArray(0))
-
-    this.http.addResponse(
-      "urn:test:0",
-      HTTPResultOK<InputStream>(
-        "OK",
-        200,
-        stream,
-        0L,
-        mutableMapOf(),
-        0L
-      )
+    this.server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody(
+          """
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>http://circulation.alpha.librarysimplified.org/loans/</id>
+  <title>Active loans and holds</title>
+  <updated>2020-01-01T00:00:00Z</updated>
+</feed>
+          """.trimIndent()
+        )
     )
-
-    val feed =
-      OPDSAcquisitionFeed.newBuilder(opdsURI, "id", DateTime.now(), "Title")
-        .build()
-
-    Mockito.`when`(this.opdsFeedParser.parse(opdsURI, stream))
-      .thenReturn(feed)
 
     val profile =
       Mockito.mock(ProfileType::class.java)
@@ -289,7 +260,7 @@ abstract class ProfileAccountCreateCustomOPDSContract {
       ProfileAccountCreateCustomOPDSTask(
         accountEvents = this.accountEvents,
         accountProviderRegistry = accountProviders,
-        http = this.http,
+        httpClient = this.http,
         opdsURI = opdsURI,
         opdsFeedParser = this.opdsFeedParser,
         profiles = this.profilesDatabase,
@@ -307,45 +278,29 @@ abstract class ProfileAccountCreateCustomOPDSContract {
 
   @Test
   fun testProviderResolutionFails() {
-    val opdsURI = URI("urn:test:0")
-    val authURI = URI("urn:auth:0")
+    this.opdsFeedParser =
+      OPDSFeedParser.newParser(OPDSAcquisitionFeedEntryParser.newParser())
+
+    val authURI = this.server.url("/auth").toUri()
+    val opdsURI = this.server.url("/").toUri()
     val accountId = AccountID.generate()
 
-    val stream =
-      ByteArrayInputStream(ByteArray(0))
-
-    this.http.addResponse(
-      "urn:test:0",
-      HTTPResultOK<InputStream>(
-        "OK",
-        200,
-        stream,
-        0L,
-        mutableMapOf(),
-        0L
-      )
+    this.server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody(
+          """
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>http://circulation.alpha.librarysimplified.org/loans/</id>
+  <title>Active loans and holds</title>
+  <updated>2020-01-01T00:00:00Z</updated>
+  <link href="https://circulation.librarysimplified.org/NYNYPL/authentication_document" rel="http://opds-spec.org/auth/document"/>
+</feed>
+          """.trimIndent()
+        )
     )
 
-    this.http.addResponse(
-      authURI,
-      HTTPResultError(
-        400,
-        "BAD!",
-        0L,
-        mutableMapOf(),
-        0L,
-        ByteArrayInputStream(ByteArray(0)),
-        Option.none()
-      )
-    )
-
-    val feed =
-      OPDSAcquisitionFeed.newBuilder(opdsURI, "id", DateTime.now(), "Title")
-        .setAuthenticationDocumentLink(Option.some(authURI))
-        .build()
-
-    Mockito.`when`(this.opdsFeedParser.parse(opdsURI, stream))
-      .thenReturn(feed)
+    this.server.enqueue(MockResponse().setResponseCode(400))
 
     val profile =
       Mockito.mock(ProfileType::class.java)
@@ -363,7 +318,7 @@ abstract class ProfileAccountCreateCustomOPDSContract {
       ProfileAccountCreateCustomOPDSTask(
         accountEvents = this.accountEvents,
         accountProviderRegistry = this.accountProviderRegistry,
-        http = this.http,
+        httpClient = this.http,
         opdsURI = opdsURI,
         opdsFeedParser = this.opdsFeedParser,
         profiles = this.profilesDatabase,
@@ -377,29 +332,25 @@ abstract class ProfileAccountCreateCustomOPDSContract {
 
   @Test
   fun testAccountCreationFails() {
-    val opdsURI = URI("urn:test:0")
+    this.opdsFeedParser =
+      OPDSFeedParser.newParser(OPDSAcquisitionFeedEntryParser.newParser())
 
-    val stream =
-      ByteArrayInputStream(ByteArray(0))
+    val opdsURI = this.server.url("/").toUri()
+    val accountId = AccountID.generate()
 
-    this.http.addResponse(
-      "urn:test:0",
-      HTTPResultOK<InputStream>(
-        "OK",
-        200,
-        stream,
-        0L,
-        mutableMapOf(),
-        0L
-      )
+    this.server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody(
+          """
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>http://circulation.alpha.librarysimplified.org/loans/</id>
+  <title>Active loans and holds</title>
+  <updated>2020-01-01T00:00:00Z</updated>
+</feed>
+          """.trimIndent()
+        )
     )
-
-    val feed =
-      OPDSAcquisitionFeed.newBuilder(opdsURI, "id", DateTime.now(), "Title")
-        .build()
-
-    Mockito.`when`(this.opdsFeedParser.parse(opdsURI, stream))
-      .thenReturn(feed)
 
     val profile =
       Mockito.mock(ProfileType::class.java)
@@ -420,7 +371,7 @@ abstract class ProfileAccountCreateCustomOPDSContract {
       ProfileAccountCreateCustomOPDSTask(
         accountEvents = this.accountEvents,
         accountProviderRegistry = accountProviders,
-        http = this.http,
+        httpClient = this.http,
         opdsURI = opdsURI,
         opdsFeedParser = this.opdsFeedParser,
         profiles = this.profilesDatabase,
@@ -430,28 +381,6 @@ abstract class ProfileAccountCreateCustomOPDSContract {
     val result = task.call()
     val failure = result as TaskResult.Failure
     Assert.assertEquals("creatingAccountFailed", failure.lastErrorCode)
-  }
-
-  private fun createFeedLoader(executorFeeds: ListeningExecutorService): FeedLoaderType {
-    val entryParser =
-      OPDSAcquisitionFeedEntryParser.newParser()
-    val parser =
-      OPDSFeedParser.newParser(entryParser)
-    val searchParser =
-      OPDSSearchParser.newParser()
-    val transport =
-      FeedHTTPTransport.newTransport(this.http)
-
-    return FeedLoader.create(
-      bookFormatSupport = this.bookFormatSupport,
-      bookRegistry = this.bookRegistry,
-      bundledContent = this.bundledContent,
-      contentResolver = this.contentResolver,
-      exec = executorFeeds,
-      parser = parser,
-      searchParser = searchParser,
-      transport = transport
-    )
   }
 
   private fun <T> anyNonNull(): T =


### PR DESCRIPTION
**What's this do?**
This updates the custom OPDS creation task to use the new
Simplified-Android-HTTP client. This ensures we follow redirects
correctly, and makes the code a bit nicer. It also removes some
code that would now be duplicated.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-2065

**How should this be tested? / Do these changes have associated tests?**
Check that a custom OPDS feed can be created by entering a URL.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m created a QA account