### PR TITLE
Fix feedIsRoot for custom OPDS feeds

### DIFF
--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountProviderType.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountProviderType.kt
@@ -181,18 +181,6 @@ interface AccountProviderType : Comparable<AccountProviderType> {
     }
   }
 
-  fun feedIsRoot(feedURI: URI): Boolean {
-    return when (val auth = this.authentication) {
-      is AccountProviderAuthenticationDescription.COPPAAgeGate ->
-        auth.greaterEqual13 == feedURI || auth.under13 == feedURI
-      is AccountProviderAuthenticationDescription.SAML2_0,
-      AccountProviderAuthenticationDescription.Anonymous,
-      is AccountProviderAuthenticationDescription.Basic,
-      is AccountProviderAuthenticationDescription.OAuthWithIntermediary ->
-        this.catalogURI == feedURI
-    }
-  }
-
   /**
    * @return The time that this account provider was most recently updated
    */

--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountReadableType.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountReadableType.kt
@@ -27,6 +27,22 @@ interface AccountReadableType {
   fun catalogURIForAge(age: Int): URI
 
   /**
+   * Determine if the provided feedURI points to the root of this account's catalog.
+   */
+
+  fun feedIsRoot(feedURI: URI): Boolean {
+    return when (val auth = this.provider.authentication) {
+      is AccountProviderAuthenticationDescription.COPPAAgeGate ->
+        auth.greaterEqual13 == feedURI || auth.under13 == feedURI
+      is AccountProviderAuthenticationDescription.SAML2_0,
+      AccountProviderAuthenticationDescription.Anonymous,
+      is AccountProviderAuthenticationDescription.Basic,
+      is AccountProviderAuthenticationDescription.OAuthWithIntermediary ->
+        this.provider.catalogURI == feedURI || this.preferences.catalogURIOverride == feedURI
+    }
+  }
+
+  /**
    * @return The account ID
    */
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFragmentFeed.kt
@@ -1074,12 +1074,11 @@ class CatalogFragmentFeed : Fragment(), AgeGateDialog.BirthYearSelectedListener 
       return false
     }
 
-    val accountProvider =
+    val account =
       this.profilesController.profileCurrent()
         .account(ownership.accountId)
-        .provider
 
-    return accountProvider.feedIsRoot(parameters.feedURI)
+    return account.feedIsRoot(parameters.feedURI)
   }
 
   override fun onBirthYearSelected(isOver13: Boolean) {


### PR DESCRIPTION
**What's this do?**
Move `feedIsRoot` method from `AccountProviderType` to `AccountReadableType` and add a check for the root URI provided when the account was created.

**Why are we doing this? (w/ JIRA link if applicable)**
With custom OPDS feeds, `AccountProviderType.feedIsRoot` failed to identify the catalog root because two different URIs coexist: one provided by the user when the account was created (stored in `AccountPreferences`), and another one from the authentication document.

**How should this be tested? / Do these changes have associated tests?**
Check that the account picker is shown on the catalog of a custom OPDS feed.

**Dependencies for merging? Releasing to production?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Yes, I did.