### PR TITLE
Fix accessibility service

### DIFF
--- a/simplified-accessibility/src/main/java/org/nypl/simplified/accessibility/AccessibilityEvents.kt
+++ b/simplified-accessibility/src/main/java/org/nypl/simplified/accessibility/AccessibilityEvents.kt
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory
 
 /**
  * The default implementation of the [AccessibilityEventsType] interface that publishes
- * events and optionally displays toasts.
+ * events.
  */
 
 class AccessibilityEvents(context: Context) : AccessibilityEventsType {

--- a/simplified-accessibility/src/main/java/org/nypl/simplified/accessibility/AccessibilityServiceType.kt
+++ b/simplified-accessibility/src/main/java/org/nypl/simplified/accessibility/AccessibilityServiceType.kt
@@ -1,35 +1,14 @@
 package org.nypl.simplified.accessibility
 
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.OnLifecycleEvent
-
 /**
  * The interface exposed by accessibility services.
  */
 
-interface AccessibilityServiceType : LifecycleObserver {
+interface AccessibilityServiceType {
 
   /**
    * @return `true` if spoken feedback is enabled
    */
 
   val spokenFeedbackEnabled: Boolean
-
-  /**
-   * A view became available. This typically means that the activity to which this
-   * service is to be attached has been started.
-   */
-
-  @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
-  fun onViewAvailable(owner: LifecycleOwner)
-
-  /**
-   * A view became unavailable. This typically means that the activity to which this
-   * service is attached has been destroyed.
-   */
-
-  @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-  fun onViewUnavailable(owner: LifecycleOwner)
 }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
@@ -11,12 +11,10 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import io.reactivex.disposables.CompositeDisposable
 import org.librarysimplified.services.api.Services
-import org.nypl.simplified.accessibility.AccessibilityService
 import org.nypl.simplified.accounts.api.AccountEvent
 import org.nypl.simplified.accounts.api.AccountEventDeletion
 import org.nypl.simplified.android.ktx.supportActionBar
 import org.nypl.simplified.books.api.BookID
-import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookStatusEvent
 import org.nypl.simplified.listeners.api.FragmentListenerType
@@ -98,18 +96,6 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
         context = requireContext(),
         uiThread = services.requireService(UIThreadServiceType::class.java),
         profileController = services.requireService(ProfilesControllerType::class.java)
-      )
-    )
-
-    /*
-     * Register an accessibility controller.
-     */
-
-    this.lifecycle.addObserver(
-      AccessibilityService.create(
-        context = requireContext(),
-        bookRegistry = services.requireService(BookRegistryType::class.java),
-        uiThread = services.requireService(UIThreadServiceType::class.java)
       )
     )
   }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -22,6 +22,8 @@ import org.librarysimplified.services.api.Services
 import org.nypl.drm.core.AdobeAdeptExecutorType
 import org.nypl.drm.core.AxisNowServiceFactoryType
 import org.nypl.drm.core.AxisNowServiceType
+import org.nypl.simplified.accessibility.AccessibilityService
+import org.nypl.simplified.accessibility.AccessibilityServiceType
 import org.nypl.simplified.accounts.api.AccountAuthenticationCredentialsStoreType
 import org.nypl.simplified.accounts.api.AccountBundledCredentialsType
 import org.nypl.simplified.accounts.api.AccountEvent
@@ -725,6 +727,12 @@ internal object MainServices {
       message = strings.bootingGeneral("book registry"),
       interfaceType = BookRegistryReadableType::class.java,
       serviceConstructor = { bookRegistry }
+    )
+
+    addService(
+      message = strings.bootingGeneral("accessibility service"),
+      interfaceType = AccessibilityServiceType::class.java,
+      serviceConstructor = { AccessibilityService.create(context, bookRegistry) }
     )
 
     val tenPrint =


### PR DESCRIPTION
**What's this do?**
Turn `AccessibilityService` into a back-end service initialized in `MainServices`. Get it rid of `runOnUIThread`.

**Why are we doing this? (w/ JIRA link if applicable)**
`AccessibilityService` didn't depend on view any more and could miss some events.

**How should this be tested? / Do these changes have associated tests?**
Check new book status are properly announced.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Yes, I did.