### PR TITLE
Introduce UIExecutor to fix a bug occuring when removing an account

### DIFF
--- a/simplified-futures/src/main/java/org/nypl/simplified/futures/FluentFutureExtensions.kt
+++ b/simplified-futures/src/main/java/org/nypl/simplified/futures/FluentFutureExtensions.kt
@@ -5,12 +5,24 @@ import com.google.common.util.concurrent.AsyncFunction
 import com.google.common.util.concurrent.FluentFuture
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.MoreExecutors
+import java.util.concurrent.Executor
 
 /**
  * Extension functions to get around the lack of SAM conversion in Kotlin.
  */
 
 object FluentFutureExtensions {
+
+  /**
+   * Apply a function `f` to the value of the current future.
+   *
+   * This is the same as `FluentFuture.transform` excepted that the compiler knows
+   * that the result is not null.
+   */
+
+  fun <A, B> FluentFuture<A>.map(f: (A) -> B, executor: Executor): FluentFuture<B> {
+    return this.transform(Function<A, B> { x -> f.invoke(x!!) }, executor)
+  }
 
   /**
    * Apply a function `f` to the value of the current future.

--- a/simplified-ui-catalog/build.gradle
+++ b/simplified-ui-catalog/build.gradle
@@ -19,6 +19,7 @@ dependencies {
   implementation project(":simplified-ui-theme")
   implementation project(":simplified-ui-accounts")
   implementation project(":simplified-ui-errorpage")
+  implementation project(":simplified-ui-thread-api")
 
   implementation libraries.androidx_core
   implementation libraries.androidx_fragment

--- a/simplified-ui-thread-api/src/main/java/org/nypl/simplified/ui/thread/api/UIExecutor.kt
+++ b/simplified-ui-thread-api/src/main/java/org/nypl/simplified/ui/thread/api/UIExecutor.kt
@@ -4,6 +4,17 @@ import android.os.Handler
 import android.os.Looper
 import java.util.concurrent.Executor
 
+/**
+ * An executor implementation that executes runnables on the UI thread and properly cancels
+ * their execution when disposed.
+ * It is primarily meant to safely listen to futures on the UI thread in a lifecycle-aware manner.
+ *
+ * Disposing the executor cancels the execution of any runnable previously submitted
+ * and not yet executed, as well as that of runnables that might be submitted in the future.
+ * Runnables being executed are not an issue because they are executed on the UI thread,
+ * which means that no UI-related lifecycle action can be performed at the same time.
+ */
+
 class UIExecutor : Executor {
 
   private val handler: Handler =
@@ -26,6 +37,11 @@ class UIExecutor : Executor {
       }
     }
   }
+
+  /**
+   * Cancel the execution of any runnable previously submitted
+   * and not yet executed, as well as that of runnables that might be submitted in the future.
+   */
 
   fun dispose() {
     synchronized(this.lock) {

--- a/simplified-ui-thread-api/src/main/java/org/nypl/simplified/ui/thread/api/UIExecutor.kt
+++ b/simplified-ui-thread-api/src/main/java/org/nypl/simplified/ui/thread/api/UIExecutor.kt
@@ -1,0 +1,39 @@
+package org.nypl.simplified.ui.thread.api
+
+import android.os.Handler
+import android.os.Looper
+import java.util.concurrent.Executor
+
+class UIExecutor : Executor {
+
+  private val handler: Handler =
+    Handler(Looper.getMainLooper())
+
+  private val callbacks: MutableList<Runnable> =
+    mutableListOf()
+
+  private var isDisposed: Boolean =
+    false
+
+  private val lock: Any =
+    Any()
+
+  override fun execute(command: Runnable) {
+    synchronized(this.lock) {
+      if (!this.isDisposed) {
+        this.callbacks.add(command)
+        this.handler.post(command)
+      }
+    }
+  }
+
+  fun dispose() {
+    synchronized(this.lock) {
+      this.isDisposed = true
+      while (this.callbacks.isNotEmpty()) {
+        val callback = this.callbacks.removeFirst()
+        this.handler.removeCallbacks(callback)
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What's this do?**
Introduce the class `UIExecutor` that should enable us to safely use Futures returned by the Controller in ViewModels. As opposed to events, Futures have the advantage of being owned by one ViewModel instance which can be the unique listener to its completion.

This is used to fix a bug in simplified-ui-catalog.

**Why are we doing this? (w/ JIRA link if applicable)**
Deleting an account could cause a crash in case there were two library accounts: the SimplyE collection and another one.
When deleting the latter account while it was shown in the Catalog tab, the CatalogFeedFragment associated with it happened to receive the callback onAgeUpdated meant to the CatalogFeedFragment showing the SimplyE collection before being deleted. Then, as the account had been deleted, it couldn't be found any more and the app crashed.

**How should this be tested? / Do these changes have associated tests?**
Add a library account via "Find my library now", and remove it. Check the app doesn't crash and everything happens as expected.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Yes, I did.