### PR TITLE
Added step to post to slack after successful build

### DIFF
--- a/.ci-local/credentials.sh
+++ b/.ci-local/credentials.sh
@@ -71,7 +71,7 @@ EOF
 
 #------------------------------------------------------------------------
 # Addding slack webhook to environment
-SLACK_WEBHOOK_URL=$(</Users/medwar40/Workspace/NYPL/Certificates/SimplyE/slack-webhook.url) || 
+SLACK_WEBHOOK_URL=$(<.ci/credentials/SimplyE/slack-webhook.url) || 
   fatal "Slack Webhook url not found."
 cat >> ".env" <<EOF
 SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL}"

--- a/.ci-local/credentials.sh
+++ b/.ci-local/credentials.sh
@@ -68,3 +68,11 @@ org.librarysimplified.nexus.password=${NYPL_NEXUS_PASSWORD}
 org.librarysimplified.app.assets.openebooks=${OPENEBOOKS_CREDENTIALS}
 org.librarysimplified.app.assets.simplye=${SIMPLYE_CREDENTIALS}
 EOF
+
+#------------------------------------------------------------------------
+# Addding slack webhook to environment
+SLACK_WEBHOOK_URL=$(</Users/medwar40/Workspace/NYPL/Certificates/SimplyE/slack-webhook.url) || 
+  fatal "Slack Webhook url not found."
+cat >> ".env" <<EOF
+SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL}"
+EOF

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ ReaderClientCert.sig
 
 # Misc
 simplified-tests-sandbox/src/main/*
+.env
 
 # deprecated
 cardcreator.conf

--- a/simplified-app-simplye/fastlane/Fastfile
+++ b/simplified-app-simplye/fastlane/Fastfile
@@ -13,14 +13,17 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+fastlane_require 'dotenv'
+
 default_platform(:android)
 
 platform :android do
 
     # Runs ktlint before doing any distribution
-    # before_all do
+    before_all do
+      Dotenv.overload '.env'
     #   sh("./gradlew", "ktlint")
-    # end
+    end
 
     desc "Submit a new beta build to Firebase Beta"
     lane :qa do |options|
@@ -37,6 +40,16 @@ platform :android do
          groups: "librarysimplified",
          release_notes: "#{release_notes}",
          firebase_cli_path: ENV["FIREBASE_CLI_PATH"])
+       slack(
+        message: "New simplyE android build available on firebase",
+        slack_url: ENV['SLACK_WEBHOOK_URL'],
+        success: true,
+        channel: "#simplified-releases",
+        default_payloads: [],
+        payload: {
+          "Release notes" => :release_notes
+        }
+       )
     end
 
      # This needs to be tested as the .aab files have dynamic naming

--- a/simplified-app-simplye/fastlane/Pluginfile
+++ b/simplified-app-simplye/fastlane/Pluginfile
@@ -3,3 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-firebase_app_distribution'
+gem  'dotenv'


### PR DESCRIPTION
**What's this do?**
Fastlane will post to slack after app is built and deployed to firebase

**Why are we doing this? (w/ JIRA link if applicable)**
To make it easier for QA to know when a new Android build is available

**How should this be tested? / Do these changes have associated tests?**
After merge see if a slack post is made

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
I tried it on a test slack channel but more tests would be nice!