### PR TITLE
Don't redirect to settings for no-auth accounts

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
@@ -682,22 +682,29 @@ class CatalogFragmentFeed : Fragment() {
       is FeedLoaderFailedAuthentication -> {
         when (val ownership = this.parameters.ownership) {
           is OwnedByAccount -> {
-            /*
-             * Explicitly deferring the opening of the fragment is required due to the
-             * tabbed navigation controller eagerly instantiating fragments and causing
-             * fragment transaction exceptions. This will go away when we have a replacement
-             * for the navigator library.
-             */
+            val shouldAuthenticate =
+              this.profilesController.profileCurrent()
+                .account(ownership.accountId)
+                .requiresCredentials
 
-            this.uiThread.runOnUIThread {
-              this.navigationController
-                .openSettingsAccount(
-                  AccountFragmentParameters(
-                    accountId = ownership.accountId,
-                    closeOnLoginSuccess = true,
-                    showPleaseLogInTitle = true
+            if (shouldAuthenticate) {
+              /*
+               * Explicitly deferring the opening of the fragment is required due to the
+               * tabbed navigation controller eagerly instantiating fragments and causing
+               * fragment transaction exceptions. This will go away when we have a replacement
+               * for the navigator library.
+               */
+
+              this.uiThread.runOnUIThread {
+                this.navigationController
+                  .openSettingsAccount(
+                    AccountFragmentParameters(
+                      accountId = ownership.accountId,
+                      closeOnLoginSuccess = true,
+                      showPleaseLogInTitle = true
+                    )
                   )
-                )
+              }
             }
           }
           CollectedFromAccounts -> {
@@ -757,7 +764,8 @@ class CatalogFragmentFeed : Fragment() {
       if (isRoot) {
         when (this.parameters.ownership) {
           is OwnedByAccount -> showAccountPickerAction()
-          else -> {} // do nothing
+          else -> {
+          } // do nothing
         }
       }
     } catch (e: Exception) {


### PR DESCRIPTION
**What's this do?**
The current application behaves badly if the server hosting an OPDS
feed returns a response that indicates that authentication is required,
but the corresponding authentication document for the account contains
no authentication mechanisms. What will happen currently is that the
app effectively goes into an unbreakable loop of redirecting the user
to the settings screen and then not presenting any way for the user
to actually log in. This change makes it so that if the account has
no authentication mechanisms, we just show a feed error instead of
opening the settings screen.

**Why are we doing this? (w/ JIRA link if applicable)**
LFA ran into this.

**How should this be tested? / Do these changes have associated tests?**
It should not be possible to encounter this in normal use as it indicates
a misconfigured server. One way to check that nothing is broken is to
add an Open eBooks account from the registry, as Open eBooks has
feeds that require authentication to view.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried with broken LFA feeds, and with working Open eBooks feeds