### PR TITLE
SMA-92: Reader preferences were incorrectly deserialized

### DIFF
--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
@@ -311,7 +311,7 @@ object ProfileDescriptionJSON {
     objectMapper: ObjectMapper,
     node: ObjectNode?
   ): ReaderPreferences {
-    return JSONParserUtilities.getObjectOptional(node, "reader-preferences")
+    return JSONParserUtilities.getObjectOptional(node, "readerPreferences")
       .mapPartial<ReaderPreferences, JSONParseException> { prefsNode ->
         ReaderPreferencesJSON.deserializeFromJSON(objectMapper, prefsNode)
       }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
@@ -5,7 +5,7 @@ import org.joda.time.DateTime
 import org.joda.time.DateTimeUtils
 import org.joda.time.DateTimeZone
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -14,6 +14,8 @@ import org.nypl.simplified.profiles.api.ProfileAttributes
 import org.nypl.simplified.profiles.api.ProfileDateOfBirth
 import org.nypl.simplified.profiles.api.ProfileDescription
 import org.nypl.simplified.profiles.api.ProfilePreferences
+import org.nypl.simplified.reader.api.ReaderColorScheme
+import org.nypl.simplified.reader.api.ReaderFontSelection
 import org.nypl.simplified.reader.api.ReaderPreferences
 import org.slf4j.LoggerFactory
 
@@ -66,7 +68,7 @@ class ProfileDescriptionJSONTest {
       ProfileDescriptionJSON.deserializeFromJSON(mapper, node)
 
     this.logger.debug("{}", ProfileDescriptionJSON.serializeToString(ObjectMapper(), description_1))
-    Assertions.assertEquals(description_0, description_1)
+    assertEquals(description_0, description_1)
   }
 
   @Test
@@ -77,8 +79,8 @@ class ProfileDescriptionJSONTest {
       ProfileDescriptionJSON.deserializeFromText(mapper, this.ofResource("profile-lfa-0.json"))
 
     this.logger.debug("{}", ProfileDescriptionJSON.serializeToString(ObjectMapper(), description))
-    Assertions.assertEquals("Eggbert", description.displayName)
-    Assertions.assertEquals("developer", description.attributes.role)
+    assertEquals("Eggbert", description.displayName)
+    assertEquals("developer", description.attributes.role)
   }
 
   @Test
@@ -89,11 +91,11 @@ class ProfileDescriptionJSONTest {
       ProfileDescriptionJSON.deserializeFromText(mapper, this.ofResource("profile-lfa-1.json"))
 
     this.logger.debug("{}", ProfileDescriptionJSON.serializeToString(ObjectMapper(), description))
-    Assertions.assertEquals("Newbert", description.displayName)
-    Assertions.assertEquals("male", description.attributes.gender)
-    Assertions.assertEquals("student", description.attributes.role)
-    Assertions.assertEquals("ຊັ້ນ 8", description.attributes.grade)
-    Assertions.assertEquals("ສົ້ນຂົວ", description.attributes.school)
+    assertEquals("Newbert", description.displayName)
+    assertEquals("male", description.attributes.gender)
+    assertEquals("student", description.attributes.role)
+    assertEquals("ຊັ້ນ 8", description.attributes.grade)
+    assertEquals("ສົ້ນຂົວ", description.attributes.school)
   }
 
   @Test
@@ -104,7 +106,20 @@ class ProfileDescriptionJSONTest {
       ProfileDescriptionJSON.deserializeFromText(mapper, this.ofResource("profile-nypl-0.json"))
 
     this.logger.debug("{}", ProfileDescriptionJSON.serializeToString(ObjectMapper(), description))
-    Assertions.assertEquals("", description.displayName)
+    assertEquals("", description.displayName)
+  }
+
+  @Test
+  fun testSMA92() {
+    val mapper = ObjectMapper()
+    val description =
+      ProfileDescriptionJSON.deserializeFromText(mapper, this.ofResource("profile-sma-92.json"))
+
+    assertEquals("", description.displayName)
+    assertEquals(1.0, description.preferences.readerPreferences.brightness())
+    assertEquals(100.0, description.preferences.readerPreferences.fontScale())
+    assertEquals(ReaderFontSelection.READER_FONT_OPEN_DYSLEXIC, description.preferences.readerPreferences.fontFamily())
+    assertEquals(ReaderColorScheme.SCHEME_WHITE_ON_BLACK, description.preferences.readerPreferences.colorScheme())
   }
 
   private fun ofResource(name: String): String {

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-sma-92.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-sma-92.json
@@ -1,0 +1,21 @@
+{
+  "@version" : 20200504,
+  "displayName" : "",
+  "preferences" : {
+    "showTestingLibraries" : true,
+    "hasSeenLibrarySelectionScreen" : true,
+    "useExperimentalR2" : true,
+    "showDebugSettings" : true,
+    "mostRecentAccount" : "5310437f-db1a-492e-a09f-1ceaa43303dd",
+    "readerPreferences" : {
+      "font_scale" : 100.0,
+      "font_family" : "READER_FONT_OPEN_DYSLEXIC",
+      "color_scheme" : "SCHEME_WHITE_ON_BLACK"
+    },
+    "dateOfBirth" : {
+      "date" : "2006-08-07",
+      "isSynthesized" : true
+    }
+  },
+  "attributes" : { }
+}


### PR DESCRIPTION
**What's this do?**
For some reason, the profile deserialization code was reading
`reader-preferences` instead of `readerPreferences`. This meant that
we were effectively _always_ using the default values for reader
preferences. This would even affect R1!

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SMA-92

**How should this be tested? / Do these changes have associated tests?**
See the SMA-92 ticket; color scheme and font preferences must be preserved in the reader across app restarts.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tested that arbitrary preferences still existed after the app was restarted