### PR TITLE
SIMPLY-3772: Add build numbers and commit information reports

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainApplication.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainApplication.kt
@@ -2,6 +2,7 @@ package org.nypl.simplified.main
 
 import android.app.Application
 import android.net.http.HttpResponseCache
+import android.os.Process
 import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
@@ -41,9 +42,26 @@ class MainApplication : Application() {
     MainLogging.configure(cacheDir)
     this.configureHttpCache()
     this.configureStrictMode()
-    this.logger.debug("starting app: pid {}", android.os.Process.myPid())
+    this.logStartup()
     this.boot.start(this)
     INSTANCE = this
+  }
+
+  private fun logStartup() {
+    this.logger.debug("starting app: pid {}", Process.myPid())
+    this.logger.debug("app version: {}", BuildConfig.SIMPLIFIED_VERSION)
+    this.logger.debug("app build:   {}", versionCode())
+    this.logger.debug("app commit:  {}", BuildConfig.GIT_COMMIT)
+  }
+
+  private fun versionCode(): String {
+    return try {
+      val info = this.packageManager.getPackageInfo(this.packageName, 0)
+      info.versionCode.toString()
+    } catch (e : Exception) {
+      this.logger.error("version info unavailable: ", e)
+      "UNKNOWN"
+    }
   }
 
   /**

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainApplication.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainApplication.kt
@@ -58,7 +58,7 @@ class MainApplication : Application() {
     return try {
       val info = this.packageManager.getPackageInfo(this.packageName, 0)
       info.versionCode.toString()
-    } catch (e : Exception) {
+    } catch (e: Exception) {
       this.logger.error("version info unavailable: ", e)
       "UNKNOWN"
     }

--- a/simplified-reports/build.gradle
+++ b/simplified-reports/build.gradle
@@ -1,3 +1,18 @@
+def getGitHash = { ->
+  def stdout = new ByteArrayOutputStream()
+  exec {
+    commandLine "git", "rev-parse", "--short", "HEAD"
+    standardOutput = stdout
+  }
+  return stdout.toString().trim()
+}
+
+android {
+  defaultConfig {
+    buildConfigField "String", "SIMPLIFIED_GIT_COMMIT", "\"${getGitHash()}\""
+  }
+}
+
 dependencies {
   api libraries.androidx_legacy_support_v4
   api libraries.kotlin_stdlib

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
@@ -167,7 +167,7 @@ class SettingsDebugViewModel(application: Application) : AndroidViewModel(applic
     Reports.sendReportsDefault(
       context = this.getApplication(),
       address = this.supportEmailAddress,
-      subject = "[simplye-error-report] ${this.appVersion}",
+      subject = "[error-report]",
       body = ""
     )
   }


### PR DESCRIPTION
**What's this do?**
This logs the app version, app build, and app commit on application
startup. It also adds that information to emailed error reports.

**Why are we doing this? (w/ JIRA link if applicable)**
Fix: https://jira.nypl.org/browse/SIMPLY-3772

**How should this be tested? / Do these changes have associated tests?**
Check that error reports have build information in the email subjects, and commit information in the email bodies. You can generate a fake error report from the debug settings menu.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m watched logcat, and tried generating an email.