### PR TITLE
SMA-91: Upgrade to Simplified-R2-Android 0.0.12

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -58,7 +58,7 @@ ext.versions = [
   nypl_overdrive                : '1.0.3',
   nypl_pdf                      : '0.1.0',
   nypl_readium                  : '0.30.0',
-  nypl_readium2                 : '0.0.11',
+  nypl_readium2                 : '0.0.12',
   okhttp3                       : '4.8.1',
   pandora_bottom_navigator      : '1.8',
   picasso                       : '2.71828',

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
@@ -242,6 +242,7 @@ class Reader2Activity : AppCompatActivity() {
       SR2ReaderParameters(
         streamer = streamer,
         bookFile = bookFile,
+        bookId = this.parameters.entry.feedEntry.id,
         theme = initialTheme,
         controllers = SR2Controllers()
       )


### PR DESCRIPTION
**What's this do?**
This upgrades to the latest Simplified-R2-Android 0.0.12 release. This
requires passing in unique book identifiers (taken from the OPDS feed),
as the identifiers are not guaranteed to be present in EPUB manifests.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/SMA-91

**How should this be tested? / Do these changes have associated tests?**
There should be no functional changes. This change just allows some books that could not be opened to be opened.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried various books to ensure no breakages