### PR TITLE
Display email in accounts screen

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -1,7 +1,6 @@
 package org.nypl.simplified.ui.accounts
 
 import android.app.Activity
-import android.app.AlertDialog
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -17,6 +16,7 @@ import android.widget.ProgressBar
 import android.widget.Switch
 import android.widget.TextView
 import androidx.annotation.UiThread
+import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
@@ -572,9 +572,19 @@ class AccountFragment : Fragment() {
       this.reportIssueGroup.setOnClickListener {
         val emailIntent =
           Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", email, null))
-        startActivity(
-          Intent.createChooser(emailIntent, resources.getString(R.string.accountReportIssue))
-        )
+        val chosenIntent =
+          Intent.createChooser(emailIntent, this.resources.getString(R.string.accountReportIssue))
+
+        try {
+          this.startActivity(chosenIntent)
+        } catch (e: Exception) {
+          this.logger.error("unable to start activity: ", e)
+          val context = this.requireContext()
+          AlertDialog.Builder(context)
+            .setMessage(context.getString(R.string.accountReportFailed, email))
+            .create()
+            .show()
+        }
       }
     } else {
       this.reportIssueGroup.visibility = View.GONE

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -119,13 +119,14 @@ class AccountFragment : Fragment() {
   private lateinit var loginTitle: ViewGroup
   private lateinit var parameters: AccountFragmentParameters
   private lateinit var profilesController: ProfilesControllerType
+  private lateinit var reportIssueEmail: TextView
+  private lateinit var reportIssueGroup: ViewGroup
+  private lateinit var reportIssueItem: View
   private lateinit var settingsCardCreator: ConstraintLayout
   private lateinit var signUpButton: Button
   private lateinit var signUpLabel: TextView
   private lateinit var uiThread: UIThreadServiceType
   private lateinit var viewModel: AccountFragmentViewModel
-  private lateinit var reportIssueGroup: ViewGroup
-  private lateinit var reportIssueItem: View
 
   private val cardCreatorResultCode = 101
   private val closing = AtomicBoolean(false)
@@ -261,6 +262,8 @@ class AccountFragment : Fragment() {
       layout.findViewById(R.id.accountReportIssue)
     this.reportIssueItem =
       this.reportIssueGroup.findViewById(R.id.accountReportIssueText)
+    this.reportIssueEmail =
+      this.reportIssueGroup.findViewById(R.id.accountReportIssueEmail)
 
     this.loginButtonErrorDetails.visibility = View.GONE
     this.loginProgress.visibility = View.INVISIBLE
@@ -565,7 +568,8 @@ class AccountFragment : Fragment() {
     val email = this.account.provider.supportEmail
     if (email != null) {
       this.reportIssueGroup.visibility = View.VISIBLE
-      this.reportIssueItem.setOnClickListener {
+      this.reportIssueEmail.text = email.removePrefix("mailto:")
+      this.reportIssueGroup.setOnClickListener {
         val emailIntent =
           Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", email, null))
         startActivity(

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -258,11 +258,11 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-      android:visibility="gone"
       android:id="@+id/accountReportIssue"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="?attr/selectableItemBackground">
+      android:background="?attr/selectableItemBackground"
+      android:visibility="visible">
 
       <View
         android:layout_width="0dp"
@@ -274,6 +274,7 @@
 
       <TextView
         android:id="@+id/accountReportIssueText"
+        android:background="?android:attr/selectableItemBackground"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
@@ -281,10 +282,23 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:text="@string/accountReportIssue"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/accountReportIssueEmail"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+      <TextView
+        android:id="@+id/accountReportIssueEmail"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:fontFamily="monospace"
+        android:text="someone@example.com"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -3,7 +3,8 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  xmlns:tools="http://schemas.android.com/tools">
 
   <LinearLayout
     android:layout_width="match_parent"
@@ -261,8 +262,7 @@
       android:id="@+id/accountReportIssue"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="?attr/selectableItemBackground"
-      android:visibility="visible">
+      android:background="?attr/selectableItemBackground">
 
       <View
         android:layout_width="0dp"
@@ -295,7 +295,7 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:fontFamily="monospace"
-        android:text="someone@example.com"
+        tools:text="someone@example.com"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -42,4 +42,5 @@
   <string name="currentlyBrowsing">You\'re currently browsing</string>
   <string name="accountSearchHint">Search accounts&#8230;</string>
   <string name="accountMore">More options</string>
+  <string name="accountReportFailed">Sorry, we weren\'t able to find a usable email app. Please send email to %1$s if you need to report an issue.</string>
 </resources>


### PR DESCRIPTION
**What's this do?**
This displays the email address used for support requests in the
account screen.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/SIMPLY-3255

**How should this be tested? / Do these changes have associated tests?**
Same as for https://github.com/NYPL-Simplified/Simplified-Android-Core/pull/830
Unfortunately, some devices just don't have working email apps. This adds an email display so someone can conceivably send an email manually instead.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m 