### PR TITLE
Intercept calls to non-local URIs

### DIFF
--- a/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
+++ b/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
@@ -17,6 +17,8 @@ class OEIBuildConfigurationService : BuildConfigurationServiceType {
     get() = "[Open eBooks error report]"
   override val oauthCallbackScheme: BuildConfigOAuthScheme
     get() = BuildConfigOAuthScheme("simplified-openebooks-oauth")
+  override val allowExternalReaderLinks: Boolean
+    get() = false
   override val showDebugBookDetailStatus: Boolean
     get() = false
   override val simplifiedVersion: String

--- a/simplified-app-simplye/src/main/java/org/nypl/simplified/simplye/SimplyEBuildConfigurationService.kt
+++ b/simplified-app-simplye/src/main/java/org/nypl/simplified/simplye/SimplyEBuildConfigurationService.kt
@@ -11,6 +11,8 @@ class SimplyEBuildConfigurationService : BuildConfigurationServiceType {
     get() = true
   override val oauthCallbackScheme: BuildConfigOAuthScheme
     get() = BuildConfigOAuthScheme("simplye-oauth")
+  override val allowExternalReaderLinks: Boolean
+    get() = true
   override val showChangeAccountsUi: Boolean
     get() = true
   override val showDebugBookDetailStatus: Boolean

--- a/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
+++ b/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
@@ -25,6 +25,8 @@ class VanillaBuildConfigurationService : BuildConfigurationServiceType {
     get() = "[vanilla-error]"
   override val oauthCallbackScheme: BuildConfigOAuthScheme
     get() = BuildConfigOAuthScheme("simplified-vanilla-oauth")
+  override val allowExternalReaderLinks: Boolean
+    get() = false
   override val showChangeAccountsUi: Boolean
     get() = true
 }

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationReaderType.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationReaderType.kt
@@ -1,0 +1,14 @@
+package org.nypl.simplified.buildconfig.api
+
+/**
+ * Configuration values related to readers/viewers.
+ */
+
+interface BuildConfigurationReaderType {
+
+  /**
+   * Allow access to external URLs in readers.
+   */
+
+  val allowExternalReaderLinks : Boolean
+}

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationReaderType.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationReaderType.kt
@@ -10,5 +10,5 @@ interface BuildConfigurationReaderType {
    * Allow access to external URLs in readers.
    */
 
-  val allowExternalReaderLinks : Boolean
+  val allowExternalReaderLinks: Boolean
 }

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationServiceType.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationServiceType.kt
@@ -9,4 +9,5 @@ interface BuildConfigurationServiceType :
   BuildConfigurationCatalogType,
   BuildConfigurationMetadataType,
   BuildConfigurationOAuthType,
+  BuildConfigurationReaderType,
   BuildConfigurationSettingsType

--- a/simplified-viewer-epub-readium1/build.gradle
+++ b/simplified-viewer-epub-readium1/build.gradle
@@ -2,6 +2,7 @@ dependencies {
   implementation project(":simplified-adobe-extensions")
   implementation project(":simplified-analytics-api")
   implementation project(":simplified-books-api")
+  implementation project(":simplified-buildconfig-api")
   implementation project(":simplified-files")
   implementation project(":simplified-profiles-controller-api")
   implementation project(":simplified-reader-bookmarks-api")

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
@@ -51,16 +51,15 @@ import org.nypl.simplified.books.api.BookLocation;
 import org.nypl.simplified.books.api.Bookmark;
 import org.nypl.simplified.books.api.BookmarkKind;
 import org.nypl.simplified.books.book_database.api.BookDatabaseException;
+import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType;
 import org.nypl.simplified.feeds.api.FeedEntry;
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryOPDS;
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry;
 import org.nypl.simplified.profiles.api.ProfileEvent;
 import org.nypl.simplified.profiles.api.ProfileNoneCurrentException;
-import org.nypl.simplified.profiles.api.ProfilePreferences;
 import org.nypl.simplified.profiles.api.ProfileUpdated;
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType;
 import org.nypl.simplified.reader.api.ReaderColorScheme;
-import org.nypl.simplified.reader.api.ReaderFontSelection;
 import org.nypl.simplified.reader.api.ReaderPreferences;
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceType;
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarks;
@@ -95,6 +94,8 @@ import kotlin.Pair;
 import static org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleEPUB;
 import static org.nypl.simplified.viewer.epub.readium1.ReaderReadiumViewerSettings.ScrollMode.AUTO;
 import static org.nypl.simplified.viewer.epub.readium1.ReaderReadiumViewerSettings.SyntheticSpreadMode.SINGLE;
+import static org.nypl.simplified.viewer.epub.readium1.ReaderWebViewClient.AllowExternalLinks.ALLOW_EXTERNAL_LINKS;
+import static org.nypl.simplified.viewer.epub.readium1.ReaderWebViewClient.AllowExternalLinks.DISALLOW_EXTERNAL_LINKS;
 
 /**
  * The main reader activity for reading an EPUB.
@@ -437,8 +438,15 @@ public final class ReaderActivity extends AppCompatActivity implements
       }
     };
 
+    final ReaderWebViewClient.AllowExternalLinks allowExternalReaderLinks =
+      Services.INSTANCE.serviceDirectory()
+        .requireService(BuildConfigurationServiceType.class)
+        .getAllowExternalReaderLinks()
+        ? ALLOW_EXTERNAL_LINKS : DISALLOW_EXTERNAL_LINKS;
+
     final WebViewClient wv_client =
-      new ReaderWebViewClient(this, sd, this, rd, this);
+      new ReaderWebViewClient(
+        this, sd, this, rd, this, allowExternalReaderLinks);
 
     in_webview.setWebChromeClient(wc_client);
     in_webview.setWebViewClient(wv_client);

--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderWebViewClient.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderWebViewClient.java
@@ -11,31 +11,33 @@ import com.io7m.jnull.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Objects;
 
 /**
  * The web client responsible for overriding the requests for certain
  * resources.
  */
 
-final class ReaderWebViewClient extends WebViewClient
-{
+final class ReaderWebViewClient extends WebViewClient {
   private static final Logger LOG = LoggerFactory.getLogger(ReaderWebViewClient.class);
 
   private final ReaderSimplifiedFeedbackDispatcherType simplified_dispatcher;
-  private final ReaderReadiumFeedbackDispatcherType    readium_dispatcher;
-  private final Activity                               activity;
-  private final ReaderSimplifiedFeedbackListenerType   simplified_listener;
-  private final ReaderReadiumFeedbackListenerType      readium_listener;
+  private final ReaderReadiumFeedbackDispatcherType readium_dispatcher;
+  private final Activity activity;
+  private final ReaderSimplifiedFeedbackListenerType simplified_listener;
+  private final ReaderReadiumFeedbackListenerType readium_listener;
 
   public ReaderWebViewClient(
     final Activity in_activity,
     final ReaderSimplifiedFeedbackDispatcherType in_simplified_dispatcher,
     final ReaderSimplifiedFeedbackListenerType in_simplified_listener,
     final ReaderReadiumFeedbackDispatcherType in_readium_dispatcher,
-    final ReaderReadiumFeedbackListenerType in_readium_listener)
-  {
+    final ReaderReadiumFeedbackListenerType in_readium_listener) {
     this.activity = NullCheck.notNull(in_activity);
     this.simplified_dispatcher = NullCheck.notNull(in_simplified_dispatcher);
     this.simplified_listener = NullCheck.notNull(in_simplified_listener);
@@ -43,9 +45,9 @@ final class ReaderWebViewClient extends WebViewClient
     this.readium_listener = NullCheck.notNull(in_readium_listener);
   }
 
-  private static @Nullable WebResourceResponse getInterceptedRequestResource(
-    final String url)
-  {
+  private static @Nullable
+  WebResourceResponse getInterceptedRequestResource(
+    final String url) {
     if ("simplified-resource:OpenDyslexic3-Regular.ttf".equals(url)) {
       ReaderWebViewClient.LOG.debug("intercepted {} request", url);
       final InputStream stream =
@@ -60,17 +62,17 @@ final class ReaderWebViewClient extends WebViewClient
     return null;
   }
 
-  @Override public void onLoadResource(
+  @Override
+  public void onLoadResource(
     final @Nullable WebView view,
-    final @Nullable String url)
-  {
+    final @Nullable String url) {
     ReaderWebViewClient.LOG.debug("web-request: {}", url);
   }
 
-  @Override public boolean shouldOverrideUrlLoading(
+  @Override
+  public boolean shouldOverrideUrlLoading(
     final @Nullable WebView view,
-    final @Nullable String url)
-  {
+    final @Nullable String url) {
     final String nu = NullCheck.notNull(url);
     final URI uu = NullCheck.notNull(URI.create(nu));
 
@@ -86,19 +88,46 @@ final class ReaderWebViewClient extends WebViewClient
       return true;
     }
 
+    if (!isLocalhost(uu.getHost())) {
+      LOG.debug("rejecting request to non-localhost URI");
+      return true;
+    }
+
     return super.shouldOverrideUrlLoading(view, url);
   }
 
-  @Override public WebResourceResponse shouldInterceptRequest(
+  private static boolean isLocalhost(String host) {
+    return Objects.equals(host, "127.0.0.1")
+      || Objects.equals(host, "::1")
+      || Objects.equals(host, "localhost");
+  }
+
+  @Override
+  public WebResourceResponse shouldInterceptRequest(
     final WebView view,
-    final String url)
-  {
+    final String url) {
     if (url.startsWith("simplified-resource:")) {
       final WebResourceResponse r =
         ReaderWebViewClient.getInterceptedRequestResource(url);
       if (r != null) {
         return r;
       }
+    }
+
+    try {
+      if (!isLocalhost(new URI(url).getHost())) {
+        LOG.debug("rejecting request to non-localhost URI");
+        return new WebResourceResponse(
+          "text/plain",
+          "UTF-8",
+          403,
+          "FORBIDDEN",
+          new HashMap<>(),
+          new ByteArrayInputStream(new byte[0])
+        );
+      }
+    } catch (URISyntaxException e) {
+      LOG.error("invalid URI: ", e);
     }
 
     return super.shouldInterceptRequest(view, url);


### PR DESCRIPTION
**What's this do?**
This adds code to reject any calls made to non-localhost URIs in
Readium 1.

**Why are we doing this? (w/ JIRA link if applicable)**
This is desired by LFA, who want to prevent the limited
bandwidth available to classrooms being wasted by accidental redirects
to real servers on the internet from inside EPUB files.

**How should this be tested? / Do these changes have associated tests?**
Check that books still work. :smile: 

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tested a couple of books in the SimplyE collection.