### PR TITLE
SIMPLY-3581: Populate error report emails with error details.

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainActivity.kt
@@ -573,7 +573,7 @@ class MainActivity :
       context = this,
       address = parameters.emailAddress,
       subject = parameters.subject,
-      body = parameters.body
+      body = parameters.report
     )
   }
 

--- a/simplified-tests/build.gradle
+++ b/simplified-tests/build.gradle
@@ -56,6 +56,7 @@ dependencies {
   api project(":simplified-tenprint")
   api project(":simplified-threads")
   api project(":simplified-ui-branding")
+  api project(":simplified-ui-errorpage")
   api project(":simplified-ui-splash")
   api project(":simplified-ui-theme")
   api project(":simplified-webview")

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/errorpage/ErrorPageParametersContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/errorpage/ErrorPageParametersContract.kt
@@ -1,0 +1,244 @@
+package org.nypl.simplified.tests.errorpage
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.nypl.simplified.taskrecorder.api.TaskStep
+import org.nypl.simplified.taskrecorder.api.TaskStepResolution
+import org.nypl.simplified.ui.errorpage.ErrorPageParameters
+
+abstract class ErrorPageParametersContract {
+  @Test
+  fun testReportMultipleTaskSteps() {
+    val parameters = ErrorPageParameters(
+      emailAddress = "",
+      subject = "",
+      body = "",
+      attributes = sortedMapOf(),
+      taskSteps = listOf(
+        TaskStep(
+          description = "Doing something...",
+          resolution = TaskStepResolution.TaskStepSucceeded(
+            message = "Done!"
+          )
+        ),
+        TaskStep(
+          description = "Doing another thing...",
+          resolution = TaskStepResolution.TaskStepSucceeded(
+            message = "Cool."
+          )
+        ),
+        TaskStep(
+          description = "Finishing up...",
+          resolution = TaskStepResolution.TaskStepFailed(
+            message = "Oh no, it failed.",
+            errorCode = "FAIL",
+            exception = Exception()
+          )
+        )
+      )
+    )
+
+    assertEquals(
+      """
+      Steps:
+      1. Doing something...
+      ✔️ Done!
+
+      2. Doing another thing...
+      ✔️ Cool.
+
+      3. Finishing up...
+      ❌ Oh no, it failed.
+      """.trimIndent(),
+      parameters.reportTaskSteps
+    )
+  }
+
+  @Test
+  fun testReportSingleTaskStep() {
+    val parameters = ErrorPageParameters(
+      emailAddress = "",
+      subject = "",
+      body = "",
+      attributes = sortedMapOf(),
+      taskSteps = listOf(
+        TaskStep(
+          description = "Doing something...",
+          resolution = TaskStepResolution.TaskStepFailed(
+            message = "Nooooooo!",
+            errorCode = "FAIL",
+            exception = Exception()
+          )
+        )
+      )
+    )
+
+    assertEquals(
+      """
+      Steps:
+      1. Doing something...
+      ❌ Nooooooo!
+      """.trimIndent(),
+      parameters.reportTaskSteps
+    )
+  }
+
+  @Test
+  fun testReportEmptyTaskSteps() {
+    val parameters = ErrorPageParameters(
+      emailAddress = "",
+      subject = "",
+      body = "",
+      attributes = sortedMapOf(),
+      taskSteps = listOf()
+    )
+
+    assertEquals("", parameters.reportTaskSteps)
+  }
+
+  @Test
+  fun testReportMultipleAttributes() {
+    val parameters = ErrorPageParameters(
+      emailAddress = "",
+      subject = "",
+      body = "",
+      attributes = sortedMapOf(
+        Pair("Account", "12345"),
+        Pair("Book", "Frankenstein"),
+        Pair("Author", "Mary Shelley")
+      ),
+      taskSteps = listOf()
+    )
+
+    assertEquals(
+      """
+      Account:
+      12345
+
+      Author:
+      Mary Shelley
+
+      Book:
+      Frankenstein
+      """.trimIndent(),
+      parameters.reportAttributes
+    )
+  }
+
+  @Test
+  fun testReportSingleAttribute() {
+    val parameters = ErrorPageParameters(
+      emailAddress = "",
+      subject = "",
+      body = "",
+      attributes = sortedMapOf(
+        Pair("Account", "12345")
+      ),
+      taskSteps = listOf()
+    )
+
+    assertEquals(
+      """
+      Account:
+      12345
+      """.trimIndent(),
+      parameters.reportAttributes
+    )
+  }
+
+  @Test
+  fun testReportEmptyAttributes() {
+    val parameters = ErrorPageParameters(
+      emailAddress = "",
+      subject = "",
+      body = "",
+      attributes = sortedMapOf(),
+      taskSteps = listOf()
+    )
+
+    assertEquals("", parameters.reportAttributes)
+  }
+
+  @Test
+  fun testReportBodyOnly() {
+    val parameters = ErrorPageParameters(
+      emailAddress = "",
+      subject = "",
+      body = "There was an error!",
+      attributes = sortedMapOf(),
+      taskSteps = listOf()
+    )
+
+    assertEquals("There was an error!", parameters.report)
+  }
+
+  @Test
+  fun testReportNoBody() {
+    val parameters = ErrorPageParameters(
+      emailAddress = "",
+      subject = "",
+      body = "",
+      attributes = sortedMapOf(
+        Pair("Account", "12345")
+      ),
+      taskSteps = listOf(
+        TaskStep(
+          description = "Doing something...",
+          resolution = TaskStepResolution.TaskStepFailed(
+            message = "Nooooooo!",
+            errorCode = "FAIL",
+            exception = Exception()
+          )
+        )
+      )
+    )
+
+    assertEquals(
+      """
+      Account:
+      12345
+
+      Steps:
+      1. Doing something...
+      ❌ Nooooooo!
+      """.trimIndent(),
+      parameters.report
+    )
+  }
+
+  @Test
+  fun testReportBodyAttributesTaskSteps() {
+    val parameters = ErrorPageParameters(
+      emailAddress = "",
+      subject = "",
+      body = "There was an error!",
+      attributes = sortedMapOf(
+        Pair("Account", "12345")
+      ),
+      taskSteps = listOf(
+        TaskStep(
+          description = "Doing something...",
+          resolution = TaskStepResolution.TaskStepFailed(
+            message = "Nooooooo!",
+            errorCode = "FAIL",
+            exception = Exception()
+          )
+        )
+      )
+    )
+
+    assertEquals(
+      """
+      There was an error!
+
+      Account:
+      12345
+
+      Steps:
+      1. Doing something...
+      ❌ Nooooooo!
+      """.trimIndent(),
+      parameters.report
+    )
+  }
+}

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/errorpage/ErrorPageParametersTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/errorpage/ErrorPageParametersTest.kt
@@ -1,0 +1,3 @@
+package org.nypl.simplified.tests.errorpage
+
+class ErrorPageParametersTest : ErrorPageParametersContract()

--- a/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageBaseActivity.kt
+++ b/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageBaseActivity.kt
@@ -52,7 +52,7 @@ abstract class ErrorPageBaseActivity : AppCompatActivity(), ErrorPageListenerTyp
       context = this,
       address = parameters.emailAddress,
       subject = parameters.subject,
-      body = parameters.body
+      body = parameters.report
     )
   }
 }

--- a/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageParameters.kt
+++ b/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageParameters.kt
@@ -1,6 +1,7 @@
 package org.nypl.simplified.ui.errorpage
 
 import org.nypl.simplified.taskrecorder.api.TaskStep
+import org.nypl.simplified.taskrecorder.api.TaskStepResolution
 import java.io.Serializable
 import java.util.SortedMap
 
@@ -40,4 +41,42 @@ data class ErrorPageParameters(
    */
 
   val taskSteps: List<TaskStep>
-) : Serializable
+) : Serializable {
+  /**
+   * The text of an error report to send to technical support, consisting of the body, attributes,
+   * and task steps.
+   */
+
+  val report get() =
+    listOf(this.body, this.reportAttributes, this.reportTaskSteps)
+      .filterNot { part -> part.isNullOrEmpty() }
+      .joinToString("\n\n")
+
+  /**
+   * The attributes, formatted as a string for use in an error report.
+   */
+
+  val reportAttributes get() =
+    this.attributes
+      .map { entry -> "${entry.key}:\n${entry.value}" }
+      .joinToString("\n\n")
+
+  /**
+   * The task steps, formatted as a string for use in an error report.
+   */
+
+  val reportTaskSteps get() =
+    this.taskSteps
+      .mapIndexed { index, step ->
+        val icon = if (step.resolution is TaskStepResolution.TaskStepFailed) "❌" else "✔️"
+        val stepNumber = index + 1
+        val description = step.description
+        val resolution = step.resolution.message
+
+        "$stepNumber. $description\n$icon $resolution"
+      }
+      .joinToString("\n\n")
+      .let {
+        if (it.isNotEmpty()) "Steps:\n$it" else it
+      }
+}


### PR DESCRIPTION
**What's this do?**

When sending error reports, populate the body with the error details as displayed on the Error Details screen:

<img src="https://user-images.githubusercontent.com/1395885/109916593-e5070500-7c81-11eb-8d8b-0c63ec7d738b.png" width="240">

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-3581](https://jira.nypl.org/browse/SIMPLY-3581). This makes error reports more informative, and makes it easier to see what the user is seeing without having to dig through logs.

**How should this be tested? / Do these changes have associated tests?**

There are unit tests for rendering the error details as strings.

To test:

- Do something that results in an error, e.g. log in to a library with an incorrect password.
- Tap the Error Details button.
- Tap the Send To Support button.
- Select Share with Gmail, Just once.

An email should be composed, containing the same details (attributes and steps) as were displayed on the Error Details screen.

**Dependencies for merging? Releasing to production?**

#865 should be merged first, because the incorrect intent that it fixes can cause gmail to get confused.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app.