### PR TITLE
SIMPLY-3362: Delete caches

### DIFF
--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
@@ -446,6 +446,7 @@ public final class ReaderActivity extends AppCompatActivity implements
       LOG.debug("ignoring long click on web view");
       return true;
     });
+    clearWebCache();
 
     // Allow the webview to be debuggable only if this is a dev build
     if ((getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0) {
@@ -579,6 +580,7 @@ public final class ReaderActivity extends AppCompatActivity implements
     this.current_location = bookmark;
 
     uiThread.runOnUIThread(this::configureBookmarkButtonUI);
+
     Services.INSTANCE.serviceDirectory()
       .requireService(ReaderBookmarkServiceType.class)
       .bookmarkCreate(this.current_account.getId(), bookmark);
@@ -613,6 +615,8 @@ public final class ReaderActivity extends AppCompatActivity implements
         .requireService(ReaderBookmarkServiceType.class)
         .bookmarkCreate(this.current_account.getId(), location);
     }
+
+    clearWebCache();
   }
 
   @Override
@@ -649,6 +653,13 @@ public final class ReaderActivity extends AppCompatActivity implements
       sub.dispose();
     }
     this.profile_subscription = null;
+
+    clearWebCache();
+  }
+
+  private void clearWebCache() {
+    LOG.debug("clearing the webview cache");
+    this.view_web_view.clearCache(true);
   }
 
   @Override

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderHTTPServerAAsync.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderHTTPServerAAsync.java
@@ -145,6 +145,7 @@ public final class ReaderHTTPServerAAsync
   {
     try {
       final ReaderNativeCodeReadLock read_lock = ReaderNativeCodeReadLock.get();
+      disableCache(response);
 
       /**
        * Determine if the current request is a range request.
@@ -281,6 +282,10 @@ public final class ReaderHTTPServerAAsync
     } finally {
       ReaderHTTPServerAAsync.LOG.trace("request: done {}", request.getPath());
     }
+  }
+
+  private Headers disableCache(AsyncHttpServerResponse response) {
+    return response.getHeaders().add("Cache-Control", "no-store");
   }
 
   private boolean isRangeRequest(Headers headers) {

--- a/simplified-viewer-epub-readium1/src/test/java/org/nypl/simplified/viewer/epub/readium1/ReaderHTTPServerAAsyncTest.java
+++ b/simplified-viewer-epub-readium1/src/test/java/org/nypl/simplified/viewer/epub/readium1/ReaderHTTPServerAAsyncTest.java
@@ -94,6 +94,7 @@ public class ReaderHTTPServerAAsyncTest {
         XHTML_MANIFEST_ITEM_RELATIVE_PATH);
 
     AsyncHttpServerResponse mockResponse = mock(AsyncHttpServerResponse.class);
+    when(mockResponse.getHeaders()).thenReturn(new Headers());
 
     httpServer.onRequest(mockRequest, mockResponse);
 
@@ -106,6 +107,7 @@ public class ReaderHTTPServerAAsyncTest {
         NULL_MANIFEST_ITEM_RELATIVE_PATH);
 
     AsyncHttpServerResponse mockResponse = mock(AsyncHttpServerResponse.class);
+    when(mockResponse.getHeaders()).thenReturn(new Headers());
 
     httpServer.onRequest(mockRequest, mockResponse);
 
@@ -118,6 +120,7 @@ public class ReaderHTTPServerAAsyncTest {
         NULL_TYPE_MANIFEST_ITEM_RELATIVE_PATH);
 
     AsyncHttpServerResponse mockResponse = mock(AsyncHttpServerResponse.class);
+    when(mockResponse.getHeaders()).thenReturn(new Headers());
 
     httpServer.onRequest(mockRequest, mockResponse);
 


### PR DESCRIPTION
**What's this do?**
This makes two main changes:

  1. Responses returned from the R1 web server have Cache-Control
     headers to prevent caching of data.
  2. The web view cache is deleted on starting and ending.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3362

**How should this be tested? / Do these changes have associated tests?**
Check that your webview cache remains generally empty when reading books.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m tested that the cache stayed mostly empty...

![cache0](https://user-images.githubusercontent.com/612494/101618536-0d2bf280-3a0a-11eb-9856-161e8ff129c9.png)
![cache1](https://user-images.githubusercontent.com/612494/101618540-0e5d1f80-3a0a-11eb-9df2-23b0b150c092.png)

The screenshots show that only a couple of internal javascript files are cached. No HTML pages appear.