### PR TITLE
Set the Crashlytics user id parameter.

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
@@ -38,16 +38,16 @@ class MainFragmentViewModel : ViewModel() {
     this.services.requireService(ProfilesControllerType::class.java)
   }
   private val crashlytics by lazy {
-    services.optionalService(CrashlyticsServiceType::class.java)
+    this.services.optionalService(CrashlyticsServiceType::class.java)
   }
 
   init {
     this.disposables.add(
-      profilesController.accountEvents()
+      this.profilesController.accountEvents()
         .subscribe(this::onAccountEvent)
     )
     this.disposables.add(
-      profilesController.profileEvents()
+      this.profilesController.profileEvents()
         .subscribe(this::onProfileEvent)
     )
   }
@@ -74,7 +74,7 @@ class MainFragmentViewModel : ViewModel() {
     super.onCleared()
 
     // Clear any disposables before the view model is destroyed
-    disposables.forEach { it.dispose() }
+    this.disposables.forEach { it.dispose() }
   }
 
   private fun onAccountLoginStateChanged(event: AccountEventLoginStateChanged) {
@@ -161,7 +161,7 @@ class MainFragmentViewModel : ViewModel() {
 
   var clearHistory: Boolean = true
     set(value) {
-      logger.debug("clearHistory set to {}", value)
+      this.logger.debug("clearHistory set to {}", value)
       field = value
     }
 }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
@@ -1,7 +1,25 @@
 package org.nypl.simplified.main
 
 import androidx.lifecycle.ViewModel
+import com.io7m.junreachable.UnreachableCodeException
+import io.reactivex.disposables.Disposable
+import org.librarysimplified.services.api.Services
+import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
+import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials.Basic
+import org.nypl.simplified.accounts.api.AccountEvent
+import org.nypl.simplified.accounts.api.AccountEventLoginStateChanged
+import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggedIn
+import org.nypl.simplified.accounts.api.AccountLoginState.AccountNotLoggedIn
+import org.nypl.simplified.accounts.api.AccountReadableType
+import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
+import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
+import org.nypl.simplified.profiles.api.ProfileEvent
+import org.nypl.simplified.profiles.api.ProfileReadableType
+import org.nypl.simplified.profiles.api.ProfileSelection.ProfileSelectionCompleted
+import org.nypl.simplified.profiles.api.ProfileUpdated
+import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.slf4j.LoggerFactory
+import java.security.MessageDigest
 
 /**
  * The view model for the main fragment.
@@ -11,13 +29,150 @@ class MainFragmentViewModel : ViewModel() {
 
   private val logger = LoggerFactory.getLogger(MainFragmentViewModel::class.java)
 
-  /**
-   * `true` if the history of tabs should be cleared.
-   */
+  private val disposables = mutableListOf<Disposable>()
+  private val services = Services.serviceDirectory()
+  private val accountProviders by lazy {
+    this.services.requireService(AccountProviderRegistryType::class.java)
+  }
+  private val profilesController by lazy {
+    this.services.requireService(ProfilesControllerType::class.java)
+  }
+  private val crashlytics by lazy {
+    services.optionalService(CrashlyticsServiceType::class.java)
+  }
+
+  init {
+    this.disposables.add(
+      profilesController.accountEvents()
+        .subscribe(this::onAccountEvent)
+    )
+    this.disposables.add(
+      profilesController.profileEvents()
+        .subscribe(this::onProfileEvent)
+    )
+  }
+
+  val currentProfile: ProfileReadableType
+    get() {
+      return this.profilesController.profileCurrent()
+    }
+  val currentAccount: AccountReadableType?
+    get() {
+      return this.currentProfile.mostRecentAccount() ?: when (this.currentProfile.accounts().size) {
+        0 -> throw UnreachableCodeException() // We expect one account to always exist
+        1 -> this.currentProfile.accounts().values.first()
+        else -> {
+          val defaultProvider = this.accountProviders.defaultProvider
+          this.currentProfile.accounts().values.first {
+            it.provider.id != defaultProvider.id
+          }
+        }
+      }
+    }
+
+  override fun onCleared() {
+    super.onCleared()
+
+    // Clear any disposables before the view model is destroyed
+    disposables.forEach { it.dispose() }
+  }
+
+  private fun onAccountLoginStateChanged(event: AccountEventLoginStateChanged) {
+    when (val state = event.state) {
+      is AccountNotLoggedIn -> {
+        if (event.accountID == this.currentAccount?.id) {
+          clearCrashlyticsUserId()
+        }
+      }
+      is AccountLoggedIn -> {
+        if (event.accountID == this.currentAccount?.id) {
+          setCrashlyticsUserId(state.credentials)
+        }
+      }
+      else -> {
+        // Ignored
+      }
+    }
+  }
+
+  private fun onAccountEvent(event: AccountEvent) {
+    when (event) {
+      is AccountEventLoginStateChanged -> {
+        onAccountLoginStateChanged(event)
+      }
+      else -> {
+        // Ignored
+      }
+    }
+  }
+
+  private fun onProfileEvent(event: ProfileEvent) {
+    when (event) {
+      is ProfileSelectionCompleted -> {
+        // The active profile changed
+        val credentials = this.currentAccount?.loginState?.credentials
+
+        if (credentials == null) {
+          clearCrashlyticsUserId()
+        } else {
+          setCrashlyticsUserId(credentials)
+        }
+      }
+      is ProfileUpdated.Succeeded -> {
+        // The profile was updated, this might mean the patron changed
+        // the current account.
+        val credentials = this.currentAccount?.loginState?.credentials
+
+        if (credentials == null) {
+          clearCrashlyticsUserId()
+        } else {
+          setCrashlyticsUserId(credentials)
+        }
+      }
+      else -> {
+        // Ignored
+      }
+    }
+  }
+
+  private fun clearCrashlyticsUserId() {
+    this.crashlytics?.setUserId("")
+  }
+
+  private fun setCrashlyticsUserId(userId: String) {
+    this.crashlytics?.let { service ->
+      val hashedUserId = md5(userId)
+      service.setUserId(hashedUserId)
+    }
+  }
+
+  private fun setCrashlyticsUserId(credentials: AccountAuthenticationCredentials) {
+    when (credentials) {
+      is Basic -> {
+        setCrashlyticsUserId(credentials.userName.value)
+      }
+      else -> {
+        clearCrashlyticsUserId()
+      }
+    }
+  }
+
+  /** `true` if the history of tabs should be cleared. */
 
   var clearHistory: Boolean = true
     set(value) {
       logger.debug("clearHistory set to {}", value)
       field = value
     }
+}
+
+private fun md5(value: String): String {
+  val md = MessageDigest.getInstance("MD5")
+  md.update(value.toByteArray())
+
+  val sb = StringBuilder(64)
+  md.digest().forEach { bb ->
+    sb.append(String.format("%02x", bb))
+  }
+  return sb.toString()
 }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
@@ -2,7 +2,7 @@ package org.nypl.simplified.main
 
 import androidx.lifecycle.ViewModel
 import com.io7m.junreachable.UnreachableCodeException
-import io.reactivex.disposables.Disposable
+import io.reactivex.disposables.CompositeDisposable
 import org.librarysimplified.services.api.Services
 import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
 import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials.Basic
@@ -29,7 +29,7 @@ class MainFragmentViewModel : ViewModel() {
 
   private val logger = LoggerFactory.getLogger(MainFragmentViewModel::class.java)
 
-  private val disposables = mutableListOf<Disposable>()
+  private val disposable = CompositeDisposable()
   private val services = Services.serviceDirectory()
   private val accountProviders by lazy {
     this.services.requireService(AccountProviderRegistryType::class.java)
@@ -42,11 +42,9 @@ class MainFragmentViewModel : ViewModel() {
   }
 
   init {
-    this.disposables.add(
+    this.disposable.addAll(
       this.profilesController.accountEvents()
-        .subscribe(this::onAccountEvent)
-    )
-    this.disposables.add(
+        .subscribe(this::onAccountEvent),
       this.profilesController.profileEvents()
         .subscribe(this::onProfileEvent)
     )
@@ -72,9 +70,7 @@ class MainFragmentViewModel : ViewModel() {
 
   override fun onCleared() {
     super.onCleared()
-
-    // Clear any disposables before the view model is destroyed
-    this.disposables.forEach { it.dispose() }
+    this.disposable.dispose()
   }
 
   private fun onAccountLoginStateChanged(event: AccountEventLoginStateChanged) {

--- a/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfileReadableType.kt
+++ b/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfileReadableType.kt
@@ -3,7 +3,6 @@ package org.nypl.simplified.profiles.api
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.accounts.database.api.AccountType
 import org.nypl.simplified.accounts.database.api.AccountsDatabaseNonexistentException
-
 import java.io.File
 import java.net.URI
 import java.util.SortedMap
@@ -91,4 +90,14 @@ interface ProfileReadableType : Comparable<ProfileReadableType> {
 
   @Throws(AccountsDatabaseNonexistentException::class)
   fun account(accountId: AccountID): AccountType
+
+  /**
+   * @return The most recently used account, or null.
+   */
+
+  fun mostRecentAccount(): AccountType? {
+    return this.preferences().mostRecentAccount?.let { accountId ->
+      this.account(accountId)
+    }
+  }
 }

--- a/simplified-profiles-controller-api/src/main/java/org/nypl/simplified/profiles/controller/api/ProfilesControllerType.kt
+++ b/simplified-profiles-controller-api/src/main/java/org/nypl/simplified/profiles/controller/api/ProfilesControllerType.kt
@@ -38,6 +38,12 @@ interface ProfilesControllerType {
   fun profiles(): SortedMap<ProfileID, ProfileReadableType>
 
   /**
+   * @return The profile, or null.
+   */
+
+  fun profile(id: ProfileID) = this.profiles()[id]
+
+  /**
    * @return [ProfilesDatabaseType.AnonymousProfileEnabled.ANONYMOUS_PROFILE_ENABLED] if the anonymous profile is enabled
    */
 


### PR DESCRIPTION
**What's this do?**
If the current account is authenticated then set the Crashlytics user id
to the md5 hash of the account username.

This allows us to search Crashlytics by username (barcode) when we get
bug reports from specific patrons.

**Why are we doing this? (w/ JIRA link if applicable)**
To match the behavior of iOS and enable partners (e.g. Lyrasis) to look up crashes.

**How should this be tested? / Do these changes have associated tests?**
n/a

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@twaddington ran the Vanilla app.