### PR TITLE
Clear web cache once readium has initialized.

### DIFF
--- a/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
+++ b/simplified-viewer-epub-readium1/src/main/java/org/nypl/simplified/viewer/epub/readium1/ReaderActivity.java
@@ -876,6 +876,8 @@ public final class ReaderActivity extends AppCompatActivity implements
           this.readium_js_api.mediaOverlayPrevious();
         });
     });
+
+    clearWebCache();
   }
 
   @Override


### PR DESCRIPTION
**What's this do?**

Clear the WebView cache as soon as Readium has initialized. This removes cached JS files.

**Why are we doing this? (w/ JIRA link if applicable)**

This is a follow-on to [SIMPLY-3362](https://jira.nypl.org/browse/SIMPLY-3362)/[#840](https://github.com/NYPL-Simplified/Simplified-Android-Core/pull/840), to add a bit of insurance that we will pass security checks. Apparently it's not possible to prevent WebView from caching JS files altogether, so this removes them as soon as possible. The problem with cached files is that they reveal the port number of the embedded http server. With this knowledge, one could use a browser to get decrypted content directly from the http server.

**How should this be tested? / Do these changes have associated tests?**

Open a book in Readium. Browse the filesystem at /data/data/org.nypl.simplified.vanilla/cache/WebView/Default/HTTP Cache/Code Cache. There should be no JS files cached.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.