### PR TITLE
SIMPLY-3574: Fix data being incorrectly set in error reporting intent.

### DIFF
--- a/simplified-reports/src/main/java/org/nypl/simplified/reports/Reports.kt
+++ b/simplified-reports/src/main/java/org/nypl/simplified/reports/Reports.kt
@@ -102,7 +102,7 @@ object Reports {
       val compressedFiles =
         files.mapNotNull(this::compressFile)
       val contentUris =
-        compressedFiles.map { file -> this.mapFileToContentURI(context, file) }
+        compressedFiles.toSet().map { file -> this.mapFileToContentURI(context, file) }
 
       this.logger.debug("attaching {} files", compressedFiles.size)
 
@@ -112,7 +112,7 @@ object Reports {
           this.putExtra(Intent.EXTRA_EMAIL, arrayOf(address))
           this.putExtra(Intent.EXTRA_SUBJECT, subject)
           this.putExtra(Intent.EXTRA_TEXT, body)
-          this.putExtra(Intent.EXTRA_STREAM, arrayListOf(contentUris))
+          this.putExtra(Intent.EXTRA_STREAM, ArrayList(contentUris))
           this.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
         context.startActivity(intent)


### PR DESCRIPTION
**What's this do?**

Fix log files not being correctly set in the intent when reporting errors.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-3574](https://jira.nypl.org/browse/SIMPLY-3574).

**How should this be tested? / Do these changes have associated tests?**

See description of [SIMPLY-3574](https://jira.nypl.org/browse/SIMPLY-3574).

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.