### PR TITLE
Ensure correct adobe credentials are associated with the current account.

### DIFF
--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLoginTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLoginTask.kt
@@ -391,8 +391,21 @@ class ProfileAccountLoginTask(
         "Must have returned at least one activation"
       )
 
+      /*
+       * Find the newly activated credentials (the one whose user id is not associated with any
+       * account). There should only be one, and it should be the last in the list, but this check
+       * makes sure.
+       */
+
+      val newPostCredentials = postCredentials.last { credentials ->
+        this.profile.accounts().values.none { account ->
+          account.loginState.credentials?.adobeCredentials?.postActivationCredentials?.userID ==
+            credentials.userID
+        }
+      }
+
       this.credentials = this.credentials.withAdobePreActivationCredentials(
-        adobePreCredentials.copy(postActivationCredentials = postCredentials.first())
+        adobePreCredentials.copy(postActivationCredentials = newPostCredentials)
       )
       this.steps.currentStepSucceeded(this.loginStrings.loginDeviceActivated)
     } catch (e: ExecutionException) {

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLoginTaskContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLoginTaskContract.kt
@@ -1025,6 +1025,164 @@ abstract class ProfileAccountLoginTaskContract {
   }
 
   /**
+   * If the Adobe DRM connector delivers multiple activations, the one that is not associated with
+   * any other accounts is used.
+   */
+
+  @Test(timeout = 5_000L)
+  fun testLoginAdobeDRMMultipleActivations() {
+    val previouslyLoggedInAccountId = AccountID(UUID.randomUUID())
+    val previouslyLoggedInAccount = Mockito.mock(AccountType::class.java, Mockito.RETURNS_DEEP_STUBS)
+
+    Mockito.`when`(
+      previouslyLoggedInAccount.loginState.credentials?.adobeCredentials?.postActivationCredentials?.userID
+    ).thenReturn(AdobeUserID("someone"))
+
+    val authDescription =
+      AccountProviderAuthenticationDescription.Basic(
+        barcodeFormat = "CODABAR",
+        keyboard = KeyboardInput.DEFAULT,
+        passwordMaximumLength = 10,
+        passwordKeyboard = KeyboardInput.DEFAULT,
+        description = "Library Login",
+        labels = mapOf(),
+        logoURI = null
+      )
+
+    val request =
+      ProfileAccountLoginRequest.Basic(
+        accountId = this.accountID,
+        description = authDescription,
+        username = AccountUsername("user"),
+        password = AccountPassword("password")
+      )
+
+    val provider =
+      Mockito.mock(AccountProviderType::class.java)
+
+    Mockito.`when`(provider.patronSettingsURI)
+      .thenReturn(this.server.url("patron").toUri())
+
+    Mockito.`when`(provider.authentication)
+      .thenReturn(authDescription)
+
+    Mockito.`when`(this.profile.id)
+      .thenReturn(this.profileID)
+    Mockito.`when`(this.profile.accounts())
+      .thenReturn(
+        sortedMapOf(
+          Pair(previouslyLoggedInAccountId, previouslyLoggedInAccount),
+          Pair(this.accountID, this.account)
+        )
+      )
+    Mockito.`when`(this.account.id)
+      .thenReturn(this.accountID)
+    Mockito.`when`(this.account.provider)
+      .thenReturn(provider)
+    Mockito.`when`(this.account.setLoginState(this.anyNonNull()))
+      .then {
+        val newState = it.getArgument<AccountLoginState>(0)
+        this.logger.debug("new state: {}", newState)
+        this.loginState = newState
+        this.loginState
+      }
+    Mockito.`when`(this.account.loginState)
+      .then { this.loginState }
+
+    this.server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody(this.profileWithDRM.trimIndent())
+    )
+
+    this.server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+    )
+
+    Mockito.`when`(
+      this.adeptConnector.activateDevice(
+        this.anyNonNull(),
+        this.anyNonNull(),
+        this.anyNonNull(),
+        this.anyNonNull()
+      )
+    ).then { invocation ->
+      val receiver = invocation.arguments[0] as AdobeAdeptActivationReceiverType
+      receiver.onActivationsCount(2)
+      receiver.onActivation(
+        0,
+        AdobeVendorID("OmniConsumerProducts"),
+        AdobeDeviceID("484799fb-d1aa-4b5d-8179-95e0b115ace4"),
+        "user",
+        AdobeUserID("someone"),
+        null
+      )
+      receiver.onActivation(
+        1,
+        AdobeVendorID("OmniConsumerProducts"),
+        AdobeDeviceID("deb213da-3dd1-4978-9642-03d1f288154c"),
+        "another.user",
+        AdobeUserID("someone.else"),
+        null
+      )
+    }
+
+    Mockito.`when`(this.adeptExecutor.execute(this.anyNonNull()))
+      .then { invocation ->
+        val procedure = invocation.arguments[0] as AdobeAdeptProcedureType
+        procedure.executeWith(this.adeptConnector)
+      }
+
+    val task =
+      ProfileAccountLoginTask(
+        adeptExecutor = this.adeptExecutor,
+        http = this.http,
+        profile = this.profile,
+        account = this.account,
+        loginStrings = this.loginStrings,
+        patronParsers = this.patronParserFactory,
+        request = request
+      )
+
+    val result = task.call()
+    TaskDumps.dump(this.logger, result)
+
+    val state =
+      this.account.loginState as AccountLoggedIn
+
+    val originalCredentials =
+      AccountAuthenticationCredentials.Basic(
+        userName = request.username,
+        password = request.password,
+        adobeCredentials = null,
+        authenticationDescription = "Library Login"
+      )
+
+    val newCredentials =
+      originalCredentials.withAdobePreActivationCredentials(
+        AccountAuthenticationAdobePreActivationCredentials(
+          vendorID = AdobeVendorID("OmniConsumerProducts"),
+          clientToken = AccountAuthenticationAdobeClientToken.parse("NYNYPL|536818535|b54be3a5-385b-42eb-9496-3879cb3ac3cc|TWFuIHN1ZmZlcnMgb25seSBiZWNhdXNlIGhlIHRha2VzIHNlcmlvdXNseSB3aGF0IHRoZSBnb2RzIG1hZGUgZm9yIGZ1bi4K"),
+          deviceManagerURI = this.server.url("devices").toUri(),
+          postActivationCredentials = AccountAuthenticationAdobePostActivationCredentials(
+            deviceID = AdobeDeviceID("deb213da-3dd1-4978-9642-03d1f288154c"),
+            userID = AdobeUserID("someone.else")
+          )
+        )
+      )
+
+    assertEquals(newCredentials, state.credentials)
+
+    val req0 = this.server.takeRequest()
+    assertEquals(this.server.url("patron"), req0.requestUrl)
+    val req1 = this.server.takeRequest()
+    assertEquals(this.server.url("devices"), req1.requestUrl)
+
+    assertEquals(2, this.server.requestCount)
+  }
+
+  /**
    * If the Adobe DRM connector delivers an error, then activation fails.
    */
 


### PR DESCRIPTION
**What's this do?**

When Adobe credentials are activated, the Adobe DRM connector can return a list of multiple credentials, including the newly activated credentials, and any that were previously activated for other accounts. This attempts to ensure that the current account is associated with the correct credentials, by finding the last credentials in the last that are not associated with any other account.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-2979](https://jira.nypl.org/browse/SIMPLY-2979). Previously, if activation returned a list of credentials, the first in the list was assumed to be the newly activated credentials for the current account. If other accounts had previously been activated, the first in the list actually belonged to the first account that was activated, not the current account being activated.

**How should this be tested? / Do these changes have associated tests?**

Unit tests are included. See the [first comment in SIMPLY-2979](https://jira.nypl.org/browse/SIMPLY-2979?focusedCommentId=52276&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-52276) for testing steps. 

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this in a slightly older commit of the SimplyE app. I can't run it in the latest commit of SimplyE because of [SIMPLY-3529](https://jira.nypl.org/browse/SIMPLY-3529), but I don't think there's any reason to believe it wouldn't work.