### PR TITLE
Re-add the ability to show books from all accounts

### DIFF
--- a/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
+++ b/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
@@ -11,6 +11,8 @@ class OEIBuildConfigurationService : BuildConfigurationServiceType {
     get() = true
   override val showHoldsTab: Boolean
     get() = false
+  override val showBooksFromAllAccounts: Boolean
+    get() = false
   override val supportErrorReportEmailAddress: String
     get() = "simplyemigrationreports@nypl.org"
   override val supportErrorReportSubject: String

--- a/simplified-app-simplye/src/main/java/org/nypl/simplified/simplye/SimplyEBuildConfigurationService.kt
+++ b/simplified-app-simplye/src/main/java/org/nypl/simplified/simplye/SimplyEBuildConfigurationService.kt
@@ -13,6 +13,8 @@ class SimplyEBuildConfigurationService : BuildConfigurationServiceType {
     get() = BuildConfigOAuthScheme("simplye-oauth")
   override val allowExternalReaderLinks: Boolean
     get() = true
+  override val showBooksFromAllAccounts: Boolean
+    get() = false
   override val showChangeAccountsUi: Boolean
     get() = true
   override val showDebugBookDetailStatus: Boolean

--- a/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
+++ b/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
@@ -15,6 +15,8 @@ class VanillaBuildConfigurationService : BuildConfigurationServiceType {
     get() = true
   override val showHoldsTab: Boolean
     get() = true
+  override val showBooksFromAllAccounts: Boolean
+    get() = true
   override val vcsCommit: String
     get() = BuildConfig.GIT_COMMIT
   override val simplifiedVersion: String

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationCatalogType.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationCatalogType.kt
@@ -29,4 +29,10 @@ interface BuildConfigurationCatalogType {
    */
 
   val showHoldsTab: Boolean
+
+  /**
+   * Should books from _all_ accounts be shown in the Books views?
+   */
+
+  val showBooksFromAllAccounts: Boolean
 }

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
@@ -27,8 +27,8 @@ import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.ui.accounts.AccountFragment
 import org.nypl.simplified.ui.accounts.AccountFragmentParameters
 import org.nypl.simplified.ui.accounts.AccountListFragment
-import org.nypl.simplified.ui.accounts.AccountListRegistryFragment
 import org.nypl.simplified.ui.accounts.AccountListFragmentParameters
+import org.nypl.simplified.ui.accounts.AccountListRegistryFragment
 import org.nypl.simplified.ui.accounts.saml20.AccountSAML20Fragment
 import org.nypl.simplified.ui.accounts.saml20.AccountSAML20FragmentParameters
 import org.nypl.simplified.ui.catalog.CatalogFeedArguments
@@ -114,6 +114,7 @@ class TabbedNavigationController private constructor(
                 context = activity,
                 id = R.id.tabBooks,
                 profilesController = profilesController,
+                settingsConfiguration = settingsConfiguration,
                 defaultProvider = accountProviders.defaultProvider
               )
             },
@@ -122,6 +123,7 @@ class TabbedNavigationController private constructor(
                 context = activity,
                 id = R.id.tabHolds,
                 profilesController = profilesController,
+                settingsConfiguration = settingsConfiguration,
                 defaultProvider = accountProviders.defaultProvider
               )
             },
@@ -231,6 +233,7 @@ class TabbedNavigationController private constructor(
       context: Context,
       id: Int,
       profilesController: ProfilesControllerType,
+      settingsConfiguration: BuildConfigurationServiceType,
       defaultProvider: AccountProviderType
     ): Fragment {
       this.logger.debug("[{}]: creating holds fragment", id)
@@ -239,10 +242,16 @@ class TabbedNavigationController private constructor(
        * SIMPLY-2923: Filter by the default account until 'All' view is approved by UX.
        */
 
-      val account = pickDefaultAccount(profilesController, defaultProvider)
+      val filterAccountId =
+        if (settingsConfiguration.showBooksFromAllAccounts) {
+          null
+        } else {
+          pickDefaultAccount(profilesController, defaultProvider).id
+        }
+
       return CatalogFragmentFeed.create(
         CatalogFeedArgumentsLocalBooks(
-          filterAccount = account.id,
+          filterAccount = filterAccountId,
           ownership = CatalogFeedOwnership.CollectedFromAccounts,
           searchTerms = null,
           selection = FeedBooksSelection.BOOKS_FEED_HOLDS,
@@ -256,6 +265,7 @@ class TabbedNavigationController private constructor(
       context: Context,
       id: Int,
       profilesController: ProfilesControllerType,
+      settingsConfiguration: BuildConfigurationServiceType,
       defaultProvider: AccountProviderType
     ): Fragment {
       this.logger.debug("[{}]: creating books fragment", id)
@@ -264,10 +274,16 @@ class TabbedNavigationController private constructor(
        * SIMPLY-2923: Filter by the default account until 'All' view is approved by UX.
        */
 
-      val account = pickDefaultAccount(profilesController, defaultProvider)
+      val filterAccountId =
+        if (settingsConfiguration.showBooksFromAllAccounts) {
+          null
+        } else {
+          pickDefaultAccount(profilesController, defaultProvider).id
+        }
+
       return CatalogFragmentFeed.create(
         CatalogFeedArgumentsLocalBooks(
-          filterAccount = account.id,
+          filterAccount = filterAccountId,
           ownership = CatalogFeedOwnership.CollectedFromAccounts,
           searchTerms = null,
           selection = FeedBooksSelection.BOOKS_FEED_LOANED,


### PR DESCRIPTION
**What's this do?**
At some point, we lost the ability for builds to have Books/Holds views
that show books from all accounts. This change adds a build-time flag
that allows builds to opt-in to showing all books.

**Why are we doing this? (w/ JIRA link if applicable)**
LFA use this in their builds.

**How should this be tested? / Do these changes have associated tests?**
Check that SimplyE builds have the same behaviour they always did (showing
books from only the relevant account). Vanilla has been changed to show books
from all accounts.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m checked SimplyE and Vanilla
