### PR TITLE
SIMPLY-3604: Bookmarks (again)

### DIFF
--- a/simplified-books-api/src/main/java/org/nypl/simplified/books/api/Bookmark.kt
+++ b/simplified-books-api/src/main/java/org/nypl/simplified/books/api/Bookmark.kt
@@ -59,7 +59,7 @@ data class Bookmark private constructor(
    * The identifier of the device that created the bookmark, if one is available.
    */
 
-  val deviceID: String?,
+  val deviceID: String,
 
   /**
    * The URI of this bookmark, if the bookmark exists on a remote server.
@@ -125,7 +125,7 @@ data class Bookmark private constructor(
       time: DateTime,
       chapterTitle: String,
       bookProgress: Double,
-      deviceID: String?,
+      deviceID: String,
       uri: URI?
     ): Bookmark {
       return Bookmark(

--- a/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookmarkKind.kt
+++ b/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookmarkKind.kt
@@ -31,7 +31,7 @@ sealed class BookmarkKind(
    */
 
   object ReaderBookmarkExplicit :
-    BookmarkKind("https://www.w3.org/ns/oa#bookmarking") {
+    BookmarkKind("http://www.w3.org/ns/oa#bookmarking") {
     override fun toString(): String {
       return "ReaderBookmarkExplicit"
     }
@@ -40,7 +40,7 @@ sealed class BookmarkKind(
   companion object {
 
     val obsoleteBookmarkingURI =
-      "http://www.w3.org/ns/oa#bookmarking"
+      "https://www.w3.org/ns/oa#bookmarking"
 
     fun ofMotivation(motivationURI: String): BookmarkKind {
       return when (motivationURI) {

--- a/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/BookmarkAnnotations.kt
+++ b/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/BookmarkAnnotations.kt
@@ -20,8 +20,8 @@ data class BookmarkAnnotationTargetNode(
 )
 
 data class BookmarkAnnotationBodyNode(
-  val timestamp: String?,
-  val device: String?,
+  val timestamp: String,
+  val device: String,
   val chapterTitle: String?,
   val bookProgress: Float?
 )
@@ -120,11 +120,7 @@ object BookmarkAnnotations {
       }
 
     val timestamp =
-      if (bookmark.time == DateTime(0L, DateTimeZone.UTC)) {
-        null
-      } else {
-        this.dateFormatter.print(bookmark.time)
-      }
+      this.dateFormatter.print(bookmark.time)
 
     val bodyAnnotation =
       BookmarkAnnotationBodyNode(

--- a/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/BookmarkAnnotationsJSON.kt
+++ b/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/BookmarkAnnotationsJSON.kt
@@ -281,7 +281,7 @@ object BookmarkAnnotationsJSON {
     return when (location) {
       is BookLocation.BookLocationR2 -> {
         objectNode.put("@type", "LocatorHrefProgression")
-        objectNode.put("idref", location.progress.chapterHref)
+        objectNode.put("href", location.progress.chapterHref)
         objectNode.put("progressWithinChapter", location.progress.chapterProgress)
         objectNode
       }
@@ -338,7 +338,7 @@ object BookmarkAnnotationsJSON {
   ): BookLocation.BookLocationR2 {
     val progress =
       BookChapterProgress(
-        chapterHref = JSONParserUtilities.getString(obj, "idref"),
+        chapterHref = JSONParserUtilities.getString(obj, "href"),
         chapterProgress = JSONParserUtilities.getDouble(obj, "progressWithinChapter")
       )
     return BookLocation.BookLocationR2(progress)

--- a/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/BookmarkAnnotationsJSON.kt
+++ b/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/BookmarkAnnotationsJSON.kt
@@ -113,9 +113,9 @@ object BookmarkAnnotationsJSON {
   fun deserializeBodyNodeFromJSON(node: ObjectNode): BookmarkAnnotationBodyNode {
     return BookmarkAnnotationBodyNode(
       timestamp =
-        JSONParserUtilities.getStringOrNull(node, "http://librarysimplified.org/terms/time"),
+        JSONParserUtilities.getString(node, "http://librarysimplified.org/terms/time"),
       device =
-        JSONParserUtilities.getStringOrNull(node, "http://librarysimplified.org/terms/device"),
+        JSONParserUtilities.getString(node, "http://librarysimplified.org/terms/device"),
       chapterTitle =
         JSONParserUtilities.getStringOrNull(node, "http://librarysimplified.org/terms/chapter"),
       bookProgress =

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/bookmark_annotations/BookmarkAnnotationsJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/bookmark_annotations/BookmarkAnnotationsJSONTest.kt
@@ -34,11 +34,11 @@ class BookmarkAnnotationsJSONTest {
   private val objectMapper: ObjectMapper = ObjectMapper()
 
   private val targetValue0 =
-    "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"idref\": \"/0.html\",\n  \"progressWithinChapter\": 0.5\n}\n"
+    "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"href\": \"/0.html\",\n  \"progressWithinChapter\": 0.5\n}\n"
   private val targetValue1 =
-    "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"idref\": \"/1.html\",\n  \"progressWithinChapter\": 0.5\n}\n"
+    "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"href\": \"/1.html\",\n  \"progressWithinChapter\": 0.5\n}\n"
   private val targetValue2 =
-    "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"idref\": \"/2.html\",\n  \"progressWithinChapter\": 0.5\n}\n"
+    "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"href\": \"/2.html\",\n  \"progressWithinChapter\": 0.5\n}\n"
 
   private val bookmarkBody0 =
     BookmarkAnnotationBodyNode(

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/bookmark_annotations/BookmarkAnnotationsJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/bookmark_annotations/BookmarkAnnotationsJSONTest.kt
@@ -291,9 +291,9 @@ class BookmarkAnnotationsJSONTest {
 
     val bookmark = BookmarkAnnotations.toBookmark(this.objectMapper, annotation)
     Assert.assertEquals("urn:uuid:1daa8de6-94e8-4711-b7d1-e43b572aa6e0", bookmark.opdsId)
-    Assert.assertEquals(null, bookmark.deviceID)
+    Assert.assertEquals("urn:uuid:c83db5b1-9130-4b86-93ea-634b00235c7c", bookmark.deviceID)
     Assert.assertEquals(BookmarkKind.ReaderBookmarkLastReadLocation, bookmark.kind)
-    Assert.assertEquals("1970-01-01T00:00:00.000Z", bookmark.time.toString())
+    Assert.assertEquals("2021-03-12T16:32:49.000Z", bookmark.time.toString())
     Assert.assertEquals("", bookmark.chapterTitle)
 
     val location = bookmark.location as BookLocation.BookLocationR2
@@ -315,9 +315,9 @@ class BookmarkAnnotationsJSONTest {
 
     val bookmark = BookmarkAnnotations.toBookmark(this.objectMapper, annotation)
     Assert.assertEquals("urn:uuid:1daa8de6-94e8-4711-b7d1-e43b572aa6e0", bookmark.opdsId)
-    Assert.assertEquals(null, bookmark.deviceID)
+    Assert.assertEquals("urn:uuid:c83db5b1-9130-4b86-93ea-634b00235c7c", bookmark.deviceID)
     Assert.assertEquals(BookmarkKind.ReaderBookmarkExplicit, bookmark.kind)
-    Assert.assertEquals("1970-01-01T00:00:00.000Z", bookmark.time.toString())
+    Assert.assertEquals("2021-03-12T16:32:49.000Z", bookmark.time.toString())
     Assert.assertEquals("", bookmark.chapterTitle)
 
     val location = bookmark.location as BookLocation.BookLocationR2
@@ -401,6 +401,26 @@ class BookmarkAnnotationsJSONTest {
     BookmarkAnnotationsJSON.deserializeBookmarkAnnotationFromJSON(
       objectMapper = this.objectMapper,
       node = this.resourceNode("invalid-bookmark-4.json")
+    )
+  }
+
+  @Test
+  fun testSpecInvalidBookmark5() {
+    this.expectedException.expect(JSONParseException::class.java)
+    this.expectedException.expectMessage("Expected: A key 'http://librarysimplified.org/terms/device'")
+    BookmarkAnnotationsJSON.deserializeBookmarkAnnotationFromJSON(
+      objectMapper = this.objectMapper,
+      node = this.resourceNode("invalid-bookmark-5.json")
+    )
+  }
+
+  @Test
+  fun testSpecInvalidBookmark6() {
+    this.expectedException.expect(JSONParseException::class.java)
+    this.expectedException.expectMessage("Expected: A key 'http://librarysimplified.org/terms/time'")
+    BookmarkAnnotationsJSON.deserializeBookmarkAnnotationFromJSON(
+      objectMapper = this.objectMapper,
+      node = this.resourceNode("invalid-bookmark-6.json")
     )
   }
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/reader/bookmarks/ReaderBookmarkHTTPCallsContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/reader/bookmarks/ReaderBookmarkHTTPCallsContract.kt
@@ -206,7 +206,7 @@ abstract class ReaderBookmarkHTTPCallsContract {
         source = "urn:book0",
         selector = BookmarkAnnotationSelectorNode(
           type = "FragmentSelector",
-          value = "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"idref\": \"/xyz.html\",\n  \"progressWithinChapter\": 0.5\n}\n"
+          value = "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"href\": \"/xyz.html\",\n  \"progressWithinChapter\": 0.5\n}\n"
         )
       )
     )
@@ -228,7 +228,7 @@ abstract class ReaderBookmarkHTTPCallsContract {
         source = "urn:book0",
         selector = BookmarkAnnotationSelectorNode(
           type = "FragmentSelector",
-          value = "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"idref\": \"/xyz.html\",\n  \"progressWithinChapter\": 0.5\n}\n"
+          value = "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"href\": \"/xyz.html\",\n  \"progressWithinChapter\": 0.5\n}\n"
         )
       )
     )
@@ -256,7 +256,7 @@ abstract class ReaderBookmarkHTTPCallsContract {
                 "target" : {
                    "source" : "urn:book0",
                    "selector" : {
-                      "value" : "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"idref\": \"/xyz.html\",\n  \"progressWithinChapter\": 0.5\n}\n",
+                      "value" : "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"href\": \"/xyz.html\",\n  \"progressWithinChapter\": 0.5\n}\n",
                       "type" : "FragmentSelector"
                    }
                 }
@@ -272,7 +272,7 @@ abstract class ReaderBookmarkHTTPCallsContract {
                 "target" : {
                    "source" : "urn:book0",
                    "selector" : {
-                      "value" : "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"idref\": \"/xyz.html\",\n  \"progressWithinChapter\": 0.5\n}\n",
+                      "value" : "{\n  \"@type\": \"LocatorHrefProgression\",\n  \"href\": \"/xyz.html\",\n  \"progressWithinChapter\": 0.5\n}\n",
                       "type" : "FragmentSelector"
                    }
                 }


### PR DESCRIPTION
**What's this do?**
This updates to the latest bookmarks spec with the changes @ettore discovered.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SIMPLY-3604

**How should this be tested? / Do these changes have associated tests?**
The same tests that were applicable to https://github.com/NYPL-Simplified/Simplified-Android-Core/pull/869 are applicable to this. The changes essentially enforce things that we were already doing implicitly, and change the format of the R2 bookmarks. There won't be any R2 bookmarks in the wild yet, because R2 hasn't been officially released.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
See the [spec](https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec).

**Did someone actually run this code to verify it works?**
@io7m ran the test suite and tried a few books.