### PR TITLE
SMA-177: Actually enable/disable bookmark syncing

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <c:changelog project="LibrarySimplified" xmlns:c="urn:com.io7m.changelog:4.0">
   <c:releases>
-    <c:release date="2021-05-14T09:39:10+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.6.5">
+    <c:release date="2021-05-28T11:28:15+00:00" is-open="true" ticket-system="org.nypl.jira" version="6.6.5">
       <c:changes>
         <c:change date="2021-03-26T00:00:00+00:00" summary="Standardize bookmarks across platforms">
           <c:tickets>
@@ -69,9 +69,14 @@
             <c:ticket id="SMA-174"/>
           </c:tickets>
         </c:change>
-        <c:change date="2021-05-14T09:39:10+00:00" summary="Fixed R2 settings icon">
+        <c:change date="2021-05-14T00:00:00+00:00" summary="Fixed R2 settings icon">
           <c:tickets>
             <c:ticket id="SMA-166"/>
+          </c:tickets>
+        </c:change>
+        <c:change date="2021-05-28T11:28:15+00:00" summary="The bookmark syncing toggle now correct turns on/off server-side syncing">
+          <c:tickets>
+            <c:ticket id="SMA-177"/>
           </c:tickets>
         </c:change>
       </c:changes>

--- a/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkServiceUsableType.kt
+++ b/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkServiceUsableType.kt
@@ -20,6 +20,26 @@ interface ReaderBookmarkServiceUsableType {
   val bookmarkEvents: Observable<ReaderBookmarkEvent>
 
   /**
+   * The result of attempting to enable/disable syncing (assuming that the attempt didn't
+   * outright fail with an exception).
+   */
+
+  enum class SyncEnableResult {
+    SYNC_ENABLE_NOT_SUPPORTED,
+    SYNC_ENABLED,
+    SYNC_DISABLED
+  }
+
+  /**
+   * Enable/disable bookmark syncing on the server.
+   */
+
+  fun bookmarkSyncEnable(
+    accountID: AccountID,
+    enabled: Boolean
+  ): FluentFuture<SyncEnableResult>
+
+  /**
    * The user wants their current bookmarks.
    */
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/reader/bookmarks/NullReaderBookmarkService.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/reader/bookmarks/NullReaderBookmarkService.kt
@@ -9,6 +9,7 @@ import org.nypl.simplified.books.api.Bookmark
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkEvent
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceProviderType
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceType
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceUsableType.SyncEnableResult
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarks
 
 class NullReaderBookmarkService(
@@ -20,6 +21,10 @@ class NullReaderBookmarkService(
 
   override val bookmarkEvents: Observable<ReaderBookmarkEvent>
     get() = this.events
+
+  override fun bookmarkSyncEnable(accountID: AccountID, enabled: Boolean): FluentFuture<SyncEnableResult> {
+    return FluentFuture.from(Futures.immediateFuture(SyncEnableResult.SYNC_ENABLE_NOT_SUPPORTED))
+  }
 
   override fun bookmarkCreate(accountID: AccountID, bookmark: Bookmark): FluentFuture<Unit> {
     return FluentFuture.from(Futures.immediateFuture(Unit))

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockAccount.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockAccount.kt
@@ -15,14 +15,28 @@ import java.util.UUID
 
 class MockAccount(override val id: AccountID) : AccountType {
 
+  @Volatile
+  private var preferencesCurrent: AccountPreferences =
+    AccountPreferences(
+      bookmarkSyncingPermitted = true,
+      catalogURIOverride = null,
+      announcementsAcknowledged = listOf()
+    )
+
   private val providerId = UUID.randomUUID()
 
+  @Volatile
+  var bookDatabaseProperty: BookDatabaseType =
+    MockBookDatabase(owner = this.id)
+
   override val bookDatabase: BookDatabaseType
-    get() = TODO("not implemented") // To change initializer of created properties use File | Settings | File Templates.
+    get() = this.bookDatabaseProperty
 
   override fun setPreferences(preferences: AccountPreferences) {
+    this.preferencesCurrent = preferences
   }
 
+  @Volatile
   private var accountProviderCurrent: AccountProviderType =
     run {
       val authentication =
@@ -92,9 +106,5 @@ class MockAccount(override val id: AccountID) : AccountType {
     get() = this.loginStateMutable
 
   override val preferences: AccountPreferences
-    get() = AccountPreferences(
-      bookmarkSyncingPermitted = true,
-      catalogURIOverride = null,
-      announcementsAcknowledged = listOf()
-    )
+    get() = this.preferencesCurrent
 }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
@@ -43,13 +43,13 @@ class MockProfile(
   override fun delete() {
   }
 
-  private val accountList =
+  val accountList: MutableList<MockAccount> =
     IntRange(1, accountCount)
       .toList()
       .map { MockAccount(AccountID(UUID.randomUUID())) }
       .toMutableList()
 
-  private val accounts =
+  val accounts: SortedMap<AccountID, MockAccount> =
     this.accountList.map { account -> Pair(account.id, account) }
       .toMap()
       .toSortedMap()

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfilesController.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfilesController.kt
@@ -49,14 +49,14 @@ class MockProfilesController(
     return FluentFuture.from(SettableFuture.create())
   }
 
-  private val profileList =
+  val profileList: List<MockProfile> =
     IntRange(1, profileCount)
       .toList()
       .map {
         MockProfile(ProfileID(UUID.randomUUID()), accountCount)
       }
 
-  private val profiles =
+  val profiles: SortedMap<ProfileID, MockProfile> =
     this.profileList.map { profile -> Pair(profile.id, profile) }
       .toMap()
       .toSortedMap()

--- a/simplified-ui-accounts/build.gradle
+++ b/simplified-ui-accounts/build.gradle
@@ -3,16 +3,17 @@ dependencies {
   implementation project(":simplified-buildconfig-api")
   implementation project(":simplified-cardcreator")
   implementation project(":simplified-documents")
+  implementation project(":simplified-metrics-api")
   implementation project(":simplified-oauth")
   implementation project(":simplified-profiles-controller-api")
+  implementation project(":simplified-reader-bookmarks-api")
   implementation project(":simplified-services-api")
-  implementation project(":simplified-metrics-api")
   implementation project(":simplified-threads")
   implementation project(":simplified-ui-errorpage")
   implementation project(":simplified-ui-images")
-  implementation project(':simplified-ui-listeners-api')
   implementation project(":simplified-ui-theme")
   implementation project(":simplified-webview")
+  implementation project(':simplified-ui-listeners-api')
 
   implementation libraries.androidx_appcompat
   implementation libraries.androidx_constraintlayout

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModel.kt
@@ -15,6 +15,7 @@ import org.nypl.simplified.profiles.api.ProfileDateOfBirth
 import org.nypl.simplified.profiles.api.ProfileEvent
 import org.nypl.simplified.profiles.controller.api.ProfileAccountLoginRequest
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceType
 import org.nypl.simplified.threads.NamedThreadPools
 
 /**
@@ -33,6 +34,9 @@ class AccountDetailViewModel(
 
   private val profilesController =
     services.requireService(ProfilesControllerType::class.java)
+
+  private val readerBookmarkService =
+    services.requireService(ReaderBookmarkServiceType::class.java)
 
   private val backgroundExecutor =
     NamedThreadPools.namedThreadPool(1, "simplified-accounts-io", 19)
@@ -85,16 +89,13 @@ class AccountDetailViewModel(
   @Volatile
   var loginExplicitlyRequested: Boolean = false
 
-  var bookmarkSyncingPermitted: Boolean
-    get() =
-      this.account.preferences.bookmarkSyncingPermitted
-    set(value) {
-      this.backgroundExecutor.execute {
-        this.account.setPreferences(
-          this.account.preferences.copy(bookmarkSyncingPermitted = value)
-        )
-      }
-    }
+  /**
+   * Enable/disable bookmark syncing.
+   */
+
+  fun enableBookmarkSyncing(enabled: Boolean) {
+    this.readerBookmarkService.bookmarkSyncEnable(this.accountId, enabled)
+  }
 
   var isOver13: Boolean
     get() {


### PR DESCRIPTION
**What's this do?**
This adds all of the necessary code to send HTTP requests to toggle
bookmark syncing on the server side. Previously, all we did was toggle
a client-side flag, meaning that some users could never get bookmark
syncing enabled.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SMA-177

**How should this be tested? / Do these changes have associated tests?**
The simplest way seems to be to try enabling and disabling bookmark syncing by toggling the switch on an NYPL account, and then checking that _disabling_ them deleted all of the bookmarks on the server.

**Dependencies for merging? Releasing to production?**
None,

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Deleted all of his bookmarks, and watched the app make HTTP requests in response to toggling the switch.