### PR TITLE
Fix several issues with the AccountDetailFragment

### DIFF
--- a/build_libraries.gradle
+++ b/build_libraries.gradle
@@ -7,7 +7,7 @@ ext.android_min_sdk_version = 21
 // Dependency versions
 
 ext.versions = [
-  androidx_activity             : '1.1.0',
+  androidx_activity             : '1.2.3',
   androidx_appcompat            : '1.2.0',
   androidx_cardview             : '1.0.0',
   androidx_constraintlayout     : '1.1.3',

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorContract.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorContract.kt
@@ -1,0 +1,73 @@
+package org.nypl.simplified.cardcreator
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.os.bundleOf
+
+class CardCreatorContract(
+  private val username: String,
+  private val password: String,
+  private val clientId: String,
+  private val clientSecret: String
+) : ActivityResultContract<CardCreatorContract.Input, CardCreatorContract.Output>() {
+
+  class Input(
+    val userIdentifier: String,
+    val isLoggedIn: Boolean
+  )
+
+  data class Output(
+    val barcode: String,
+    val pin: String
+  )
+
+  override fun createIntent(context: Context, input: Input): Intent {
+    val extras = this.createExtras(input)
+    val intent = Intent(context, CardCreatorActivity::class.java)
+    intent.putExtras(extras)
+    return intent
+  }
+
+  private fun createExtras(input: Input): Bundle =
+    bundleOf(
+      USERNAME_KEY to this.username,
+      PASSWORD_KEY to this.password,
+      CLIENT_ID_KEY to this.clientId,
+      CLIENT_SECRET_KEY to this.clientSecret,
+      IS_LOGGED_IN_KEY to input.isLoggedIn,
+      USER_IDENTIFIER_KEY to input.userIdentifier
+    )
+
+  override fun parseResult(resultCode: Int, intent: Intent?): Output? =
+    if (intent == null || resultCode != Activity.RESULT_OK) {
+      null
+    } else {
+      this.parseResult(intent.extras!!)
+    }
+
+  private fun parseResult(result: Bundle): Output {
+    val barcode = result.getString(BARCODE_KEY)!!
+    val pin = result.getString(PIN_KEY)!!
+
+    return Output(barcode, pin)
+  }
+
+  companion object {
+    private const val USERNAME_KEY = "username"
+    private const val PASSWORD_KEY = "password"
+    private const val CLIENT_ID_KEY = "clientId"
+    private const val CLIENT_SECRET_KEY = "clientSecret"
+    private const val IS_LOGGED_IN_KEY = "isLoggedIn"
+    private const val USER_IDENTIFIER_KEY = "userIdentifier"
+
+    private const val BARCODE_KEY = "barcode"
+    private const val PIN_KEY = "pin"
+
+    fun createResult(barcode: String, pin: String): Bundle {
+      return bundleOf(BARCODE_KEY to barcode, PIN_KEY to pin)
+    }
+  }
+}

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorService.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorService.kt
@@ -1,12 +1,9 @@
 package org.nypl.simplified.cardcreator
 
 import android.content.Context
-import android.content.Intent
-import androidx.fragment.app.Fragment
 import org.slf4j.LoggerFactory
 import java.io.FileNotFoundException
 import java.io.InputStream
-import java.lang.NullPointerException
 import java.util.Properties
 
 class CardCreatorService(
@@ -58,20 +55,11 @@ class CardCreatorService(
     }
   }
 
-  override fun openCardCreatorActivity(
-    fragment: Fragment,
-    context: Context?,
-    resultCode: Int,
-    isLoggedIn: Boolean,
-    userIdentifier: String
-  ) {
-    val intent = Intent(context, CardCreatorActivity::class.java)
-    intent.putExtra("username", username)
-    intent.putExtra("password", password)
-    intent.putExtra("clientId", clientId)
-    intent.putExtra("clientSecret", clientSecret)
-    intent.putExtra("isLoggedIn", isLoggedIn)
-    intent.putExtra("userIdentifier", userIdentifier)
-    fragment.startActivityForResult(intent, resultCode)
-  }
+  override fun getCardCreatorContract(): CardCreatorContract =
+    CardCreatorContract(
+      this.username,
+      this.password,
+      this.clientId,
+      this.clientSecret
+    )
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorServiceType.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/CardCreatorServiceType.kt
@@ -1,14 +1,6 @@
 package org.nypl.simplified.cardcreator
 
-import android.content.Context
-import androidx.fragment.app.Fragment
-
 interface CardCreatorServiceType {
-  fun openCardCreatorActivity(
-    fragment: Fragment,
-    context: Context?,
-    resultCode: Int,
-    isLoggedIn: Boolean,
-    userIdentifier: String
-  )
+
+  fun getCardCreatorContract(): CardCreatorContract
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/ConfirmationFragment.kt
@@ -18,6 +18,7 @@ import androidx.fragment.app.Fragment
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import org.nypl.simplified.cardcreator.CardCreatorContract
 import org.nypl.simplified.cardcreator.R
 import org.nypl.simplified.cardcreator.databinding.FragmentConfirmationBinding
 import org.nypl.simplified.cardcreator.utils.Cache
@@ -168,13 +169,15 @@ class ConfirmationFragment : Fragment() {
    * Returns result to caller with card details
    */
   private fun returnResult() {
+    val bundle = CardCreatorContract.createResult(barcode, pin)
+    bundle.apply {
+      putString("type", type)
+      putString("username", username)
+      putBoolean("temporary", temporary)
+      putString("message", message)
+    }
     val data = Intent().apply {
-      putExtra("type", type)
-      putExtra("username", username)
-      putExtra("barcode", barcode)
-      putExtra("pin", pin)
-      putExtra("temporary", temporary)
-      putExtra("message", message)
+      putExtras(bundle)
     }
     if (requireActivity().intent.getBooleanExtra("isLoggedIn", false)) {
       requireActivity().setResult(Activity.RESULT_CANCELED, data)

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -485,6 +485,7 @@ internal class MainFragmentListenerDelegate(
   }
 
   private fun openCatalogAfterAuthentication() {
+    this.navigator.popBackStack()
     this.navigator.reset(R.id.tabCatalog, false)
   }
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -71,7 +71,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
   private val subscriptions: CompositeDisposable =
     CompositeDisposable()
 
-  private val listener: FragmentListenerType<org.nypl.simplified.ui.accounts.AccountDetailEvent> by fragmentListeners()
+  private val listener: FragmentListenerType<AccountDetailEvent> by fragmentListeners()
 
   private val parameters: AccountFragmentParameters by lazy {
     this.requireArguments()[PARAMETERS_ID] as AccountFragmentParameters
@@ -221,9 +221,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     val eula = this.viewModel.eula
     if (eula != null) {
       this.eulaCheckbox.visibility = View.VISIBLE
-      this.eulaCheckbox.isChecked = eula.hasAgreed
       this.eulaCheckbox.setOnCheckedChangeListener { _, checked ->
-        eula.hasAgreed = checked
         this.setLoginButtonStatus(this.determineLoginIsSatisfied())
       }
     } else {
@@ -297,8 +295,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
   }
 
   private fun determineEULAIsSatisfied(): Boolean {
-    val eula = this.viewModel.eula
-    return eula?.hasAgreed ?: true
+    return this.eulaCheckbox.isChecked
   }
 
   private fun shouldSignUpBeEnabled(): Boolean {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
@@ -103,7 +102,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
   private lateinit var bookmarkSync: ViewGroup
   private lateinit var bookmarkSyncCheck: SwitchCompat
   private lateinit var bookmarkSyncLabel: View
-  private lateinit var eulaCheckbox: CheckBox
   private lateinit var loginProgress: ViewGroup
   private lateinit var loginButtonErrorDetails: Button
   private lateinit var loginProgressBar: ProgressBar
@@ -175,8 +173,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       view.findViewById(R.id.accountLoginProgressText)
     this.loginButtonErrorDetails =
       view.findViewById(R.id.accountLoginButtonErrorDetails)
-    this.eulaCheckbox =
-      view.findViewById(R.id.accountEULACheckbox)
     this.signUpButton =
       view.findViewById(R.id.accountCardCreatorSignUp)
     this.signUpLabel =
@@ -235,12 +231,10 @@ class AccountDetailFragment : Fragment(R.layout.account) {
 
   private fun determineLoginIsSatisfied(): AccountLoginButtonStatus {
     val authDescription = this.viewModel.account.provider.authentication
-    val eulaOk = this.eulaCheckbox.isChecked
     val loginPossible = authDescription.isLoginPossible
     val satisfiedFor = this.authenticationViews.isSatisfiedFor(authDescription)
 
-    this.logger.debug("eula: {}, possible: {}, satisfied: {}", eulaOk, loginPossible, satisfiedFor)
-    return if (eulaOk && loginPossible && satisfiedFor) {
+    return if (loginPossible && satisfiedFor) {
       AsLoginButtonEnabled {
         this.loginFormLock()
         this.tryLogin()
@@ -297,10 +291,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     super.onStart()
 
     this.configureToolbar(requireActivity())
-
-    this.eulaCheckbox.setOnCheckedChangeListener { _, checked ->
-      this.setLoginButtonStatus(this.determineLoginIsSatisfied())
-    }
 
     /*
      * Configure the COPPA age gate switch. If the user changes their age, a log out
@@ -530,20 +520,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     this.bookmarkSyncLabel.isEnabled = isSupported
 
     this.authenticationViews.showFor(this.viewModel.account.provider.authentication)
-
-    /*
-     * Only show a EULA checkbox if there's actually a EULA.
-     */
-
-    if (this.viewModel.account.provider.eula != null) {
-      this.eulaCheckbox.visibility = View.VISIBLE
-      this.eulaCheckbox.setOnCheckedChangeListener { _, checked ->
-        this.setLoginButtonStatus(this.determineLoginIsSatisfied())
-      }
-    } else {
-      this.eulaCheckbox.visibility = View.GONE
-    }
-
 
     this.hideCardCreatorForNonNYPL()
 
@@ -806,7 +782,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     )
 
     this.authenticationViews.lock()
-    this.eulaCheckbox.isEnabled = false
 
     this.setLoginButtonStatus(AsLoginButtonDisabled)
     this.authenticationAlternativesHide()
@@ -819,7 +794,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     )
 
     this.authenticationViews.unlock()
-    this.eulaCheckbox.isEnabled = true
 
     val loginSatisfied = this.determineLoginIsSatisfied()
     this.setLoginButtonStatus(loginSatisfied)

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -646,7 +646,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
         when (val creds = loginState.credentials) {
           is AccountAuthenticationCredentials.Basic -> {
             this.authenticationViews.setBasicUserAndPass("", "")
-
           }
           is AccountAuthenticationCredentials.OAuthWithIntermediary -> {
             // No UI

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModel.kt
@@ -106,7 +106,7 @@ class AccountDetailViewModel(
   val account: AccountType =
     this.accountLive.value!!
 
-    /**
+  /**
    * Logging in was explicitly requested. This is tracked in order to allow for optionally
    * closing the account fragment on successful logins.
    */

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModel.kt
@@ -5,8 +5,6 @@ import hu.akarnokd.rxjava2.subjects.UnicastWorkSubject
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import org.joda.time.DateTime
-import org.librarysimplified.documents.DocumentStoreType
-import org.librarysimplified.documents.EULAType
 import org.librarysimplified.services.api.Services
 import org.nypl.simplified.accounts.api.AccountEvent
 import org.nypl.simplified.accounts.api.AccountID
@@ -16,7 +14,7 @@ import org.nypl.simplified.profiles.api.ProfileEvent
 import org.nypl.simplified.profiles.controller.api.ProfileAccountLoginRequest
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceType
-import org.nypl.simplified.threads.NamedThreadPools
+import java.net.URI
 
 /**
  * A view model for storing state during login attempts.
@@ -29,17 +27,11 @@ class AccountDetailViewModel(
   private val services =
     Services.serviceDirectory()
 
-  private val documents =
-    services.requireService(DocumentStoreType::class.java)
-
   private val profilesController =
     services.requireService(ProfilesControllerType::class.java)
 
   private val readerBookmarkService =
     services.requireService(ReaderBookmarkServiceType::class.java)
-
-  private val backgroundExecutor =
-    NamedThreadPools.namedThreadPool(1, "simplified-accounts-io", 19)
 
   private val subscriptions = CompositeDisposable(
     this.profilesController.accountEvents()
@@ -61,7 +53,6 @@ class AccountDetailViewModel(
   override fun onCleared() {
     super.onCleared()
     this.subscriptions.clear()
-    this.backgroundExecutor.shutdown()
   }
 
   val accountEvents: UnicastWorkSubject<AccountEvent> =
@@ -73,13 +64,13 @@ class AccountDetailViewModel(
   val buildConfig =
     services.requireService(BuildConfigurationServiceType::class.java)
 
-  val eula: EULAType? =
-    this.documents.eula
-
   val account =
     this.profilesController
       .profileCurrent()
       .account(this.accountId)
+
+  val eula: URI? =
+    this.account.provider.eula
 
   /**
    * Logging in was explicitly requested. This is tracked in order to allow for optionally

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModelFactory.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModelFactory.kt
@@ -3,20 +3,23 @@ package org.nypl.simplified.ui.accounts
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.listeners.api.FragmentListenerType
 
 /**
  * A factory for account view state.
  */
 
-class AccountViewModelFactory(
+class AccountDetailViewModelFactory(
   private val account: AccountID,
+  private val listener: FragmentListenerType<AccountDetailEvent>
 ) : ViewModelProvider.Factory {
 
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel?> create(modelClass: Class<T>): T {
     if (modelClass == AccountDetailViewModel::class.java) {
       return AccountDetailViewModel(
-        accountId = this.account
+        accountId = this.account,
+        listener = this.listener
       ) as T
     }
     throw IllegalStateException("Can't create values of $modelClass")

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListAdapter.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListAdapter.kt
@@ -110,6 +110,7 @@ class AccountListAdapter(
           View.GONE
         }
 
+      this.imageLoader.loader.cancelRequest(this.accountIcon)
       ImageAccountIcons.loadAccountLogoIntoView(
         loader = this.imageLoader.loader,
         account = item.provider.toDescription(),

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -55,19 +55,6 @@
       android:layout_width="match_parent"
       android:layout_height="16dp" />
 
-    <CheckBox
-      android:id="@+id/accountEULACheckbox"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="16dp"
-      android:layout_marginEnd="16dp"
-      android:gravity="center"
-      android:text="@string/accountEULAStatement" />
-
-    <Space
-      android:layout_width="match_parent"
-      android:layout_height="16dp" />
-
     <include layout="@layout/auth" />
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/simplified-ui-images/src/main/java/org/nypl/simplified/ui/images/ImageAccountIcons.kt
+++ b/simplified-ui-images/src/main/java/org/nypl/simplified/ui/images/ImageAccountIcons.kt
@@ -25,7 +25,7 @@ object ImageAccountIcons {
     loader: Picasso,
     account: AccountProviderDescription,
     @DrawableRes defaultIcon: Int,
-    iconView: ImageView
+    iconView: ImageView,
   ) {
     val uri = account.logoURI?.hrefURI
     this.logger.debug("configuring account logo: {}", uri)


### PR DESCRIPTION
**What's this do?**
- Refactor a bit the AccountDetailFragment
- Modernize and simplify CardCreator's API
- Remove the EULA checkbox because it was meaningless
- Actually close the AccountDetailFragment once logged in if the catalog was waiting for the operation's completion

**Why are we doing this? (w/ JIRA link if applicable)**
- Login button status was wrong after having switched tab from the AccountDetailFragment and back.
- Barcode and PIN used to be lost on orientation changes.

**How should this be tested? / Do these changes have associated tests?**
- Try to log in and log out, switching device orientation.
- Leave the AccountDetailFragment switching tab and go back to it, check the status is correct.
- Check the CardCreator is still working.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Yes, I did.