### PR TITLE
Feat/sma 211 - Update CI to use App Bundles Instead of APKs

### DIFF
--- a/simplified-app-openebooks/firebase-bundle.conf
+++ b/simplified-app-openebooks/firebase-bundle.conf
@@ -1,0 +1,4 @@
+build/outputs/bundle/release/openebooks-release.aab
+#
+# The first line of this file is the APK that will be deployed to Firebase.
+#

--- a/simplified-app-simplye/fastlane/Fastfile
+++ b/simplified-app-simplye/fastlane/Fastfile
@@ -34,11 +34,12 @@ platform :android do
         next
       end
       gradle(task: "clean")
-      gradle(task: "assembleRelease")
+      gradle(task: "bundleRelease")
        firebase_app_distribution(
          app: "1:220408294534:android:594dde26dd9d35c301f507",
          groups: "librarysimplified",
          release_notes: "#{release_notes}",
+         android_artifact_type: "AAB",
          firebase_cli_path: ENV["FIREBASE_CLI_PATH"])
        slack(
         message: "New simplyE android build available on firebase",

--- a/simplified-app-simplye/firebase-bundle.conf
+++ b/simplified-app-simplye/firebase-bundle.conf
@@ -1,4 +1,4 @@
-build/outputs/apk/release/simplye-release.apk
+build/outputs/aab/release/simplye-release.aab
 #
 # The first line of this file is the AAB that will be deployed to Firebase.
 #


### PR DESCRIPTION
**What's this do?**
- Adds `firebase-bundle.conf` to SimplyE & OpenEBooks app modules which point to app bundle (.aab) (see https://github.com/NYPL-Simplified/Simplified-Android-CI/pull/1 for changes to CI script)

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SMA-211

**How should this be tested? / Do these changes have associated tests?**
Verify that CI build is successful and that firebase receives an .aab file instead of an .apk

**Dependencies for merging? Releasing to production?**
Requires this PR: https://github.com/NYPL-Simplified/Simplified-Android-CI/pull/1 to be merged as well

**Has the application documentation been updated for these changes?**
Yes

**Did someone actually run this code to verify it works?**
No, can only really be tested once it's merged in unfortunately