### PR TITLE
Add public.xml files to mark module resources public or private.

### DIFF
--- a/simplified-accounts-source-spi/src/main/res/values/public.xml
+++ b/simplified-accounts-source-spi/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+    <public />
+</resources>

--- a/simplified-app-vanilla/src/main/res/values/public.xml
+++ b/simplified-app-vanilla/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+    <public />
+</resources>

--- a/simplified-app-vanilla/src/vanillaWithProfiles/res/values/public.xml
+++ b/simplified-app-vanilla/src/vanillaWithProfiles/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-books-covers/src/main/res/values/public.xml
+++ b/simplified-books-covers/src/main/res/values/public.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public name="cover_error" type="drawable" />
+  <public name="cover_loading" type="drawable" />
+</resources>

--- a/simplified-cardcreator/src/main/res/values/public.xml
+++ b/simplified-cardcreator/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-main/src/main/res/values/public.xml
+++ b/simplified-main/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <!-- All resources public by default -->
+</resources>

--- a/simplified-migration-from3master/src/main/res/values/public.xml
+++ b/simplified-migration-from3master/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+    <public />
+</resources>

--- a/simplified-ui-accounts/src/main/res/values/public.xml
+++ b/simplified-ui-accounts/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-ui-catalog/src/main/res/values/public.xml
+++ b/simplified-ui-catalog/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-ui-errorpage/src/main/res/values/public.xml
+++ b/simplified-ui-errorpage/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-ui-navigation-tabs/src/main/res/values/public.xml
+++ b/simplified-ui-navigation-tabs/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-ui-profiles/src/main/res/values/public.xml
+++ b/simplified-ui-profiles/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-ui-settings/src/main/res/values/public.xml
+++ b/simplified-ui-settings/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-ui-splash/src/main/res/values/public.xml
+++ b/simplified-ui-splash/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-ui-theme/src/main/res/values/public.xml
+++ b/simplified-ui-theme/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <!-- All resources public by default -->
+</resources>

--- a/simplified-viewer-audiobook/src/main/res/values/public.xml
+++ b/simplified-viewer-audiobook/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-viewer-epub-readium1/src/main/res/values/public.xml
+++ b/simplified-viewer-epub-readium1/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-viewer-epub-readium2/src/main/res/values/public.xml
+++ b/simplified-viewer-epub-readium2/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>

--- a/simplified-viewer-pdf/src/main/res/values/public.xml
+++ b/simplified-viewer-pdf/src/main/res/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <public />
+</resources>


### PR DESCRIPTION
All submodules expose their resources publicly by default. By defining a
public.xml file we can mark resources private to prevent them from being
reused in other modules. Individual resources can be marked public to
make them available for reuse.

https://developer.android.com/studio/projects/android-library#PrivateResources

This should not break the build but may result in lint warnings if
resources are used that are now marked private.