### PR TITLE
Make ServiceDirectoryProviderType.serviceDirectory() block

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainActivity.kt
@@ -114,7 +114,7 @@ class MainActivity :
 
   private fun getAvailableEULA(): EULAType? {
     val eulaOpt =
-      Services.serviceDirectoryWaiting(30L, TimeUnit.SECONDS)
+      Services.serviceDirectory()
         .requireService(DocumentStoreType::class.java)
         .eula
 
@@ -207,7 +207,7 @@ class MainActivity :
     this.logger.debug("onStartupFinished")
 
     val services =
-      Services.serviceDirectoryWaiting(30L, TimeUnit.SECONDS)
+      Services.serviceDirectory()
     val profilesController =
       services.requireService(ProfilesControllerType::class.java)
     val accountProviders =
@@ -452,7 +452,7 @@ class MainActivity :
     this.logger.debug("onSplashOpenProfileAnonymous")
 
     val profilesController =
-      Services.serviceDirectoryWaiting(30L, TimeUnit.SECONDS)
+      Services.serviceDirectory()
         .requireService(ProfilesControllerType::class.java)
 
     profilesController.profileSelect(profilesController.profileCurrent().id)
@@ -461,14 +461,14 @@ class MainActivity :
   override fun onSplashWantProfilesMode(): ProfilesDatabaseType.AnonymousProfileEnabled {
     this.logger.debug("onSplashWantProfilesMode")
 
-    return Services.serviceDirectoryWaiting(30L, TimeUnit.SECONDS)
+    return Services.serviceDirectory()
       .requireService(ProfilesControllerType::class.java)
       .profileAnonymousEnabled()
   }
 
   override fun onSplashWantMigrations(): MigrationsType {
     val profilesController =
-      Services.serviceDirectoryWaiting(30L, TimeUnit.SECONDS)
+      Services.serviceDirectory()
         .requireService(ProfilesControllerType::class.java)
 
     val migrationServiceDependencies =
@@ -530,7 +530,7 @@ class MainActivity :
 
   override fun onSplashLibrarySelectionNotWanted() {
     val profilesController =
-      Services.serviceDirectoryWaiting(30L, TimeUnit.SECONDS)
+      Services.serviceDirectory()
         .requireService(ProfilesControllerType::class.java)
 
     /*

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
@@ -37,7 +37,6 @@ import org.nypl.simplified.ui.settings.SettingsNavigationControllerType
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
 import org.nypl.simplified.ui.toolbar.ToolbarHostType
 import org.slf4j.LoggerFactory
-import java.util.concurrent.TimeUnit
 
 /**
  * The main application fragment.
@@ -68,7 +67,7 @@ class MainFragment : Fragment() {
       NavigationControllers.findDirectory(this.requireActivity())
 
     val services =
-      Services.serviceDirectoryWaiting(30L, TimeUnit.SECONDS)
+      Services.serviceDirectory()
 
     this.accountProviders =
       services.requireService(AccountProviderRegistryType::class.java)

--- a/simplified-services-api/src/main/java/org/librarysimplified/services/api/Services.kt
+++ b/simplified-services-api/src/main/java/org/librarysimplified/services/api/Services.kt
@@ -2,29 +2,27 @@ package org.librarysimplified.services.api
 
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
-import java.lang.IllegalStateException
+import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
 
 object Services : ServiceDirectoryProviderType {
 
+  private val logger = LoggerFactory.getLogger(Services::class.java)
   private val servicesLock: Any = Any()
   private var servicesDirectory: ServiceDirectoryType? = null
   private val servicesFuture: SettableFuture<ServiceDirectoryType> = SettableFuture.create()
 
   override fun serviceDirectory(): ServiceDirectoryType {
-    return synchronized(this.servicesLock) {
-      this.servicesDirectory ?: throw IllegalStateException("No service directory has been created!")
+    try {
+      return this.servicesFuture.get(3L, TimeUnit.MINUTES)
+    } catch (e: Exception) {
+      this.logger.error("unable to fetch service directory: ", e)
+      throw e
     }
   }
 
   fun serviceDirectoryFuture(): ListenableFuture<ServiceDirectoryType> =
     this.servicesFuture
-
-  fun serviceDirectoryWaiting(
-    time: Long,
-    timeUnit: TimeUnit
-  ): ServiceDirectoryType =
-    this.servicesFuture.get(time, timeUnit)
 
   fun isInitialized(): Boolean {
     return synchronized(this.servicesLock) {

--- a/simplified-services-api/src/main/java/org/librarysimplified/services/api/Services.kt
+++ b/simplified-services-api/src/main/java/org/librarysimplified/services/api/Services.kt
@@ -14,7 +14,7 @@ object Services : ServiceDirectoryProviderType {
 
   override fun serviceDirectory(): ServiceDirectoryType {
     try {
-      return this.servicesFuture.get(3L, TimeUnit.MINUTES)
+      return this.servicesFuture.get(30L, TimeUnit.SECONDS)
     } catch (e: Exception) {
       this.logger.error("unable to fetch service directory: ", e)
       throw e

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -150,7 +150,7 @@ class AudioBookPlayerActivity :
     this.log.debug("entry id:      {}", this.parameters.opdsEntry.id)
 
     this.setTheme(
-      Services.serviceDirectoryWaiting(30L, TimeUnit.SECONDS)
+      Services.serviceDirectory()
         .requireService(ThemeServiceType::class.java)
         .findCurrentTheme()
         .themeWithActionBar

--- a/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfReaderActivity.kt
@@ -22,7 +22,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.InputStream
-import java.util.concurrent.TimeUnit
 
 class PdfReaderActivity :
   AppCompatActivity(),
@@ -78,7 +77,7 @@ class PdfReaderActivity :
     this.id = intentParams.id
 
     val services =
-      Services.serviceDirectoryWaiting(30L, TimeUnit.SECONDS)
+      Services.serviceDirectory()
 
     this.currentProfile =
       services.requireService(ProfilesControllerType::class.java).profileCurrent()


### PR DESCRIPTION
**What's this do?**
This switches to a model where asking for the service directory is now
a blocking operation. In theory, we block indefinitely.  In practice,
we place a three minute bound on the operation: If it's taking longer
than this to retrieve the service directory, something is seriously
wrong and we should abort, print a stack trace, and then throw an
exception.

This should fix any and all problems where we get a lifecycle-related
exception, and may also remove the need to use Kotlin `lazy` properties.

**Why are we doing this? (w/ JIRA link if applicable)**
I've seen numerous issues over the past few months where we've requested the service directory before it exists. The Android lifecycle is one big design flaw.

**How should this be tested? / Do these changes have associated tests?**
No specific tests. If this is working, there should be no noticeable difference in the app.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
I ran the vanilla app and opened a few books.