### PR TITLE
SIMPLY-3255: Show Report Issue in account views

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -124,6 +124,8 @@ class AccountFragment : Fragment() {
   private lateinit var signUpLabel: TextView
   private lateinit var uiThread: UIThreadServiceType
   private lateinit var viewModel: AccountFragmentViewModel
+  private lateinit var reportIssueGroup: ViewGroup
+  private lateinit var reportIssueItem: View
 
   private val cardCreatorResultCode = 101
   private val closing = AtomicBoolean(false)
@@ -254,6 +256,11 @@ class AccountFragment : Fragment() {
       layout.findViewById(R.id.accountCustomOPDS)
     this.accountCustomOPDSField =
       this.accountCustomOPDS.findViewById(R.id.accountCustomOPDSField)
+
+    this.reportIssueGroup =
+      layout.findViewById(R.id.accountReportIssue)
+    this.reportIssueItem =
+      this.reportIssueGroup.findViewById(R.id.accountReportIssueText)
 
     this.loginButtonErrorDetails.visibility = View.GONE
     this.loginProgress.visibility = View.INVISIBLE
@@ -500,6 +507,12 @@ class AccountFragment : Fragment() {
         View.GONE
       }
 
+    /*
+     * Configure the "Report issue..." item.
+     */
+
+    this.configureReportIssue()
+
     this.accountSubscription =
       this.profilesController.accountEvents()
         .subscribe(this::onAccountEvent)
@@ -541,6 +554,26 @@ class AccountFragment : Fragment() {
           this.authenticationAlternativesButtons.addView(layout)
         }
       }
+    }
+  }
+
+  /**
+   * If there's a support email, enable an option to use it.
+   */
+
+  private fun configureReportIssue() {
+    val email = this.account.provider.supportEmail
+    if (email != null) {
+      this.reportIssueGroup.visibility = View.VISIBLE
+      this.reportIssueItem.setOnClickListener {
+        val emailIntent =
+          Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", email, null))
+        startActivity(
+          Intent.createChooser(emailIntent, resources.getString(R.string.accountReportIssue))
+        )
+      }
+    } else {
+      this.reportIssueGroup.visibility = View.GONE
     }
   }
 

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -280,7 +280,6 @@
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
-        android:enabled="false"
         android:text="@string/accountReportIssue"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
**What's this do?**
This re-enables the Report Issue item in the account view. When
selected, the user's default email client is opened in with the
published support email address.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3255

**How should this be tested? / Do these changes have associated tests?**
Visit the account screen for a collection that you know publishes a support email. Check that the Report Issue item is there and that it offers to open an email client.
Visit the account screen for a collection that you know _doesn't_ publish a support email. Check that the Report Issue item is gone.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m tested various accounts with support email addresses, but couldn't find a collection without one.