### PR TITLE
SMA-226: Fix a crash related to stale account IDs

### DIFF
--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
@@ -218,7 +218,6 @@ class Controller private constructor(
       if (crash != null) {
         ControllerCrashlytics.configureCrashlytics(
           profile = profile,
-          accountProviders = accountProviders,
           crashlytics = crash
         )
       }

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ControllerCrashlytics.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ControllerCrashlytics.kt
@@ -1,22 +1,25 @@
 package org.nypl.simplified.books.controller
 
 import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
-import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
 import org.nypl.simplified.profiles.api.ProfileReadableType
+import org.slf4j.LoggerFactory
 import java.security.MessageDigest
 
 internal object ControllerCrashlytics {
 
+  private val logger =
+    LoggerFactory.getLogger(ControllerCrashlytics::class.java)
+
   fun configureCrashlytics(
     profile: ProfileReadableType,
-    accountProviders: AccountProviderRegistryType,
     crashlytics: CrashlyticsServiceType
   ) {
-    val account =
-      profile.mostRecentAccount() ?: profile.accountsByProvider()[accountProviders.defaultProvider.id]
-    if (account != null) {
+    try {
+      val account = profile.mostRecentAccount()
       this.configureCrashlyticsForCredentials(crashlytics, account.loginState.credentials)
+    } catch (e: Exception) {
+      this.logger.debug("exception raised when configuring crashlytics: ", e)
     }
   }
 

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
@@ -394,7 +394,7 @@ object ProfilesDatabases {
         accounts.first()
       }
 
-    val desc: ProfileDescription =
+    var description: ProfileDescription =
       try {
         ProfileDescriptionJSON.deserializeFromFile(jom, profileFile, mostRecentFallback.id)
       } catch (e: IOException) {
@@ -408,7 +408,7 @@ object ProfilesDatabases {
       directory = profileDir,
       analytics = analytics,
       accounts = accountsDatabase,
-      initialDescription = desc
+      initialDescription = description
     )
   }
 


### PR DESCRIPTION
**What's this do?**
* Catch any possible exception raised when configuring Crashlytics.
* Fix broken account IDs when initializing profiles.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/SMA-226

**How should this be tested? / Do these changes have associated tests?**
Uncertain, because we don't know how the accounts got into this state in the first place. See Slack!

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried breaking the app, and wrote tests.