### PR TITLE
SMA-186: Make the account bookmark sync switch reflect reality

### DIFF
--- a/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkEvent.kt
+++ b/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkEvent.kt
@@ -10,6 +10,15 @@ import org.nypl.simplified.books.api.Bookmark
 sealed class ReaderBookmarkEvent {
 
   /**
+   * The status of bookmark syncing changed.
+   */
+
+  data class ReaderBookmarkSyncSettingChanged(
+    val accountID: AccountID,
+    val status: ReaderBookmarkSyncEnableStatus
+  ) : ReaderBookmarkEvent()
+
+  /**
    * Synchronizing bookmarks for the given account has started.
    */
 

--- a/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkServiceUsableType.kt
+++ b/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkServiceUsableType.kt
@@ -20,15 +20,12 @@ interface ReaderBookmarkServiceUsableType {
   val bookmarkEvents: Observable<ReaderBookmarkEvent>
 
   /**
-   * The result of attempting to enable/disable syncing (assuming that the attempt didn't
-   * outright fail with an exception).
+   * Fetch the bookmark sync status for the given account.
    */
 
-  enum class SyncEnableResult {
-    SYNC_ENABLE_NOT_SUPPORTED,
-    SYNC_ENABLED,
-    SYNC_DISABLED
-  }
+  fun bookmarkSyncStatus(
+    accountID: AccountID
+  ): ReaderBookmarkSyncEnableStatus
 
   /**
    * Enable/disable bookmark syncing on the server.
@@ -37,7 +34,7 @@ interface ReaderBookmarkServiceUsableType {
   fun bookmarkSyncEnable(
     accountID: AccountID,
     enabled: Boolean
-  ): FluentFuture<SyncEnableResult>
+  ): FluentFuture<ReaderBookmarkSyncEnableResult>
 
   /**
    * The user wants their current bookmarks.

--- a/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkSyncEnableResult.kt
+++ b/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkSyncEnableResult.kt
@@ -1,0 +1,12 @@
+package org.nypl.simplified.reader.bookmarks.api
+
+/**
+ * The result of attempting to enable/disable syncing (assuming that the attempt didn't
+ * outright fail with an exception).
+ */
+
+enum class ReaderBookmarkSyncEnableResult {
+  SYNC_ENABLE_NOT_SUPPORTED,
+  SYNC_ENABLED,
+  SYNC_DISABLED
+}

--- a/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkSyncEnableStatus.kt
+++ b/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkSyncEnableStatus.kt
@@ -1,0 +1,28 @@
+package org.nypl.simplified.reader.bookmarks.api
+
+import org.nypl.simplified.accounts.api.AccountID
+
+/**
+ * The current status of the bookmark syncing configuration switch. The configuration is either
+ * idle, or is in the process of changing.
+ */
+
+sealed class ReaderBookmarkSyncEnableStatus {
+
+  /**
+   * The switch is idle.
+   */
+
+  data class Idle(
+    val accountID: AccountID,
+    val status: ReaderBookmarkSyncEnableResult
+  ) : ReaderBookmarkSyncEnableStatus()
+
+  /**
+   * The switch is changing.
+   */
+
+  data class Changing(
+    val accountID: AccountID
+  ) : ReaderBookmarkSyncEnableStatus()
+}

--- a/simplified-reader-bookmarks/src/main/java/org/nypl/simplified/books/reader/bookmarks/ReaderBookmarkService.kt
+++ b/simplified-reader-bookmarks/src/main/java/org/nypl/simplified/books/reader/bookmarks/ReaderBookmarkService.kt
@@ -41,19 +41,22 @@ import org.nypl.simplified.reader.bookmarks.api.BookmarkAnnotations
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkEvent
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkEvent.ReaderBookmarkSaved
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkEvent.ReaderBookmarkSyncFinished
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkEvent.ReaderBookmarkSyncSettingChanged
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkEvent.ReaderBookmarkSyncStarted
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkHTTPCallsType
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceProviderType
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceProviderType.Requirements
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceType
-import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceUsableType.SyncEnableResult
-import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceUsableType.SyncEnableResult.SYNC_DISABLED
-import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceUsableType.SyncEnableResult.SYNC_ENABLED
-import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceUsableType.SyncEnableResult.SYNC_ENABLE_NOT_SUPPORTED
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableResult
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableResult.SYNC_DISABLED
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableResult.SYNC_ENABLED
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableResult.SYNC_ENABLE_NOT_SUPPORTED
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableStatus
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarks
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URI
+import java.util.Collections
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 
@@ -95,6 +98,7 @@ class ReaderBookmarkService private constructor(
 
   private val logger = LoggerFactory.getLogger(ReaderBookmarkService::class.java)
   private val objectMapper = ObjectMapper()
+  private val accountsSyncChanging = Collections.synchronizedSet(hashSetOf<AccountID>())
 
   @Volatile
   private var policyState: ReaderBookmarkPolicyState
@@ -518,33 +522,58 @@ class ReaderBookmarkService private constructor(
 
   private class OpEnableSync(
     logger: Logger,
+    private val accountsSyncChanging: MutableSet<AccountID>,
+    private val bookmarkEventsOut: Subject<ReaderBookmarkEvent>,
     private val httpCalls: ReaderBookmarkHTTPCallsType,
     private val profile: ProfileReadableType,
     private val syncableAccount: SyncableAccount,
     private val enable: Boolean
-  ) : ReaderBookmarkControllerOp<SyncEnableResult>(logger) {
+  ) : ReaderBookmarkControllerOp<ReaderBookmarkSyncEnableResult>(logger) {
 
-    override fun runActual(): SyncEnableResult {
+    override fun runActual(): ReaderBookmarkSyncEnableResult {
+      val accountId = this.syncableAccount.account.id
+
       this.logger.debug(
         "[{}]: {} syncing for account {}",
         this.profile.id.uuid,
         if (this.enable) "enabling" else "disabling",
-        this.syncableAccount.account.id.uuid
+        accountId.uuid
       )
 
-      this.httpCalls.syncingEnable(
-        settingsURI = this.syncableAccount.settingsURI,
-        credentials = this.syncableAccount.credentials,
-        enabled = this.enable
-      )
+      this.accountsSyncChanging.add(accountId)
 
-      this.syncableAccount.account.setPreferences(
-        this.syncableAccount.account.preferences.copy(bookmarkSyncingPermitted = enable)
-      )
+      try {
+        this.httpCalls.syncingEnable(
+          settingsURI = this.syncableAccount.settingsURI,
+          credentials = this.syncableAccount.credentials,
+          enabled = this.enable
+        )
 
-      return when (enable) {
-        true -> SYNC_ENABLED
-        false -> SYNC_DISABLED
+        this.syncableAccount.account.setPreferences(
+          this.syncableAccount.account.preferences.copy(bookmarkSyncingPermitted = this.enable)
+        )
+
+        val status = when (this.enable) {
+          true -> SYNC_ENABLED
+          false -> SYNC_DISABLED
+        }
+
+        this.accountsSyncChanging.remove(accountId)
+        this.bookmarkEventsOut.onNext(
+          ReaderBookmarkSyncSettingChanged(
+            accountID = accountId,
+            status = ReaderBookmarkSyncEnableStatus.Idle(accountId, status)
+          )
+        )
+
+        return status
+      } finally {
+
+        /*
+         * Redundantly ensure the account has been removed from the changing set.
+         */
+
+        this.accountsSyncChanging.remove(accountId)
       }
     }
   }
@@ -769,11 +798,46 @@ class ReaderBookmarkService private constructor(
     }
   }
 
+  override fun bookmarkSyncStatus(
+    accountID: AccountID
+  ): ReaderBookmarkSyncEnableStatus {
+    val profile =
+      this.profilesController.profileCurrent()
+    val syncable =
+      accountSupportsSyncing(profile.account(accountID))
+
+    if (syncable == null) {
+      this.logger.error("bookmarkSyncEnable: account does not support syncing")
+      return ReaderBookmarkSyncEnableStatus.Idle(accountID, SYNC_ENABLE_NOT_SUPPORTED)
+    }
+
+    val changing = this.accountsSyncChanging.contains(accountID)
+    if (changing) {
+      return ReaderBookmarkSyncEnableStatus.Changing(accountID)
+    }
+
+    return ReaderBookmarkSyncEnableStatus.Idle(
+      accountID = accountID,
+      status = if (syncable.account.preferences.bookmarkSyncingPermitted) {
+        SYNC_ENABLED
+      } else {
+        SYNC_DISABLED
+      }
+    )
+  }
+
   override fun bookmarkSyncEnable(
     accountID: AccountID,
     enabled: Boolean
-  ): FluentFuture<SyncEnableResult> {
+  ): FluentFuture<ReaderBookmarkSyncEnableResult> {
     return try {
+      this.bookmarkEventsOut.onNext(
+        ReaderBookmarkSyncSettingChanged(
+          accountID = accountID,
+          status = ReaderBookmarkSyncEnableStatus.Changing(accountID)
+        )
+      )
+
       val profile =
         this.profilesController.profileCurrent()
       val syncable =
@@ -781,12 +845,25 @@ class ReaderBookmarkService private constructor(
 
       if (syncable == null) {
         this.logger.error("bookmarkSyncEnable: account does not support syncing")
-        return FluentFuture.from(Futures.immediateFuture(SYNC_ENABLE_NOT_SUPPORTED))
+        val status = SYNC_ENABLE_NOT_SUPPORTED
+
+        this.bookmarkEventsOut.onNext(
+          ReaderBookmarkSyncSettingChanged(
+            accountID = accountID,
+            status = ReaderBookmarkSyncEnableStatus.Idle(accountID, status)
+          )
+        )
+
+        return FluentFuture.from(Futures.immediateFuture(status))
       }
+
+      this.accountsSyncChanging.add(accountID)
 
       val opEnable =
         OpEnableSync(
           logger = this.logger,
+          accountsSyncChanging = this.accountsSyncChanging,
+          bookmarkEventsOut = this.bookmarkEventsOut,
           httpCalls = this.httpCalls,
           profile = profile,
           syncableAccount = syncable,

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/reader/bookmarks/NullReaderBookmarkService.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/reader/bookmarks/NullReaderBookmarkService.kt
@@ -9,7 +9,8 @@ import org.nypl.simplified.books.api.Bookmark
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkEvent
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceProviderType
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceType
-import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceUsableType.SyncEnableResult
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableResult
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableStatus
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarks
 
 class NullReaderBookmarkService(
@@ -22,8 +23,12 @@ class NullReaderBookmarkService(
   override val bookmarkEvents: Observable<ReaderBookmarkEvent>
     get() = this.events
 
-  override fun bookmarkSyncEnable(accountID: AccountID, enabled: Boolean): FluentFuture<SyncEnableResult> {
-    return FluentFuture.from(Futures.immediateFuture(SyncEnableResult.SYNC_ENABLE_NOT_SUPPORTED))
+  override fun bookmarkSyncStatus(accountID: AccountID): ReaderBookmarkSyncEnableStatus {
+    return ReaderBookmarkSyncEnableStatus.Changing(accountID)
+  }
+
+  override fun bookmarkSyncEnable(accountID: AccountID, enabled: Boolean): FluentFuture<ReaderBookmarkSyncEnableResult> {
+    return FluentFuture.from(Futures.immediateFuture(ReaderBookmarkSyncEnableResult.SYNC_ENABLE_NOT_SUPPORTED))
   }
 
   override fun bookmarkCreate(accountID: AccountID, bookmark: Bookmark): FluentFuture<Unit> {

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/reader/bookmarks/ReaderBookmarkServiceContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/reader/bookmarks/ReaderBookmarkServiceContract.kt
@@ -44,9 +44,9 @@ import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkEvent
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkHTTPCallsType
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceType
-import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceUsableType.SyncEnableResult.SYNC_DISABLED
-import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceUsableType.SyncEnableResult.SYNC_ENABLED
-import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceUsableType.SyncEnableResult.SYNC_ENABLE_NOT_SUPPORTED
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableResult.SYNC_DISABLED
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableResult.SYNC_ENABLED
+import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkSyncEnableResult.SYNC_ENABLE_NOT_SUPPORTED
 import org.nypl.simplified.tests.EventAssertions
 import org.nypl.simplified.tests.EventLogging
 import org.nypl.simplified.tests.mocking.MockProfilesController

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -214,8 +214,21 @@
         android:labelFor="@id/accountSyncBookmarksCheck"
         android:text="@string/accountSyncBookmarks"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/accountSyncBookmarksCheck"
+        app:layout_constraintEnd_toStartOf="@+id/accountSyncProgress"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <ProgressBar
+        android:id="@+id/accountSyncProgress"
+        style="?android:attr/progressBarStyle"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:indeterminate="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/accountSyncBookmarksCheck"
         app:layout_constraintTop_toTopOf="parent" />
 
       <androidx.appcompat.widget.SwitchCompat
@@ -230,6 +243,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
**What's this do?**
This adjusts the account bookmark sync switch so that it works based
off of an observable status value. When the switch is toggled, the
reader bookmark service tracks the progress of the operation and can
publish appropriate status values when asked. A small indefinite
progress indicator has been added to show that a long-running
operation is occurring when the switch is toggled, and the switch is
marked as disabled (non-interactable) when a sync setting change is
in progress. This prevents users from being able to queue up dozens
of switch changes by hammering the toggle repeatedly.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/SMA-186

**How should this be tested? / Do these changes have associated tests?**
Ensure that the switch reflects what you know to be true of an existing account (ie, the account either has syncing enabled or disabled when you're logged in). Ensure that you can't just quickly and repeatedly tap the switch and end up with it toggling backwards and forwards long after you stopped tapping.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried it lots with an NYPL account.