### PR TITLE
Hide cancellation buttons

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -783,13 +783,19 @@ class CatalogFragmentBookDetail : Fragment() {
 
     this.buttons.removeAllViews()
     this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
-    this.buttons.addView(
-      this.buttonCreator.createCancelDownloadButton {
-        this.borrowViewModel.tryCancelDownload(book.account, book.id)
-      }
-    )
+    this.buttons.addView(this.buttonCreator.createCancelDownloadButton {
+      this.borrowViewModel.tryCancelDownload(book.account, book.id)
+    })
     this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.checkButtonViewCount()
+
+    /*
+     * XXX: https://jira.nypl.org/browse/SIMPLY-3444
+     *
+     * Hide the cancel button until we can reliably support cancellation for *all* books. That is,
+     * when the Adobe DRM is dead and buried.
+     */
+    this.buttons.removeAllViews()
 
     this.statusInProgress.visibility = View.VISIBLE
     this.statusIdle.visibility = View.INVISIBLE

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -783,9 +783,11 @@ class CatalogFragmentBookDetail : Fragment() {
 
     this.buttons.removeAllViews()
     this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
-    this.buttons.addView(this.buttonCreator.createCancelDownloadButton {
-      this.borrowViewModel.tryCancelDownload(book.account, book.id)
-    })
+    this.buttons.addView(
+      this.buttonCreator.createCancelDownloadButton {
+        this.borrowViewModel.tryCancelDownload(book.account, book.id)
+      }
+    )
     this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.checkButtonViewCount()
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentBookDetail.kt
@@ -781,22 +781,13 @@ class CatalogFragmentBookDetail : Fragment() {
   ) {
     this.uiThread.checkIsUIThread()
 
-    this.buttons.removeAllViews()
-    this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
-    this.buttons.addView(
-      this.buttonCreator.createCancelDownloadButton {
-        this.borrowViewModel.tryCancelDownload(book.account, book.id)
-      }
-    )
-    this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
-    this.checkButtonViewCount()
-
     /*
      * XXX: https://jira.nypl.org/browse/SIMPLY-3444
      *
-     * Hide the cancel button until we can reliably support cancellation for *all* books. That is,
-     * when the Adobe DRM is dead and buried.
+     * Avoid creating a cancel button until we can reliably support cancellation for *all* books.
+     * That is, when the Adobe DRM is dead and buried.
      */
+
     this.buttons.removeAllViews()
 
     this.statusInProgress.visibility = View.VISIBLE


### PR DESCRIPTION
**What's this do?**
This hides the buttons that are used to cancel downloads in book
detail pages. They can be made visible again when _all_ books can be
reliably cancelled regardless of DRM system.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3444

**How should this be tested? / Do these changes have associated tests?**
Check that cancel buttons aren't visible when downloading.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m downloaded various books