### PR TITLE
SIMPLY-2214: Allow for specifying custom Library Registry URIs

### DIFF
--- a/simplified-accounts-registry/src/main/java/org/nypl/simplified/accounts/registry/AccountProviderRegistry.kt
+++ b/simplified-accounts-registry/src/main/java/org/nypl/simplified/accounts/registry/AccountProviderRegistry.kt
@@ -19,6 +19,7 @@ import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryStatus.R
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.accounts.source.spi.AccountProviderSourceFactoryType
 import org.nypl.simplified.accounts.source.spi.AccountProviderSourceType
+import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.taskrecorder.api.TaskRecorder
 import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.slf4j.LoggerFactory
@@ -232,8 +233,10 @@ class AccountProviderRegistry private constructor(
     ): AccountProviderRegistryType {
       val loader =
         ServiceLoader.load(AccountProviderSourceFactoryType::class.java)
+      val buildConfig =
+        ServiceLoader.load(BuildConfigurationServiceType::class.java).first()
       val sources =
-        loader.toList().map { it.create(context, http) }
+        loader.toList().map { it.create(context, http, buildConfig) }
       return this.createFrom(context, sources, defaultProvider)
     }
 

--- a/simplified-accounts-source-filebased/src/main/java/org/nypl/simplified/accounts/source/filebased/AccountProviderSourceFileBasedFactory.kt
+++ b/simplified-accounts-source-filebased/src/main/java/org/nypl/simplified/accounts/source/filebased/AccountProviderSourceFileBasedFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import org.librarysimplified.http.api.LSHTTPClientType
 import org.nypl.simplified.accounts.source.spi.AccountProviderSourceFactoryType
 import org.nypl.simplified.accounts.source.spi.AccountProviderSourceType
+import org.nypl.simplified.buildconfig.api.BuildConfigurationAccountsType
 
 /**
  * A factory for file-based sources.
@@ -12,7 +13,8 @@ import org.nypl.simplified.accounts.source.spi.AccountProviderSourceType
 class AccountProviderSourceFileBasedFactory : AccountProviderSourceFactoryType {
   override fun create(
     context: Context,
-    http: LSHTTPClientType
+    http: LSHTTPClientType,
+    buildConfig: BuildConfigurationAccountsType
   ): AccountProviderSourceType {
     return AccountProviderSourceFileBased { c -> c.assets.open("Accounts.json") }
   }

--- a/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderSourceNYPLFactory.kt
+++ b/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderSourceNYPLFactory.kt
@@ -6,6 +6,7 @@ import org.nypl.simplified.accounts.json.AccountProviderDescriptionCollectionPar
 import org.nypl.simplified.accounts.json.AccountProviderDescriptionCollectionSerializers
 import org.nypl.simplified.accounts.source.spi.AccountProviderSourceFactoryType
 import org.nypl.simplified.accounts.source.spi.AccountProviderSourceType
+import org.nypl.simplified.buildconfig.api.BuildConfigurationAccountsType
 import org.nypl.simplified.opds.auth_document.api.AuthenticationDocumentParsersType
 import org.nypl.simplified.opds2.irradia.OPDS2ParsersIrradia
 import java.util.ServiceLoader
@@ -24,13 +25,16 @@ class AccountProviderSourceNYPLFactory : AccountProviderSourceFactoryType {
 
   override fun create(
     context: Context,
-    http: LSHTTPClientType
+    http: LSHTTPClientType,
+    buildConfig: BuildConfigurationAccountsType
   ): AccountProviderSourceType {
     return AccountProviderSourceNYPLRegistry(
       http = http,
       authDocumentParsers = this.findAuthenticationDocumentParsers(),
       parsers = AccountProviderDescriptionCollectionParsers(OPDS2ParsersIrradia),
-      serializers = AccountProviderDescriptionCollectionSerializers()
+      serializers = AccountProviderDescriptionCollectionSerializers(),
+      uriProduction = buildConfig.libraryRegistry.registry,
+      uriQA = buildConfig.libraryRegistry.registryQA
     )
   }
 }

--- a/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderSourceNYPLRegistry.kt
+++ b/simplified-accounts-source-nyplregistry/src/main/java/org/nypl/simplified/accounts/source/nyplregistry/AccountProviderSourceNYPLRegistry.kt
@@ -44,8 +44,8 @@ class AccountProviderSourceNYPLRegistry(
   private val authDocumentParsers: AuthenticationDocumentParsersType,
   private val parsers: AccountProviderDescriptionCollectionParsersType,
   private val serializers: AccountProviderDescriptionCollectionSerializersType,
-  private val uriProduction: URI = URI("https://libraryregistry.librarysimplified.org/libraries"),
-  private val uriQA: URI = URI("https://libraryregistry.librarysimplified.org/libraries/qa")
+  private val uriProduction: URI,
+  private val uriQA: URI
 ) : AccountProviderSourceType {
 
   private val logger =

--- a/simplified-accounts-source-spi/build.gradle
+++ b/simplified-accounts-source-spi/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
   api project(':simplified-accounts-api')
+  api project(':simplified-buildconfig-api')
 
   api libraries.google_guava
   api libraries.io7m_jfunctional

--- a/simplified-accounts-source-spi/src/main/java/org/nypl/simplified/accounts/source/spi/AccountProviderSourceFactoryType.kt
+++ b/simplified-accounts-source-spi/src/main/java/org/nypl/simplified/accounts/source/spi/AccountProviderSourceFactoryType.kt
@@ -2,6 +2,7 @@ package org.nypl.simplified.accounts.source.spi
 
 import android.content.Context
 import org.librarysimplified.http.api.LSHTTPClientType
+import org.nypl.simplified.buildconfig.api.BuildConfigurationAccountsType
 
 /**
  * A factory for creating account sources.
@@ -15,6 +16,7 @@ interface AccountProviderSourceFactoryType {
 
   fun create(
     context: Context,
-    http: LSHTTPClientType
+    http: LSHTTPClientType,
+    buildConfig: BuildConfigurationAccountsType
   ): AccountProviderSourceType
 }

--- a/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
+++ b/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
@@ -1,10 +1,17 @@
 package org.nypl.labs.OpenEbooks.app
 
 import org.nypl.simplified.buildconfig.api.BuildConfigOAuthScheme
+import org.nypl.simplified.buildconfig.api.BuildConfigurationAccountsRegistryURIs
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.main.BuildConfig
+import java.net.URI
 
 class OEIBuildConfigurationService : BuildConfigurationServiceType {
+  override val libraryRegistry: BuildConfigurationAccountsRegistryURIs
+    get() = BuildConfigurationAccountsRegistryURIs(
+      registry = URI("https://libraryregistry.librarysimplified.org/libraries"),
+      registryQA = URI("https://libraryregistry.librarysimplified.org/libraries/qa")
+    )
   override val vcsCommit: String
     get() = BuildConfig.GIT_COMMIT
   override val showSettingsTab: Boolean

--- a/simplified-app-simplye/src/main/java/org/nypl/simplified/simplye/SimplyEBuildConfigurationService.kt
+++ b/simplified-app-simplye/src/main/java/org/nypl/simplified/simplye/SimplyEBuildConfigurationService.kt
@@ -1,10 +1,17 @@
 package org.nypl.simplified.simplye
 
 import org.nypl.simplified.buildconfig.api.BuildConfigOAuthScheme
+import org.nypl.simplified.buildconfig.api.BuildConfigurationAccountsRegistryURIs
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.main.BuildConfig
+import java.net.URI
 
 class SimplyEBuildConfigurationService : BuildConfigurationServiceType {
+  override val libraryRegistry: BuildConfigurationAccountsRegistryURIs
+    get() = BuildConfigurationAccountsRegistryURIs(
+      registry = URI("https://libraryregistry.librarysimplified.org/libraries"),
+      registryQA = URI("https://libraryregistry.librarysimplified.org/libraries/qa")
+    )
   override val allowAccountsAccess: Boolean
     get() = true
   override val allowAccountsRegistryAccess: Boolean

--- a/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
+++ b/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
@@ -1,10 +1,17 @@
 package org.nypl.simplified.vanilla
 
 import org.nypl.simplified.buildconfig.api.BuildConfigOAuthScheme
+import org.nypl.simplified.buildconfig.api.BuildConfigurationAccountsRegistryURIs
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.main.BuildConfig
+import java.net.URI
 
 class VanillaBuildConfigurationService : BuildConfigurationServiceType {
+  override val libraryRegistry: BuildConfigurationAccountsRegistryURIs
+    get() = BuildConfigurationAccountsRegistryURIs(
+      registry = URI("https://libraryregistry.librarysimplified.org/libraries"),
+      registryQA = URI("https://libraryregistry.librarysimplified.org/libraries/qa")
+    )
   override val allowAccountsAccess: Boolean
     get() = true
   override val allowAccountsRegistryAccess: Boolean

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationAccountsRegistryURIs.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationAccountsRegistryURIs.kt
@@ -1,0 +1,22 @@
+package org.nypl.simplified.buildconfig.api
+
+import java.net.URI
+
+/**
+ * The Library Registry URIs.
+ */
+
+data class BuildConfigurationAccountsRegistryURIs(
+
+  /**
+   * The URI for the production Library Registry.
+   */
+
+  val registry: URI,
+
+  /**
+   * The URI for the QA Library Registry.
+   */
+
+  val registryQA: URI
+)

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationAccountsType.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationAccountsType.kt
@@ -7,6 +7,12 @@ package org.nypl.simplified.buildconfig.api
 interface BuildConfigurationAccountsType {
 
   /**
+   * The base URI for the library registry.
+   */
+
+  val libraryRegistry: BuildConfigurationAccountsRegistryURIs
+
+  /**
    * If set to `true`, then users are allowed access to the accounts panel and
    * can add/remove accounts. If set to `false`, the accounts setting item is
    * removed.


### PR DESCRIPTION
**What's this do?**
This adds a field to the build configuration service that allows for
specifying custom Library Registry URIs.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/SIMPLY-2214

This will allow us to produce a custom Open eBooks build using the QA Library Registry.

**How should this be tested? / Do these changes have associated tests?**
N/A

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Checked that nothing broke.