### PR TITLE
Bugfix/sma 195 - "Holds" navigation icon shows up on SimplyE Collection

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
@@ -100,10 +100,7 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
     /*
      * Hide various tabs based on build configuration and other settings.
      */
-
-    val holdsItem = this.bottomView.menu.findItem(R.id.tabHolds)
-    holdsItem.isVisible = viewModel.buildConfig.showHoldsTab
-    holdsItem.isEnabled = viewModel.buildConfig.showHoldsTab
+    this.setShowHoldsVisibility()
 
     val settingsItem = this.bottomView.menu.findItem(R.id.tabSettings)
     settingsItem.isVisible = viewModel.buildConfig.showSettingsTab
@@ -203,6 +200,13 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
     }
   }
 
+  private fun setShowHoldsVisibility() {
+    val showHolds = viewModel.showHoldsTab
+    val holdsItem = this.bottomView.menu.findItem(R.id.tabHolds)
+    holdsItem.isVisible = showHolds
+    holdsItem.isEnabled = showHolds
+  }
+
   private fun onProfileUpdateSucceeded(event: ProfileUpdated.Succeeded) {
     val oldAccountId = event.oldDescription.preferences.mostRecentAccount
     val newAccountId = event.newDescription.preferences.mostRecentAccount
@@ -215,6 +219,7 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
     }
 
     this.checkForAnnouncements()
+    this.setShowHoldsVisibility()
   }
 
   private fun onIdleTimedOut() {

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
@@ -37,10 +37,8 @@ class MainFragmentViewModel : ViewModel() {
   val buildConfig =
     services.requireService(BuildConfigurationServiceType::class.java)
   val showHoldsTab: Boolean
-    get() {
-      return  buildConfig.showHoldsTab && profilesController.profileCurrent()
-        .mostRecentAccount()?.provider?.supportsReservations == true
-    }
+    get() = buildConfig.showHoldsTab && profilesController.profileCurrent()
+      .mostRecentAccount().provider.supportsReservations
 
   private val subscriptions: CompositeDisposable =
     CompositeDisposable()

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
@@ -36,6 +36,11 @@ class MainFragmentViewModel : ViewModel() {
     services.requireService(BookRegistryType::class.java)
   val buildConfig =
     services.requireService(BuildConfigurationServiceType::class.java)
+  val showHoldsTab: Boolean
+    get() {
+      return  buildConfig.showHoldsTab && profilesController.profileCurrent()
+        .mostRecentAccount()?.provider?.supportsReservations == true
+    }
 
   private val subscriptions: CompositeDisposable =
     CompositeDisposable()


### PR DESCRIPTION
**What's this do?**
- Adds additional check for displaying 'Holds'  bottom navigation icon
- Added additional logic to check if 'Holds' icon should be shown when user changes libraries

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SMA-195

**How should this be tested? / Do these changes have associated tests?**
Verify that 'Holds' tab doesn't appear on SimplyE Collection & that it properly updates when switching libraries

**Dependencies for merging? Releasing to production?**
None

**Screenshots**
![image](https://user-images.githubusercontent.com/5824872/124199575-32b14400-daa1-11eb-98e5-5c7740c9f778.png)
![image](https://user-images.githubusercontent.com/5824872/124199531-13b2b200-daa1-11eb-9c3f-94afefc60c05.png)

**Has the application documentation been updated for these changes?**
No documentation changes needed

**Did someone actually run this code to verify it works?**
I did