### PR TITLE
SMA-205: Update book registry during sync-related book removals

### DIFF
--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLoanCreate.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLoanCreate.kt
@@ -44,6 +44,8 @@ import java.net.URI
 
 /**
  * A task that creates an OPDS loan by hitting an acquisition URI.
+ *
+ * XXX: Use [FeedLoading.loadSingleEntryFeed]
  */
 
 class BorrowLoanCreate private constructor() : BorrowSubtaskType {

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookSyncTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookSyncTask.kt
@@ -1,5 +1,6 @@
 package org.nypl.simplified.books.controller
 
+import com.io7m.jfunctional.Some
 import org.librarysimplified.http.api.LSHTTPClientType
 import org.librarysimplified.http.api.LSHTTPResponseStatus
 import org.nypl.simplified.accounts.api.AccountAuthenticatedHTTP
@@ -12,11 +13,15 @@ import org.nypl.simplified.accounts.database.api.AccountType
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.books.api.BookID
 import org.nypl.simplified.books.api.BookIDs
+import org.nypl.simplified.books.book_database.api.BookDatabaseEntryType
 import org.nypl.simplified.books.book_database.api.BookDatabaseException
 import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.controller.api.BooksControllerType
+import org.nypl.simplified.feeds.api.FeedLoaderType
+import org.nypl.simplified.feeds.api.FeedLoading
+import org.nypl.simplified.opds.core.OPDSAvailabilityRevoked
 import org.nypl.simplified.opds.core.OPDSFeedParserType
 import org.nypl.simplified.opds.core.OPDSParseException
 import org.nypl.simplified.patron.api.PatronUserProfile
@@ -29,15 +34,18 @@ import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.io.InputStream
+import java.net.URI
 import java.util.HashSet
+import java.util.concurrent.TimeUnit
 
 class BookSyncTask(
-  accountID: AccountID,
+  private val accountID: AccountID,
   profileID: ProfileID,
   profiles: ProfilesDatabaseType,
   private val booksController: BooksControllerType,
   private val accountRegistry: AccountProviderRegistryType,
   private val bookRegistry: BookRegistryType,
+  private val feedLoader: FeedLoaderType,
   private val patronParsers: PatronUserProfileParsersType,
   private val http: LSHTTPClientType,
   private val feedParser: OPDSFeedParserType
@@ -242,8 +250,15 @@ class BookSyncTask(
         this.logger.debug("[{}] checking for deletion", existingId.brief())
 
         if (!received.contains(existingId)) {
-          revoking.add(existingId)
-          this.logger.debug("[{}] scheduling for deletion", existingId.brief())
+          val dbEntry = bookDatabase.entry(existingId)
+          val a = dbEntry.book.entry.availability
+          if (a is OPDSAvailabilityRevoked) {
+            revoking.add(existingId)
+          } else {
+            this.logger.debug("[{}] deleting", existingId.brief())
+            this.updateRegistryForBook(account, dbEntry)
+            dbEntry.delete()
+          }
         } else {
           this.logger.debug("[{}] keeping", existingId.brief())
         }
@@ -259,6 +274,43 @@ class BookSyncTask(
     for (revoke_id in revoking) {
       this.logger.debug("[{}] revoking", revoke_id.brief())
       this.booksController.bookRevoke(account.id, revoke_id)
+    }
+  }
+
+  private fun updateRegistryForBook(
+    account: AccountType,
+    dbEntry: BookDatabaseEntryType
+  ) {
+    this.logger.debug("attempting to fetch book permalink to update registry")
+    val alternateOpt = dbEntry.book.entry.alternate
+    return if (alternateOpt is Some<URI>) {
+      val alternate = alternateOpt.get()
+      val entry =
+        FeedLoading.loadSingleEntryFeed(
+          feedLoader = this.feedLoader,
+          taskRecorder = this.taskRecorder,
+          accountID = this.accountID,
+          uri = alternate,
+          timeout = Pair(30L, TimeUnit.SECONDS),
+          httpAuth = null,
+          method = "GET"
+        )
+
+      /*
+       * Write a new book database entry based on the server state, and pretend that all the
+       * books have been deleted. The code will delete the entire database entry after this
+       * method returns anyway, so this code ensures that something sensible goes into the
+       * book registry.
+       */
+
+      dbEntry.writeOPDSEntry(entry.feedEntry)
+      val newBook = dbEntry.book.copy(formats = emptyList())
+      val status = BookStatus.fromBook(newBook)
+
+      this.logger.debug("book's new state is {}", status)
+      this.bookRegistry.update(BookWithStatus(newBook, status))
+    } else {
+      throw IOException("No alternate link is available")
     }
   }
 

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
@@ -605,6 +605,7 @@ class Controller private constructor(
         bookRegistry = this.bookRegistry,
         booksController = this,
         feedParser = this.feedParser,
+        feedLoader = this.feedLoader,
         patronParsers = this.patronUserProfileParsers,
         http = this.lsHttp
       )

--- a/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedLoader.kt
+++ b/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedLoader.kt
@@ -159,7 +159,9 @@ class FeedLoader private constructor(
 
     val linearizedPaths = OPDSAcquisitionPaths.linearize(entry)
     for (path in linearizedPaths) {
-      if (this.isRelationSupported(path.source.relation) && this.isTypePathSupported(path)) {
+      val relationSupported = this.isRelationSupported(path.source.relation)
+      val typePathSupported = this.isTypePathSupported(path)
+      if (relationSupported && typePathSupported) {
         return true
       }
     }
@@ -176,8 +178,9 @@ class FeedLoader private constructor(
       ACQUISITION_SUBSCRIBE -> false
     }
 
-  private fun isTypePathSupported(path: OPDSAcquisitionPath) =
-    this.bookFormatSupport.isSupportedPath(path.asMIMETypes())
+  private fun isTypePathSupported(path: OPDSAcquisitionPath): Boolean {
+    return this.bookFormatSupport.isSupportedPath(path.asMIMETypes())
+  }
 
   private fun parseFromContentResolver(
     accountId: AccountID,

--- a/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedLoading.kt
+++ b/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedLoading.kt
@@ -1,0 +1,118 @@
+package org.nypl.simplified.feeds.api
+
+import org.librarysimplified.http.api.LSHTTPAuthorizationType
+import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.feeds.api.Feed.FeedWithGroups
+import org.nypl.simplified.feeds.api.Feed.FeedWithoutGroups
+import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryOPDS
+import org.nypl.simplified.feeds.api.FeedLoaderResult.FeedLoaderFailure.FeedLoaderFailedAuthentication
+import org.nypl.simplified.feeds.api.FeedLoaderResult.FeedLoaderFailure.FeedLoaderFailedGeneral
+import org.nypl.simplified.feeds.api.FeedLoaderResult.FeedLoaderSuccess
+import org.nypl.simplified.taskrecorder.api.TaskRecorderType
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+/**
+ * Convenience functions for fetching and parsing feeds.
+ */
+
+object FeedLoading {
+
+  /**
+   * Synchronously load a URI, returning the first usable OPDS entry in the feed.
+   *
+   * @param feedLoader The feed loader that will be used
+   * @param taskRecorder A task recorder used to record the operation steps
+   * @param accountID The account that owns the feed
+   * @param uri The target URI
+   * @param timeout The timeout value
+   * @param httpAuth The authorization information
+   * @param method The HTTP request method
+   */
+
+  fun loadSingleEntryFeed(
+    feedLoader: FeedLoaderType,
+    taskRecorder: TaskRecorderType,
+    accountID: AccountID,
+    uri: URI,
+    timeout: Pair<Long, TimeUnit>,
+    httpAuth: LSHTTPAuthorizationType?,
+    method: String = "GET"
+  ): FeedEntryOPDS {
+    taskRecorder.beginNewStep("Fetching OPDS feed...")
+
+    val feedResult =
+      feedLoader.fetchURI(
+        account = accountID,
+        uri = uri,
+        auth = httpAuth,
+        method = method
+      ).get(timeout.first, timeout.second)
+
+    return when (feedResult) {
+      is FeedLoaderFailedAuthentication -> {
+        taskRecorder.currentStepFailed(feedResult.message, "feedAuthentication", feedResult.exception)
+        throw feedResult.exception
+      }
+      is FeedLoaderFailedGeneral -> {
+        taskRecorder.currentStepFailed(feedResult.message, "feedFailed", feedResult.exception)
+        throw feedResult.exception
+      }
+      is FeedLoaderSuccess -> {
+        taskRecorder.currentStepSucceeded("Feed retrieved and parsed.")
+        taskRecorder.beginNewStep("Finding OPDS feed entry...")
+
+        when (val feed = feedResult.feed) {
+          is FeedWithGroups ->
+            this.checkEntry(taskRecorder, findFirstInGroups(feed.feedGroupsInOrder))
+          is FeedWithoutGroups ->
+            this.checkEntry(taskRecorder, findFirst(feed.entriesInOrder))
+        }
+      }
+    }
+  }
+
+  private fun checkEntry(
+    taskRecorder: TaskRecorderType,
+    feedOPDS: FeedEntryOPDS?
+  ): FeedEntryOPDS =
+    if (feedOPDS != null) {
+      taskRecorder.currentStepSucceeded("Found OPDS feed entry.")
+      feedOPDS
+    } else {
+      val message = "Expected a feed containing at least one OPDS entry"
+      val exception = IllegalArgumentException(message)
+      taskRecorder.currentStepFailed(message, "feedUnsuitable", exception)
+      throw exception
+    }
+
+  private fun findFirst(
+    feedEntries: List<FeedEntry>
+  ): FeedEntryOPDS? {
+    for (entry in feedEntries) {
+      when (entry) {
+        is FeedEntry.FeedEntryCorrupt ->
+          Unit
+        is FeedEntryOPDS ->
+          return entry
+      }
+    }
+    return null
+  }
+
+  private fun findFirstInGroups(
+    feedGroupsInOrder: List<FeedGroup>
+  ): FeedEntryOPDS? {
+    for (group in feedGroupsInOrder) {
+      for (entry in group.groupEntries) {
+        when (entry) {
+          is FeedEntry.FeedEntryCorrupt ->
+            Unit
+          is FeedEntryOPDS ->
+            return entry
+        }
+      }
+    }
+    return null
+  }
+}

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskAdobeDRMTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskAdobeDRMTest.kt
@@ -1298,7 +1298,7 @@ class BookRevokeTaskAdobeDRMTest {
     TaskDumps.dump(logger, result)
     result as TaskResult.Failure
 
-    Assertions.assertEquals("revokeCredentialsRequired", result.lastErrorCode)
+    Assertions.assertEquals("credentialsRequired", result.lastErrorCode)
     Mockito.verify(bookDatabaseEntry, Times(0)).delete()
   }
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
@@ -650,6 +650,13 @@ abstract class BooksControllerContract {
 
     controller.booksSync(account.id).get()
 
+    /*
+     * Wait for all subtasks to complete.
+     */
+
+    this.executorBooks.shutdown()
+    this.executorBooks.awaitTermination(30L, TimeUnit.SECONDS)
+
     Assertions.assertEquals(1, bookDatabase.books().size)
 
     bookDatabase.entry(

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
@@ -76,6 +76,7 @@ import org.nypl.simplified.tests.mocking.MockAccountLogoutStringResources
 import org.nypl.simplified.tests.mocking.MockAccountProviderResolutionStrings
 import org.nypl.simplified.tests.mocking.MockAccountProviders
 import org.nypl.simplified.tests.mocking.MockAnalytics
+import org.nypl.simplified.tests.mocking.MockBookFormatSupport
 import org.nypl.simplified.tests.mocking.MockRevokeStringResources
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -98,7 +99,7 @@ abstract class BooksControllerContract {
   private lateinit var audioBookManifestStrategies: AudioBookManifestStrategiesType
   private lateinit var authDocumentParsers: AuthenticationDocumentParsersType
   private lateinit var bookEvents: MutableList<BookEvent>
-  private lateinit var bookFormatSupport: BookFormatSupportType
+  private lateinit var bookFormatSupport: MockBookFormatSupport
   private lateinit var bookRegistry: BookRegistryType
   private lateinit var borrowSubtasks: BorrowSubtaskDirectoryType
   private lateinit var cacheDirectory: File
@@ -214,7 +215,7 @@ abstract class BooksControllerContract {
     this.audioBookManifestStrategies = Mockito.mock(AudioBookManifestStrategiesType::class.java)
     this.authDocumentParsers = Mockito.mock(AuthenticationDocumentParsersType::class.java)
     this.bookEvents = Collections.synchronizedList(ArrayList())
-    this.bookFormatSupport = Mockito.mock(BookFormatSupportType::class.java)
+    this.bookFormatSupport = MockBookFormatSupport()
     this.bookRegistry = BookRegistry.create()
     this.borrowSubtasks = BorrowSubtasks.directory()
     this.cacheDirectory = File.createTempFile("book-borrow-tmp", "dir")
@@ -246,7 +247,7 @@ abstract class BooksControllerContract {
         )
 
     this.server = MockWebServer()
-    this.server.start()
+    this.server.start(port = 9000)
   }
 
   @AfterEach
@@ -574,9 +575,12 @@ abstract class BooksControllerContract {
    */
 
   @Test
-  @Timeout(value = 3L, unit = TimeUnit.SECONDS)
+  @Timeout(value = 10L, unit = TimeUnit.SECONDS)
   @Throws(Exception::class)
   fun testBooksSyncRemoveEntries() {
+    this.bookFormatSupport.onIsSupportedFinalContentType = { true }
+    this.bookFormatSupport.onIsSupportedPath = { true }
+
     val controller =
       createController(
         exec = this.executorBooks,
@@ -623,13 +627,13 @@ abstract class BooksControllerContract {
 
     this.bookRegistry.bookOrException(
       BookID.create("39434e1c3ea5620fdcc2303c878da54cc421175eb09ce1a6709b54589eb8711f")
-    )
+    ).status as BookStatus.Loaned.LoanedNotDownloaded
     this.bookRegistry.bookOrException(
       BookID.create("f9a7536a61caa60f870b3fbe9d4304b2d59ea03c71cbaee82609e3779d1e6e0f")
-    )
+    ).status as BookStatus.Loaned.LoanedNotDownloaded
     this.bookRegistry.bookOrException(
       BookID.create("251cc5f69cd2a329bb6074b47a26062e59f5bb01d09d14626f41073f63690113")
-    )
+    ).status as BookStatus.Loaned.LoanedNotDownloaded
 
     this.bookRegistry.bookEvents().subscribe { this.bookEvents.add(it) }
 
@@ -646,6 +650,21 @@ abstract class BooksControllerContract {
       MockResponse()
         .setResponseCode(200)
         .setBody(Buffer().readFrom(resource("testBooksSyncRemoveEntries.xml")))
+    )
+    this.server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody(Buffer().readFrom(resource("testBook0.xml")))
+    )
+    this.server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody(Buffer().readFrom(resource("testBook1.xml")))
+    )
+    this.server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody(Buffer().readFrom(resource("testBook2.xml")))
     )
 
     controller.booksSync(account.id).get()
@@ -669,11 +688,11 @@ abstract class BooksControllerContract {
 
     this.bookRegistry.bookOrException(
       BookID.create("f9a7536a61caa60f870b3fbe9d4304b2d59ea03c71cbaee82609e3779d1e6e0f")
-    ).status as BookStatus.Loaned.LoanedNotDownloaded
+    ).status as BookStatus.Loanable
 
     this.bookRegistry.bookOrException(
       BookID.create("251cc5f69cd2a329bb6074b47a26062e59f5bb01d09d14626f41073f63690113")
-    ).status as BookStatus.Loaned.LoanedNotDownloaded
+    ).status as BookStatus.Loanable
   }
 
   /**

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookFormatSupport.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookFormatSupport.kt
@@ -16,6 +16,7 @@ class MockBookFormatSupport : BookFormatSupportType {
   override fun isSupportedFinalContentType(mime: MIMEType): Boolean =
     this.onIsSupportedFinalContentType(mime)
 
-  override fun isSupportedPath(typePath: List<MIMEType>): Boolean =
-    this.onIsSupportedPath(typePath)
+  override fun isSupportedPath(typePath: List<MIMEType>): Boolean {
+    return this.onIsSupportedPath(typePath)
+  }
 }

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/controller/testBook0.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/controller/testBook0.xml
@@ -1,0 +1,25 @@
+<feed xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog">
+  <id>urn:feed:0</id>
+  <title>Feed</title>
+  <updated>2015-03-24T17:23:50Z</updated>
+  <link href="urn:feed:0" rel="self"/>
+
+  <entry schema:additionalType="http://schema.org/Book">
+    <id>urn:book:0</id>
+    <title>Book 0</title>
+    <author>
+      <name>A. Author</name>
+    </author>
+    <summary type="html">No Description Available</summary>
+    <updated>2017-02-09T18:18:35Z</updated>
+    <published>2016-11-18T17:28:14Z</published>
+    <link href="urn:book:0:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image"/>
+    <link href="urn:book:0:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
+    <link href="urn:book:0:book.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/borrow">
+      <opds:availability since="2018-10-05T12:51:06Z" status="available" until="2018-10-26T18:51:07Z" />
+      <opds:holds total="0" />
+      <opds:copies available="5" total="5" />
+    </link>
+    <link href="http://localhost:9000/book/0" rel="alternate"/>
+  </entry>
+</feed>

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/controller/testBook1.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/controller/testBook1.xml
@@ -1,0 +1,25 @@
+<feed xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog">
+  <id>urn:feed:1</id>
+  <title>Feed</title>
+  <updated>2015-03-24T17:23:50Z</updated>
+  <link href="urn:feed:1" rel="self"/>
+
+  <entry schema:additionalType="http://schema.org/Book">
+    <id>urn:book:1</id>
+    <title>Book 0</title>
+    <author>
+      <name>A. Author</name>
+    </author>
+    <summary type="html">No Description Available</summary>
+    <updated>2017-02-09T18:18:35Z</updated>
+    <published>2016-11-18T17:28:14Z</published>
+    <link href="urn:book:1:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image"/>
+    <link href="urn:book:1:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
+    <link href="urn:book:1:book.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/borrow">
+      <opds:availability since="2018-10-05T12:51:06Z" status="available" until="2018-10-26T18:51:07Z" />
+      <opds:holds total="0" />
+      <opds:copies available="5" total="5" />
+    </link>
+    <link href="http://localhost:9000/book/1" rel="alternate"/>
+  </entry>
+</feed>

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/controller/testBook2.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/controller/testBook2.xml
@@ -1,0 +1,25 @@
+<feed xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog">
+  <id>urn:feed:2</id>
+  <title>Feed</title>
+  <updated>2015-03-24T17:23:50Z</updated>
+  <link href="urn:feed:2" rel="self"/>
+
+  <entry schema:additionalType="http://schema.org/Book">
+    <id>urn:book:2</id>
+    <title>Book 0</title>
+    <author>
+      <name>A. Author</name>
+    </author>
+    <summary type="html">No Description Available</summary>
+    <updated>2017-02-09T18:28:35Z</updated>
+    <published>2016-11-18T17:28:24Z</published>
+    <link href="urn:book:2:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image"/>
+    <link href="urn:book:2:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
+    <link href="urn:book:2:book.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/borrow">
+      <opds:availability since="2018-10-05T12:51:06Z" status="available" until="2018-10-26T18:51:07Z" />
+      <opds:holds total="0" />
+      <opds:copies available="5" total="5" />
+    </link>
+    <link href="http://localhost:9000/book/2" rel="alternate"/>
+  </entry>
+</feed>

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/controller/testBooksSyncNewEntries.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/controller/testBooksSyncNewEntries.xml
@@ -17,6 +17,7 @@
     <link href="urn:book:0:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image"/>
     <link href="urn:book:0:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
     <link href="urn:book:0:book.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
+    <link href="http://localhost:9000/book/0" rel="alternate"/>
   </entry>
 
   <entry schema:additionalType="http://schema.org/Book">
@@ -31,6 +32,7 @@
     <link href="urn:book:1:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image"/>
     <link href="urn:book:1:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
     <link href="urn:book:1:book.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
+    <link href="http://localhost:9000/book/1" rel="alternate"/>
   </entry>
 
   <entry schema:additionalType="http://schema.org/Book">
@@ -45,6 +47,7 @@
     <link href="urn:book:2:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image"/>
     <link href="urn:book:2:cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image/thumbnail"/>
     <link href="urn:book:2:book.epub" type="application/epub+zip" rel="http://opds-spec.org/acquisition/open-access"/>
+    <link href="http://localhost:9000/book/2" rel="alternate"/>
   </entry>
 
 </feed>


### PR DESCRIPTION
**What's this do?**
This updates the code so that expired-loan books that are deleted when the user syncs their loans don't get into odd states. Essentially, this deletes entries from the book database, and updates the new state of the book in the registry from the book's `alternate` permalink.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SMA-205

**How should this be tested? / Do these changes have associated tests?**
Check that expired loans disappear from the Books tab.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m tested with @leonardr, and added tests to the test suite.