### PR TITLE
Temporarily fix custom OPDS feeds

### DIFF
--- a/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderResolution.kt
+++ b/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderResolution.kt
@@ -373,7 +373,7 @@ class AccountProviderResolution(
 
   private fun contentTypeOf(result: HTTPResultError<InputStream>): String {
     val contentTypeHeaders = result.responseHeaders["content-type"]
-    return contentTypeHeaders ?.firstOrNull() ?: "application/octet-stream"
+    return contentTypeHeaders?.firstOrNull() ?: "application/octet-stream"
   }
 
   private fun parseAuthenticationDocument(

--- a/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderResolution.kt
+++ b/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderResolution.kt
@@ -336,8 +336,13 @@ class AccountProviderResolution(
       is Link.LinkBasic -> {
         when (val result = this.http.get(Option.none(), targetLink.href, 0L)) {
           is HTTPResultError -> {
-            val problem =
-              this.someOrNull(result.problemReport)
+            val problem = this.someOrNull(result.problemReport)
+            val contentType = contentTypeOf(result)
+
+            if (contentType == "application/vnd.opds.authentication.v1.0+json") {
+              return this.parseAuthenticationDocument(targetLink.href, result.data, taskRecorder)
+            }
+
             val message = this.stringResources.resolvingAuthDocumentRetrievalFailed
             taskRecorder.addAttribute("Authentication Document", targetLink.href.toString())
             taskRecorder.addAttributes(Presentables.problemReportAsAttributes(problem))
@@ -364,6 +369,11 @@ class AccountProviderResolution(
         throw IOException(message)
       }
     }
+  }
+
+  private fun contentTypeOf(result: HTTPResultError<InputStream>): String {
+    val contentTypeHeaders = result.responseHeaders["content-type"]
+    return contentTypeHeaders ?.firstOrNull() ?: "application/octet-stream"
   }
 
   private fun parseAuthenticationDocument(


### PR DESCRIPTION
**What's this do?**
Somehow, I managed to break the custom OPDS feed feature again. This
fixes it until we replace all of the uses of the old HTTP client with
the new one.

**Why are we doing this? (w/ JIRA link if applicable)**
Custom OPDS feeds are required for the integration tests.

**How should this be tested? / Do these changes have associated tests?**
Try to create a custom OPDS feed in the hidden debug menu.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
I created an account (again) on the NYPL QA server.