### PR TITLE
Fix an SLF4J crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,17 @@ ext {
   }
 }
 
+subprojects {
+  /*
+   * We currently have transitive dependencies that specify dependencies on newer versions
+   * of SLF4J. These are subtly incompatible with Logback-Android, and it will be a while before
+   * new versions appear of both artifacts. Remove this when both are updated!
+   */
+  configurations.all {
+    resolutionStrategy.force libraries.slf4j
+  }
+}
+
 subprojects { project ->
   group = project.ext["GROUP"]
   version = project.ext["VERSION_NAME"]


### PR DESCRIPTION
**What's this do?**
I recently removed the SLF4J version resolution adjustment thinking
that it was no longer necessary. Turns out that it's still necessary. Fixes
a crash on startup.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/SMA-176

**How should this be tested? / Do these changes have associated tests?**
Check the app starts up!

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m ran it, with a sense of shame.