### PR TITLE
SIMPLY-3259: Open eBooks: Accounts Button

### DIFF
--- a/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
+++ b/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
@@ -25,4 +25,6 @@ class VanillaBuildConfigurationService : BuildConfigurationServiceType {
     get() = "[vanilla-error]"
   override val oauthCallbackScheme: BuildConfigOAuthScheme
     get() = BuildConfigOAuthScheme("simplified-vanilla-oauth")
+  override val showChangeAccountsUi: Boolean
+    get() = true
 }

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationAccountsType.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationAccountsType.kt
@@ -22,4 +22,11 @@ interface BuildConfigurationAccountsType {
    */
 
   val allowAccountsRegistryAccess: Boolean
+
+  /**
+   * If set to `true`, users will be shown the option to switch accounts on the
+   * catalog screen.
+   */
+
+  val showChangeAccountsUi: Boolean
 }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
@@ -743,10 +743,12 @@ class CatalogFragmentFeed : Fragment() {
       this.supportActionBar?.apply {
         // Configure whether or not the user should be able to change accounts
         if (configurationService.showChangeAccountsUi) {
-            setHomeAsUpIndicator(R.drawable.accounts)
-            setHomeActionContentDescription(R.string.catalogAccounts)
+          setHomeAsUpIndicator(R.drawable.accounts)
+          setHomeActionContentDescription(R.string.catalogAccounts)
+          setDisplayHomeAsUpEnabled(true)
+        } else {
+          setDisplayHomeAsUpEnabled(false)
         }
-        setDisplayHomeAsUpEnabled(configurationService.showChangeAccountsUi)
       }
     }
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
@@ -741,9 +741,12 @@ class CatalogFragmentFeed : Fragment() {
     fun showAccountPickerAction() {
       // Configure the 'Home Action' in the Toolbar to show the account picker when tapped.
       this.supportActionBar?.apply {
-        setHomeAsUpIndicator(R.drawable.accounts)
-        setHomeActionContentDescription(R.string.catalogAccounts)
-        setDisplayHomeAsUpEnabled(true)
+        // Configure whether or not the user should be able to change accounts
+        if (configurationService.showChangeAccountsUi) {
+            setHomeAsUpIndicator(R.drawable.accounts)
+            setHomeActionContentDescription(R.string.catalogAccounts)
+        }
+        setDisplayHomeAsUpEnabled(configurationService.showChangeAccountsUi)
       }
     }
 


### PR DESCRIPTION
**What's this do?**
Here the `showChangeAccountsUi` attribute is added to the `BuildConfigurationAccountsType` to allow for the hiding of the change account option on the Catalog screen.

**Why are we doing this? (w/ JIRA link if applicable)**
[SIMPLY-3259: Open eBooks: Accounts Button](https://jira.nypl.org/browse/SIMPLY-3259)

**How should this be tested? / Do these changes have associated tests?**
Toggle the `showChangeAccountsUi` attribute true/false to see if the change account screen his hidden/shown on the Catalog screen with in the vanilla app with `VanillaBuildConfigurationService`.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@MalcolmMcFly 