### PR TITLE
Version v6.6.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/NYPL-Simplified/Simplified-Android-C
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/NYPL-Simplified/Simplified-Android-Core
 POM_SCM_URL=http://github.com/NYPL-Simplified/Simplified-Android-Core
 POM_URL=http://github.com/NYPL-Simplified/Simplified-Android-Core
-VERSION_NAME=6.6.4-SNAPSHOT
+VERSION_NAME=6.6.4
 VERSION_CODE_BASE=70000
 
 android.useAndroidX=true


### PR DESCRIPTION
**What's this do?**
Removing `--snapshot` suffix for release.  

Build is based on: https://github.com/NYPL-Simplified/android-binaries/commit/aa83b1cbc54e0d1ca419876daf5ee3e2eb681b6c