### PR TITLE
SIMPLY-3476: Explicit auth return

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainActivity.kt
@@ -521,6 +521,10 @@ class MainActivity :
         override fun openSettingsAccountRegistry() {
           throw UnreachableCodeException()
         }
+
+        override fun openCatalogAfterAuthentication() {
+          throw UnreachableCodeException()
+        }
       }
     )
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -608,7 +608,9 @@ class AccountFragment : Fragment() {
 
   private fun explicitlyClose() {
     if (this.closing.compareAndSet(false, true)) {
-      this.findNavigationController().popBackStack()
+      this.logger.debug("explicitlyClose: popping backstack")
+      this.findNavigationController()
+        .openCatalogAfterAuthentication()
     }
   }
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountNavigationControllerType.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountNavigationControllerType.kt
@@ -33,4 +33,10 @@ interface AccountNavigationControllerType : NavigationControllerType {
    */
 
   fun openSettingsAccountRegistry()
+
+  /**
+   * Switch to whichever tab contains the catalog, forcing a reset of the tab.
+   */
+
+  fun openCatalogAfterAuthentication()
 }

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigationController.kt
@@ -432,6 +432,10 @@ class TabbedNavigationController private constructor(
     )
   }
 
+  override fun openCatalogAfterAuthentication() {
+    this.navigator.reset(R.id.tabCatalog, false)
+  }
+
   override fun clearHistory() {
     this.logger.debug("clearing bottom navigator history")
     this.navigator.clearAll()


### PR DESCRIPTION
**What's this do?**
This adjusts the behaviour of the account fragment in that the "closeOnLoginSuccess"
flag now explicitly switches back to the catalog tab. This is a bit of a stopgap
measure to specifically support Open eBooks and should be replaced when we have
a better viewmodel backing the catalog (the viewmodel would subscribe to account
events, and would refresh itself when an account logs in).

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3476

**How should this be tested? / Do these changes have associated tests?**
1. Open the Open eBooks collection in any app capable of seeing it. The collection (assuming you're not logged in) will redirect you to the settings screen to log in.
2. Log in.
3. After a brief pause (two seconds, currently), observe that you're redirected back to the catalog.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried the Open eBooks collection in SimplyE and Vanilla.