### PR TITLE
Redo Crashlytics control

### DIFF
--- a/simplified-books-controller/build.gradle
+++ b/simplified-books-controller/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   implementation project(":simplified-books-audio")
   implementation project(":simplified-books-borrowing")
   implementation project(":simplified-books-registry-api")
+  implementation project(":simplified-crashlytics-api")
   implementation project(":simplified-feeds-api")
   implementation project(":simplified-files")
   implementation project(":simplified-futures")

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ControllerCrashlytics.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ControllerCrashlytics.kt
@@ -1,0 +1,60 @@
+package org.nypl.simplified.books.controller
+
+import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
+import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
+import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
+import org.nypl.simplified.profiles.api.ProfileReadableType
+import java.security.MessageDigest
+
+internal object ControllerCrashlytics {
+
+  fun configureCrashlytics(
+    profile: ProfileReadableType,
+    accountProviders: AccountProviderRegistryType,
+    crashlytics: CrashlyticsServiceType
+  ) {
+    val account =
+      profile.mostRecentAccount() ?: profile.accountsByProvider()[accountProviders.defaultProvider.id]
+    if (account != null) {
+      this.configureCrashlyticsForCredentials(crashlytics, account.loginState.credentials)
+    }
+  }
+
+  private fun configureCrashlyticsForCredentials(
+    crashlytics: CrashlyticsServiceType,
+    credentials: AccountAuthenticationCredentials?
+  ) {
+    return when (credentials) {
+      is AccountAuthenticationCredentials.Basic -> {
+        this.setCrashlyticsUserID(crashlytics, credentials.userName.value)
+      }
+      is AccountAuthenticationCredentials.OAuthWithIntermediary,
+      is AccountAuthenticationCredentials.SAML2_0,
+      null -> {
+        this.clearCrashlyticsUserID(crashlytics)
+      }
+    }
+  }
+
+  private fun setCrashlyticsUserID(
+    crashlytics: CrashlyticsServiceType,
+    value: String
+  ) {
+    crashlytics.setUserId(this.md5(value))
+  }
+
+  private fun clearCrashlyticsUserID(crashlytics: CrashlyticsServiceType) {
+    crashlytics.setUserId("")
+  }
+
+  private fun md5(value: String): String {
+    val md = MessageDigest.getInstance("MD5")
+    md.update(value.toByteArray())
+
+    val sb = StringBuilder(64)
+    md.digest().forEach { bb ->
+      sb.append(String.format("%02x", bb))
+    }
+    return sb.toString()
+  }
+}

--- a/simplified-crashlytics-api/src/main/java/org/nypl/simplified/crashlytics/api/CrashlyticsServiceType.kt
+++ b/simplified-crashlytics-api/src/main/java/org/nypl/simplified/crashlytics/api/CrashlyticsServiceType.kt
@@ -11,6 +11,9 @@ package org.nypl.simplified.crashlytics.api
 
 interface CrashlyticsServiceType {
 
+  /** The most recently configured user ID. */
+  val userId: String
+
   /** Logs a message with the next fatal or non-fatal report. */
   fun log(message: String)
 

--- a/simplified-crashlytics/src/main/java/org/nypl/simplified/crashlytics/CrashlyticsService.kt
+++ b/simplified-crashlytics/src/main/java/org/nypl/simplified/crashlytics/CrashlyticsService.kt
@@ -4,9 +4,16 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
 
 class CrashlyticsService : CrashlyticsServiceType {
+
+  @Volatile
+  private var userIdMostRecent: String = ""
+
   private val instance by lazy {
     FirebaseCrashlytics.getInstance()
   }
+
+  override val userId: String
+    get() = this.userIdMostRecent
 
   override fun log(message: String) {
     this.instance.log(message)
@@ -21,6 +28,7 @@ class CrashlyticsService : CrashlyticsServiceType {
   }
 
   override fun setUserId(identifier: String) {
+    this.userIdMostRecent = identifier
     this.instance.setUserId(identifier)
   }
 

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
@@ -1,25 +1,7 @@
 package org.nypl.simplified.main
 
 import androidx.lifecycle.ViewModel
-import com.io7m.junreachable.UnreachableCodeException
-import io.reactivex.disposables.CompositeDisposable
-import org.librarysimplified.services.api.Services
-import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
-import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials.Basic
-import org.nypl.simplified.accounts.api.AccountEvent
-import org.nypl.simplified.accounts.api.AccountEventLoginStateChanged
-import org.nypl.simplified.accounts.api.AccountLoginState.AccountLoggedIn
-import org.nypl.simplified.accounts.api.AccountLoginState.AccountNotLoggedIn
-import org.nypl.simplified.accounts.api.AccountReadableType
-import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
-import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
-import org.nypl.simplified.profiles.api.ProfileEvent
-import org.nypl.simplified.profiles.api.ProfileReadableType
-import org.nypl.simplified.profiles.api.ProfileSelection.ProfileSelectionCompleted
-import org.nypl.simplified.profiles.api.ProfileUpdated
-import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.slf4j.LoggerFactory
-import java.security.MessageDigest
 
 /**
  * The view model for the main fragment.
@@ -29,130 +11,6 @@ class MainFragmentViewModel : ViewModel() {
 
   private val logger = LoggerFactory.getLogger(MainFragmentViewModel::class.java)
 
-  private val disposable = CompositeDisposable()
-  private val services = Services.serviceDirectory()
-  private val accountProviders by lazy {
-    this.services.requireService(AccountProviderRegistryType::class.java)
-  }
-  private val profilesController by lazy {
-    this.services.requireService(ProfilesControllerType::class.java)
-  }
-  private val crashlytics by lazy {
-    this.services.optionalService(CrashlyticsServiceType::class.java)
-  }
-
-  init {
-    this.disposable.addAll(
-      this.profilesController.accountEvents()
-        .subscribe(this::onAccountEvent),
-      this.profilesController.profileEvents()
-        .subscribe(this::onProfileEvent)
-    )
-  }
-
-  val currentProfile: ProfileReadableType
-    get() {
-      return this.profilesController.profileCurrent()
-    }
-  val currentAccount: AccountReadableType?
-    get() {
-      return this.currentProfile.mostRecentAccount() ?: when (this.currentProfile.accounts().size) {
-        0 -> throw UnreachableCodeException() // We expect one account to always exist
-        1 -> this.currentProfile.accounts().values.first()
-        else -> {
-          val defaultProvider = this.accountProviders.defaultProvider
-          this.currentProfile.accounts().values.first {
-            it.provider.id != defaultProvider.id
-          }
-        }
-      }
-    }
-
-  override fun onCleared() {
-    super.onCleared()
-    this.disposable.dispose()
-  }
-
-  private fun onAccountLoginStateChanged(event: AccountEventLoginStateChanged) {
-    when (val state = event.state) {
-      is AccountNotLoggedIn -> {
-        if (event.accountID == this.currentAccount?.id) {
-          clearCrashlyticsUserId()
-        }
-      }
-      is AccountLoggedIn -> {
-        if (event.accountID == this.currentAccount?.id) {
-          setCrashlyticsUserId(state.credentials)
-        }
-      }
-      else -> {
-        // Ignored
-      }
-    }
-  }
-
-  private fun onAccountEvent(event: AccountEvent) {
-    when (event) {
-      is AccountEventLoginStateChanged -> {
-        onAccountLoginStateChanged(event)
-      }
-      else -> {
-        // Ignored
-      }
-    }
-  }
-
-  private fun onProfileEvent(event: ProfileEvent) {
-    when (event) {
-      is ProfileSelectionCompleted -> {
-        // The active profile changed
-        val credentials = this.currentAccount?.loginState?.credentials
-
-        if (credentials == null) {
-          clearCrashlyticsUserId()
-        } else {
-          setCrashlyticsUserId(credentials)
-        }
-      }
-      is ProfileUpdated.Succeeded -> {
-        // The profile was updated, this might mean the patron changed
-        // the current account.
-        val credentials = this.currentAccount?.loginState?.credentials
-
-        if (credentials == null) {
-          clearCrashlyticsUserId()
-        } else {
-          setCrashlyticsUserId(credentials)
-        }
-      }
-      else -> {
-        // Ignored
-      }
-    }
-  }
-
-  private fun clearCrashlyticsUserId() {
-    this.crashlytics?.setUserId("")
-  }
-
-  private fun setCrashlyticsUserId(userId: String) {
-    this.crashlytics?.let { service ->
-      val hashedUserId = md5(userId)
-      service.setUserId(hashedUserId)
-    }
-  }
-
-  private fun setCrashlyticsUserId(credentials: AccountAuthenticationCredentials) {
-    when (credentials) {
-      is Basic -> {
-        setCrashlyticsUserId(credentials.userName.value)
-      }
-      else -> {
-        clearCrashlyticsUserId()
-      }
-    }
-  }
-
   /** `true` if the history of tabs should be cleared. */
 
   var clearHistory: Boolean = true
@@ -160,15 +18,4 @@ class MainFragmentViewModel : ViewModel() {
       this.logger.debug("clearHistory set to {}", value)
       field = value
     }
-}
-
-private fun md5(value: String): String {
-  val md = MessageDigest.getInstance("MD5")
-  md.update(value.toByteArray())
-
-  val sb = StringBuilder(64)
-  md.digest().forEach { bb ->
-    sb.append(String.format("%02x", bb))
-  }
-  return sb.toString()
 }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -69,6 +69,7 @@ import org.nypl.simplified.cardcreator.CardCreatorService
 import org.nypl.simplified.cardcreator.CardCreatorServiceType
 import org.nypl.simplified.content.api.ContentResolverSane
 import org.nypl.simplified.content.api.ContentResolverType
+import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
 import org.nypl.simplified.feeds.api.FeedHTTPTransport
 import org.nypl.simplified.feeds.api.FeedLoader
 import org.nypl.simplified.feeds.api.FeedLoaderType
@@ -604,6 +605,20 @@ internal object MainServices {
       return service
     }
 
+    fun <T : Any> addServiceFromServiceLoaderOptionally(
+      message: String,
+      interfaceType: Class<T>
+    ): T? {
+      publishEvent(message)
+      val service = ServiceLoader.load(interfaceType).firstOrNull()
+      if (service != null) {
+        services.addService(interfaceType, service)
+      } else {
+        logger.debug("no services of type {} available in ServiceLoader", interfaceType)
+      }
+      return service
+    }
+
     addService(
       message = strings.bootingGeneral("login strings"),
       interfaceType = AccountLoginStringResourcesType::class.java,
@@ -640,6 +655,11 @@ internal object MainServices {
       message = strings.bootingGeneral("book revocation strings"),
       interfaceType = BookRevokeStringResourcesType::class.java,
       serviceConstructor = { MainCatalogBookRevokeStrings(context.resources) }
+    )
+
+    addServiceFromServiceLoaderOptionally(
+      message = strings.bootingGeneral("Crashlytics"),
+      interfaceType = CrashlyticsServiceType::class.java
     )
 
     val lsHTTP =

--- a/simplified-ui-settings/build.gradle
+++ b/simplified-ui-settings/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   implementation project(":simplified-boot-api")
   implementation project(":simplified-buildconfig-api")
   implementation project(":simplified-cardcreator")
+  implementation project(":simplified-crashlytics-api")
   implementation project(":simplified-documents")
   implementation project(":simplified-oauth")
   implementation project(":simplified-profiles-controller-api")

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentDebug.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsFragmentDebug.kt
@@ -29,6 +29,7 @@ import org.nypl.simplified.books.controller.api.BooksControllerType
 import org.nypl.simplified.boot.api.BootFailureTesting
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.cardcreator.CardCreatorDebugging
+import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
 import org.nypl.simplified.feeds.api.FeedLoaderType
 import org.nypl.simplified.navigation.api.NavigationControllers
 import org.nypl.simplified.profiles.api.ProfileEvent
@@ -77,6 +78,7 @@ class SettingsFragmentDebug : Fragment() {
   private lateinit var cacheButton: Button
   private lateinit var cardCreatorFakeLocation: SwitchCompat
   private lateinit var crashButton: Button
+  private lateinit var crashlyticsId: TextView
   private lateinit var customOPDS: Button
   private lateinit var drmTable: TableLayout
   private lateinit var enableR2: SwitchCompat
@@ -92,7 +94,7 @@ class SettingsFragmentDebug : Fragment() {
   private lateinit var showTesting: SwitchCompat
   private lateinit var syncAccountsButton: Button
   private lateinit var uiThread: UIThreadServiceType
-
+  private var crashlytics: CrashlyticsServiceType? = null
   private var adeptExecutor: AdobeAdeptExecutorType? = null
   private var profileEventSubscription: Disposable? = null
 
@@ -117,6 +119,8 @@ class SettingsFragmentDebug : Fragment() {
       services.requireService(BuildConfigurationServiceType::class.java)
     this.adeptExecutor =
       services.optionalService(AdobeAdeptExecutorType::class.java)
+    this.crashlytics =
+      services.optionalService(CrashlyticsServiceType::class.java)
   }
 
   override fun onCreateView(
@@ -159,6 +163,8 @@ class SettingsFragmentDebug : Fragment() {
       view.findViewById(R.id.settingsVersionDevShowOnlySupported)
     this.customOPDS =
       view.findViewById(R.id.settingsVersionDevCustomOPDS)
+    this.crashlyticsId =
+      view.findViewById<TextView>(R.id.settingsVersionCrashlyticsID)
 
     return view
   }
@@ -336,6 +342,22 @@ class SettingsFragmentDebug : Fragment() {
 
     this.forgetAnnouncementsButton.setOnClickListener {
       this.forgetAllAnnouncements()
+    }
+
+    /*
+     * Show the current Crashlytics user ID.
+     */
+
+    val crash = this.crashlytics
+    if (crash != null) {
+      val id = crash.userId
+      if (id == "") {
+        this.crashlyticsId.text = "(Unassigned)"
+      } else {
+        this.crashlyticsId.text = crash.userId
+      }
+    } else {
+      this.crashlyticsId.text = "Crashlytics is not enabled."
     }
   }
 

--- a/simplified-ui-settings/src/main/res/layout/settings_debug.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_debug.xml
@@ -123,6 +123,33 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginBottom="16dp"
+      android:text="Crashlytics"
+      android:textSize="24sp"
+      android:textStyle="bold" />
+
+    <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="16dp"
+      android:text="Current Crashlytics User ID"
+      android:textSize="14sp"
+      android:textStyle="bold" />
+
+    <TextView
+      android:id="@+id/settingsVersionCrashlyticsID"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="16dp"
+      android:fontFamily="monospace"
+      android:text="PLACEHOLDER"
+      android:textIsSelectable="true"
+      android:textSize="14sp"
+      android:textStyle="bold" />
+
+    <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="16dp"
       android:text="Testing Features"
       android:textSize="24sp"
       android:textStyle="bold" />


### PR DESCRIPTION
**What's this do?**
This moves the Crashlytics handling from the main fragment view model
into the profile controller. This prevents a couple of crashes that
showed up in LFA builds. This also adds a small section to the debug
setting UI that shows the user their current Crashlytics ID.

**Why are we doing this? (w/ JIRA link if applicable)**
LFA builds were crashing due to a `lazy` race condition. Looking at it, I realized that the Crashlytics handling didn't need to be in a view model at all.

**How should this be tested? / Do these changes have associated tests?**
Check Crashlytics. :smile:

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tested on multiple accounts.