### PR TITLE
Simplify code for loading account icons.

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountsAdapter.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountsAdapter.kt
@@ -53,7 +53,6 @@ class AccountsAdapter(
         View.GONE
       }
 
-    holder.accountIcon.setImageDrawable(null)
     holder.accountTitleView.text = account.provider.displayName
     holder.accountSubtitleView.text = account.provider.subtitle
     holder.parent.setOnClickListener {

--- a/simplified-ui-images/src/main/java/org/nypl/simplified/ui/images/ImageAccountIcons.kt
+++ b/simplified-ui-images/src/main/java/org/nypl/simplified/ui/images/ImageAccountIcons.kt
@@ -1,14 +1,10 @@
 package org.nypl.simplified.ui.images
 
-import android.view.View
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
-import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
-import com.squareup.picasso.RequestCreator
 import org.nypl.simplified.accounts.api.AccountProviderDescription
 import org.slf4j.LoggerFactory
-import java.net.URI
 
 /**
  * Functions to efficiently load account logos.
@@ -16,7 +12,7 @@ import java.net.URI
 
 object ImageAccountIcons {
 
-  private val LOG =
+  private val logger =
     LoggerFactory.getLogger(ImageAccountIcons::class.java)
 
   /**
@@ -31,28 +27,13 @@ object ImageAccountIcons {
     @DrawableRes defaultIcon: Int,
     iconView: ImageView
   ) {
-    val request: RequestCreator
-    val logoURI: URI? = account.logoURI?.hrefURI
-    if (logoURI != null) {
-      LOG.debug("configuring account logo: {}", logoURI)
-      request = loader.load(logoURI.toString())
-    } else {
-      request = loader.load(defaultIcon)
-    }
+    val uri = account.logoURI?.hrefURI ?: return
+    this.logger.debug("configuring account logo: {}", uri)
 
-    request.into(
-      iconView,
-      object : Callback {
-        override fun onSuccess() {
-          iconView.visibility = View.VISIBLE
-        }
-
-        override fun onError(e: Exception) {
-          LOG.error("failed to load account icon: ", e)
-          iconView.setImageResource(defaultIcon)
-          iconView.visibility = View.VISIBLE
-        }
-      }
-    )
+    loader
+      .load(uri.toString())
+      .placeholder(defaultIcon)
+      .error(defaultIcon)
+      .into(iconView)
   }
 }


### PR DESCRIPTION
**What's this do?**
This is a small refactor of the `ImageAccountIcons` code to eliminate some unnecessary work.

**Why are we doing this? (w/ JIRA link if applicable)**
Picasso is trying to fetch every image resource in the account list, even if they're null. This is a lot of unnecessary work and can cause the account list to become choppy when scrolling around. This was easily fixed by just doing nothing if the uri is null.

Additionally, use the default error and placeholder functions of Picasso for setting the default image.

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the Vanilla app.