### PR TITLE
SIMPLY-3544: Remove mailto: from recipient address in report an issue email

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountFragment.kt
@@ -477,11 +477,13 @@ class AccountFragment : Fragment() {
   private fun configureReportIssue() {
     val email = this.account.provider.supportEmail
     if (email != null) {
+      val address = email.removePrefix("mailto:")
+
       this.reportIssueGroup.visibility = View.VISIBLE
-      this.reportIssueEmail.text = email.removePrefix("mailto:")
+      this.reportIssueEmail.text = address
       this.reportIssueGroup.setOnClickListener {
         val emailIntent =
-          Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", email, null))
+          Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", address, null))
         val chosenIntent =
           Intent.createChooser(emailIntent, this.resources.getString(R.string.accountReportIssue))
 
@@ -491,7 +493,7 @@ class AccountFragment : Fragment() {
           this.logger.error("unable to start activity: ", e)
           val context = this.requireContext()
           AlertDialog.Builder(context)
-            .setMessage(context.getString(R.string.accountReportFailed, email))
+            .setMessage(context.getString(R.string.accountReportFailed, address))
             .create()
             .show()
         }


### PR DESCRIPTION
**What's this do?**

Removes the "mailto:" prefix from the To address in an email composed from the "Report an issue" link.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-3544](https://jira.nypl.org/browse/SIMPLY-3544).

**How should this be tested? / Do these changes have associated tests?**

Open the Account screen for the SimplyE collection. Tap "Report an issue..." at the bottom. An email should open, and the To address should be populated with `gethelp+simplye-collection@nypl.org` (not `mailto:gethelp+simplye-collection@nypl.org`).

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.