### PR TITLE
Fix a crash for Related Books...

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <c:changelog project="LibrarySimplified" xmlns:c="urn:com.io7m.changelog:4.0">
   <c:releases>
-    <c:release date="2021-01-14T10:24:26+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.6.0">
+    <c:release date="2021-01-22T13:30:58+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.6.0">
       <c:changes>
         <c:change date="2021-01-14T00:00:00+00:00" summary="Implemented announcements">
           <c:tickets>
@@ -9,9 +9,14 @@
           </c:tickets>
         </c:change>
         <c:change date="2021-01-14T00:00:00+00:00" summary="Improved behaviour of login fields for password managers"/>
-        <c:change date="2021-01-14T10:24:26+00:00" summary="Bookmark syncing support is now correctly remembered for all accounts">
+        <c:change date="2021-01-14T00:00:00+00:00" summary="Bookmark syncing support is now correctly remembered for all accounts">
           <c:tickets>
             <c:ticket id="SIMPLY-2403"/>
+          </c:tickets>
+        </c:change>
+        <c:change date="2021-01-22T13:30:58+00:00" summary="Fix a crash when viewing Related Books in My Books">
+          <c:tickets>
+            <c:ticket id="SIMPLY-3471"/>
           </c:tickets>
         </c:change>
       </c:changes>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -441,6 +441,31 @@ class CatalogFeedViewModel(
     }
   }
 
+  override fun resolveFeedFromBook(
+    accountID: AccountID,
+    title: String,
+    uri: URI
+  ): CatalogFeedArguments {
+    return when (val arguments = this.feedArguments) {
+      is CatalogFeedArgumentsRemote ->
+        CatalogFeedArgumentsRemote(
+          feedURI = arguments.feedURI.resolve(uri).normalize(),
+          isSearchResults = false,
+          ownership = CatalogFeedOwnership.OwnedByAccount(accountID),
+          title = title
+        )
+
+      is CatalogFeedArgumentsLocalBooks -> {
+        CatalogFeedArgumentsRemote(
+          feedURI = uri.normalize(),
+          isSearchResults = false,
+          ownership = CatalogFeedOwnership.OwnedByAccount(accountID),
+          title = title
+        )
+      }
+    }
+  }
+
   override fun reloadFeed(arguments: CatalogFeedArguments) {
     synchronized(this.stateLock) {
       this.state = null

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModelType.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModelType.kt
@@ -2,6 +2,7 @@ package org.nypl.simplified.ui.catalog
 
 import android.os.Parcelable
 import io.reactivex.Observable
+import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.feeds.api.FeedFacet
 import org.nypl.simplified.feeds.api.FeedSearch
 import java.net.URI
@@ -37,6 +38,24 @@ interface CatalogFeedViewModelType {
     title: String,
     uri: URI,
     isSearchResults: Boolean
+  ): CatalogFeedArguments
+
+  /**
+   * Resolve a given URI as a remote feed. The URI, if non-absolute, is resolved against
+   * the current feed arguments in order to produce new arguments to load another feed. This
+   * method is intended to be called from book detail contexts, where there may not be a
+   * feed accessible that has unambiguous account ownership information (ownership can be
+   * per-book, and feeds can contain a mix of accounts).
+   *
+   * @param accountID The account ID that owns the book
+   * @param title The title of the target feed
+   * @param uri The URI of the target feed
+   */
+
+  fun resolveFeedFromBook(
+    accountID: AccountID,
+    title: String,
+    uri: URI
   ): CatalogFeedArguments
 
   /**

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -379,10 +379,10 @@ class CatalogFragmentBookDetail : Fragment() {
     val context = this.requireContext()
     val feedModel = this.createOrGetFeedModel(context)
     val targetFeed =
-      feedModel.resolveFeed(
+      feedModel.resolveFeedFromBook(
+        accountID = this.parameters.feedEntry.accountID,
         title = context.resources.getString(R.string.catalogRelatedBooks),
-        uri = feedRelated,
-        isSearchResults = false
+        uri = feedRelated
       )
     this.findNavigationController().openFeed(targetFeed)
   }


### PR DESCRIPTION
**What's this do?**
This fixes a crash triggered when the user follows a Related Books
link from a book detail page when that book detail page came from
a book in "My Books". This fix introduces a new `resolveFeedFromBook`
method that requires passing in explicit ownership information for
the feed. 

This is somewhat of a stopgap measure. The real fix is
to replace the 1:1 correspondence between catalog feed fragments
and catalog view models with an N:1 correspondence; catalog feed
and book detail fragments should share a single view model that
stores the entire stack of feeds and book detail entries. Once
that happens, full ownership information will be available in
all circumstances and methods like `resolveFeedFromBook` will
no longer be necessary.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3471

**How should this be tested? / Do these changes have associated tests?**
Find a book that you have on loan that has a Related Books link in the
My Books entry for it. Check that you get a feed and not an app crash.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Changelog updated.

**Did someone actually run this code to verify it works?**
@io7m Tried a few books.