### PR TITLE
Hide the "pretend user is in NYC" debug item

### DIFF
--- a/simplified-ui-settings/src/main/res/layout/settings_debug.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_debug.xml
@@ -154,6 +154,7 @@
       android:layout_marginBottom="16dp"
       android:checked="false"
       android:enabled="true"
+      android:visibility="gone"
       android:text="Card Creator: Pretend the user is in New York" />
 
     <androidx.appcompat.widget.SwitchCompat


### PR DESCRIPTION
**What's this do?**
Hides the "pretend user is in NYC" debug item.

**Why are we doing this? (w/ JIRA link if applicable)**
That's classified.

**How should this be tested? / Do these changes have associated tests?**
Check that you can't see the debug item anymore.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m failed to see the debug item.