### PR TITLE
SMA-25: Clearly disambiguate same and/or similarly named libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,17 @@ ext {
   }
 }
 
+subprojects {
+  /*
+   * We currently have transitive dependencies that specify dependencies on newer versions
+   * of SLF4J. These are subtly incompatible with Logback-Android, and it will be a while before
+   * new versions appear of both artifacts. Remove this when both are updated!
+   */
+  configurations.all {
+    resolutionStrategy.force libraries.slf4j
+  }
+}
+
 subprojects { project ->
   group = project.ext["GROUP"]
   version = project.ext["VERSION_NAME"]

--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountLibraryLocation.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountLibraryLocation.kt
@@ -6,5 +6,6 @@ package org.nypl.simplified.accounts.api
 
 data class AccountLibraryLocation(
   val location: AccountGeoLocation,
+  val locationDescription: String,
   val distance: AccountDistance?
 )

--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountLibraryLocation.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountLibraryLocation.kt
@@ -6,6 +6,6 @@ package org.nypl.simplified.accounts.api
 
 data class AccountLibraryLocation(
   val location: AccountGeoLocation,
-  val locationDescription: String,
+  val locationDescription: String?,
   val distance: AccountDistance?
 )

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProviderDescriptionCollectionParser.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProviderDescriptionCollectionParser.kt
@@ -137,6 +137,7 @@ class AccountProviderDescriptionCollectionParser internal constructor(
       val longitude = segments[1].trim().toDouble()
       return AccountLibraryLocation(
         location = AccountGeoLocation.Coordinates(longitude, latitude),
+        locationDescription = location,
         distance = null
       )
     } catch (e: Exception) {

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
@@ -315,6 +315,7 @@ object AccountProvidersJSON {
 
       return AccountLibraryLocation(
         location = AccountGeoLocation.Coordinates(longitude, latitude),
+        locationDescription = "TODO", //TODO
         distance = distance
       )
     }

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
@@ -315,8 +315,8 @@ object AccountProvidersJSON {
 
       return AccountLibraryLocation(
         location = AccountGeoLocation.Coordinates(longitude, latitude),
-        locationDescription = "TODO", //TODO
-        distance = distance
+        distance = distance,
+        locationDescription = null
       )
     }
 

--- a/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderSourceNYPLRegistry.kt
+++ b/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderSourceNYPLRegistry.kt
@@ -139,7 +139,8 @@ class AccountProviderSourceNYPLRegistry(
                   longitude = 48.009720957177684,
                   latitude = -106.42124352031094
                 ),
-                distance = AccountDistance(entry.value.id.hashCode() * 0.00001, KILOMETERS)
+                distance = AccountDistance(entry.value.id.hashCode() * 0.00001, KILOMETERS),
+                locationDescription = "Yellowstone Rd, Fort Peck, MT 59223"
               )
             )
           }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/FilterableAccountListAdapter.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/FilterableAccountListAdapter.kt
@@ -115,6 +115,26 @@ class AccountItemViewHolder(
   }
 
   fun bind(item: AccountProviderDescription) {
+    val location = item.location
+    val context = itemView.context
+    this.itemView.contentDescription = when {
+      location?.locationDescription != null && location.distance != null -> {
+        context.getString(
+          R.string.accountRegistryItemContentDescriptionDistance,
+          item.title,
+          location.locationDescription,
+          location.distance!!.toText()
+        )
+      }
+      location?.locationDescription != null -> {
+        context.getString(
+          R.string.accountRegistryItemContentDescription,
+          item.title,
+          location.locationDescription
+        )
+      }
+      else -> item.title
+    }
     this.accountTitleView.text = item.title
     this.accountCaptionView.text = ""
     this.accountCaptionView.visibility =
@@ -152,6 +172,6 @@ val DIFF_CALLBACK =
       oldItem: AccountProviderDescription,
       newItem: AccountProviderDescription
     ): Boolean {
-      return oldItem.title == newItem.title
+      return oldItem == newItem
     }
   }

--- a/simplified-ui-accounts/src/main/res/layout/account_list_registry.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_list_registry.xml
@@ -16,7 +16,6 @@
         android:text="@string/accountRegistrySelect"
         android:textStyle="bold" />
 
-    <!-- TODO -->
     <TextView
         android:id="@+id/accountRegistryNoLocation"
         android:layout_width="match_parent"

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
   <string name="accountRegistryRetrieving">Retrieving accounts from registry…</string>
   <string name="accountRegistrySelect">Please select a library…</string>
   <string name="accountRegistryNoLocation">You can search for your library by name, branch location, or your own location.</string>
+  <string name="accountRegistryItemContentDescription">%s located at %s</string>
+  <string name="accountRegistryItemContentDescriptionDistance">%s located at %s, about %s from you</string>
   <string name="accountReportIssue">Report an issue…</string>
   <string name="accounts">Accounts</string>
   <string name="accountsDelete">@string/accountDelete</string>


### PR DESCRIPTION
**What's this do?**
Adds location information to contentDescriptions in library finder items

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SMA-25

**How should this be tested? / Do these changes have associated tests?**
Verify that screen reader can read off location information 

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No documentation changes needed

**Did someone actually run this code to verify it works?**
I did