### PR TITLE
SIMPLY-3305: Explicitly send empty passwords for Overdrive

### DIFF
--- a/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookCredentials.kt
+++ b/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookCredentials.kt
@@ -1,5 +1,7 @@
 package org.nypl.simplified.books.audio
 
+import com.google.common.base.Preconditions
+
 /**
  * Credentials used when fulfilling audio books.
  */
@@ -13,6 +15,22 @@ sealed class AudioBookCredentials {
   data class UsernamePassword(
     val userName: String,
     val password: String
+  ) : AudioBookCredentials() {
+    init {
+      Preconditions.checkArgument(
+        password.isNotBlank(),
+        "Password cannot be empty/blank (Use the UsernameOnly) class."
+      )
+    }
+  }
+
+  /**
+   * Credentials represented by a username. Some audio book backends require an explicit
+   * indication that there is no password. This class must be used to provide that indication.
+   */
+
+  data class UsernameOnly(
+    val userName: String
   ) : AudioBookCredentials()
 
   /**

--- a/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookManifestStrategy.kt
+++ b/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookManifestStrategy.kt
@@ -308,6 +308,15 @@ class AudioBookManifestStrategy(
               targetURI = OPAManifestURI.Indirect(this.request.targetURI),
               userAgent = this.request.userAgent
             )
+          is AudioBookCredentials.UsernameOnly ->
+            OPAParameters(
+              userName = credentials.userName,
+              password = OPAPassword.NotRequired,
+              clientKey = secretService.clientKey,
+              clientPass = secretService.clientPass,
+              targetURI = OPAManifestURI.Indirect(this.request.targetURI),
+              userAgent = this.request.userAgent
+            )
           is AudioBookCredentials.BearerToken ->
             throw UnsupportedOperationException("Can't use bearer tokens for Overdrive fulfillment")
           null ->
@@ -332,6 +341,11 @@ class AudioBookManifestStrategy(
                 ManifestFulfillmentBasicCredentials(
                   userName = credentials.userName,
                   password = credentials.password
+                )
+              is AudioBookCredentials.UsernameOnly ->
+                ManifestFulfillmentBasicCredentials(
+                  userName = credentials.userName,
+                  password = ""
                 )
               is AudioBookCredentials.BearerToken ->
                 throw UnsupportedOperationException(

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowAudioBook.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowAudioBook.kt
@@ -81,11 +81,18 @@ class BorrowAudioBook private constructor() : BorrowSubtaskType {
     val audioBookCredentials: AudioBookCredentials? =
       context.account.loginState.credentials?.let { credentials ->
         when (credentials) {
-          is AccountAuthenticationCredentials.Basic ->
-            AudioBookCredentials.UsernamePassword(
-              userName = credentials.userName.value,
-              password = credentials.password.value
-            )
+          is AccountAuthenticationCredentials.Basic -> {
+            if (credentials.password.value.isBlank()) {
+              AudioBookCredentials.UsernameOnly(
+                userName = credentials.userName.value
+              )
+            } else {
+              AudioBookCredentials.UsernamePassword(
+                userName = credentials.userName.value,
+                password = credentials.password.value
+              )
+            }
+          }
           is AccountAuthenticationCredentials.OAuthWithIntermediary ->
             AudioBookCredentials.BearerToken(accessToken = credentials.accessToken)
         }

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerParameters.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerParameters.kt
@@ -82,11 +82,18 @@ data class AudioBookPlayerParameters(
 
     val audioBookCredentials =
       when (credentials) {
-        is AccountAuthenticationCredentials.Basic ->
-          AudioBookCredentials.UsernamePassword(
-            userName = credentials.userName.value,
-            password = credentials.password.value
-          )
+        is AccountAuthenticationCredentials.Basic -> {
+          if (credentials.password.value.isBlank()) {
+            AudioBookCredentials.UsernameOnly(
+              userName = credentials.userName.value
+            )
+          } else {
+            AudioBookCredentials.UsernamePassword(
+              userName = credentials.userName.value,
+              password = credentials.password.value
+            )
+          }
+        }
         is AccountAuthenticationCredentials.OAuthWithIntermediary ->
           AudioBookCredentials.BearerToken(credentials.accessToken)
         null ->


### PR DESCRIPTION
**What's this do?**
This adjusts various calls to the audio book API so that we explicitly
signal that a password is not required. This is used by backends such
as Overdrive to send slightly different token requests.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3305

**How should this be tested? / Do these changes have associated tests?**
Get an audio book from Kalama Public Library. They use Overdrive but do not use passwords.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m downloaded and listened to a book from Kalama