### PR TITLE
SMA-229: Add a toggle to enable/disable publisher CSS

### DIFF
--- a/build_libraries.gradle
+++ b/build_libraries.gradle
@@ -56,7 +56,7 @@ ext.versions = [
   nypl_overdrive                : '1.0.3',
   nypl_pdf                      : '0.1.0',
   nypl_readium                  : '0.30.0',
-  nypl_readium2                 : '0.0.22-SNAPSHOT',
+  nypl_readium2                 : '0.0.23-SNAPSHOT',
   okhttp3                       : '4.8.1',
   pandora_bottom_navigator      : 'ec834b9',
   picasso                       : '2.71828',

--- a/simplified-reader-api/src/main/java/org/nypl/simplified/reader/api/ReaderPreferences.java
+++ b/simplified-reader-api/src/main/java/org/nypl/simplified/reader/api/ReaderPreferences.java
@@ -19,6 +19,7 @@ public abstract class ReaderPreferences {
     builder.setFontFamily(ReaderFontSelection.READER_FONT_SANS_SERIF);
     builder.setBrightness(1.0);
     builder.setFontScale(100.0);
+    builder.setPublisherCSS(ReaderPublisherCSS.PUBLISHER_DEFAULT_CSS_DISABLED);
     return builder;
   }
 
@@ -47,11 +48,16 @@ public abstract class ReaderPreferences {
   public abstract Builder toBuilder();
 
   /**
-   *
    * @return The screen brightness value in the range {@code [0.0, 1.0]}
    */
 
   public abstract double brightness();
+
+  /**
+   * @return The publisher CSS setting
+   */
+
+  public abstract ReaderPublisherCSS publisherCSS();
 
   /**
    * A mutable builder for reader preferences.
@@ -92,7 +98,17 @@ public abstract class ReaderPreferences {
 
     public abstract Builder setBrightness(double brightness);
 
+    /**
+     * @param css The new css setting
+     * @return This builder
+     * @see #publisherCSS()
+     */
+
+    public abstract Builder setPublisherCSS(ReaderPublisherCSS css);
+
     public abstract double brightness();
+
+    public abstract ReaderPublisherCSS publisherCSS();
 
     public abstract double fontScale();
 

--- a/simplified-reader-api/src/main/java/org/nypl/simplified/reader/api/ReaderPreferencesJSON.java
+++ b/simplified-reader-api/src/main/java/org/nypl/simplified/reader/api/ReaderPreferencesJSON.java
@@ -59,12 +59,24 @@ public final class ReaderPreferencesJSON {
     final ReaderColorScheme color_scheme =
       colorScheme(JSONParserUtilities.getStringDefault(
         obj, "color_scheme", SCHEME_BLACK_ON_WHITE.name()));
+    final ReaderPublisherCSS css =
+      publisherCSS(JSONParserUtilities.getStringDefault(
+        obj, "publisher_css", ReaderPublisherCSS.PUBLISHER_DEFAULT_CSS_DISABLED.name()));
 
     return ReaderPreferences.builder()
       .setFontScale(font_scale)
       .setFontFamily(font_family)
       .setColorScheme(color_scheme)
+      .setPublisherCSS(css)
       .build();
+  }
+
+  private static ReaderPublisherCSS publisherCSS(String publisher_css) throws JSONParseException {
+    try {
+      return ReaderPublisherCSS.valueOf(publisher_css);
+    } catch (final IllegalArgumentException e) {
+      throw new JSONParseException("Unparseable publisher CSS", e);
+    }
   }
 
   private static ReaderColorScheme colorScheme(final String font_family) throws JSONParseException {
@@ -101,6 +113,7 @@ public final class ReaderPreferencesJSON {
     jo.put("font_scale", description.fontScale());
     jo.put("font_family", description.fontFamily().name());
     jo.put("color_scheme", description.colorScheme().name());
+    jo.put("publisher_css", description.publisherCSS().name());
     return jo;
   }
 

--- a/simplified-reader-api/src/main/java/org/nypl/simplified/reader/api/ReaderPublisherCSS.kt
+++ b/simplified-reader-api/src/main/java/org/nypl/simplified/reader/api/ReaderPublisherCSS.kt
@@ -1,0 +1,20 @@
+package org.nypl.simplified.reader.api
+
+/**
+ * A specification of whether or not the publisher default CSS is enabled.
+ */
+
+enum class ReaderPublisherCSS {
+
+  /**
+   * Publisher default CSS is enabled.
+   */
+
+  PUBLISHER_DEFAULT_CSS_ENABLED,
+
+  /**
+   * Publisher default CSS is disabled.
+   */
+
+  PUBLISHER_DEFAULT_CSS_DISABLED
+}

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Themes.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Themes.kt
@@ -2,10 +2,16 @@ package org.nypl.simplified.viewer.epub.readium2
 
 import org.librarysimplified.r2.api.SR2ColorScheme
 import org.librarysimplified.r2.api.SR2Font
+import org.librarysimplified.r2.api.SR2PublisherCSS
+import org.librarysimplified.r2.api.SR2PublisherCSS.SR2_PUBLISHER_DEFAULT_CSS_DISABLED
+import org.librarysimplified.r2.api.SR2PublisherCSS.SR2_PUBLISHER_DEFAULT_CSS_ENABLED
 import org.librarysimplified.r2.api.SR2Theme
 import org.nypl.simplified.reader.api.ReaderColorScheme
 import org.nypl.simplified.reader.api.ReaderFontSelection
 import org.nypl.simplified.reader.api.ReaderPreferences
+import org.nypl.simplified.reader.api.ReaderPublisherCSS
+import org.nypl.simplified.reader.api.ReaderPublisherCSS.PUBLISHER_DEFAULT_CSS_DISABLED
+import org.nypl.simplified.reader.api.ReaderPublisherCSS.PUBLISHER_DEFAULT_CSS_ENABLED
 
 object Reader2Themes {
 
@@ -19,7 +25,17 @@ object Reader2Themes {
       .setColorScheme(fromSR2Color(theme.colorScheme))
       .setFontFamily(fromSR2Font(theme.font))
       .setFontScale(fromSR2Size(theme.textSize))
+      .setPublisherCSS(fromSR2PublisherCSS(theme.publisherCSS))
       .build()
+  }
+
+  private fun fromSR2PublisherCSS(
+    publisherCSS: SR2PublisherCSS
+  ): ReaderPublisherCSS {
+    return when (publisherCSS) {
+      SR2_PUBLISHER_DEFAULT_CSS_ENABLED -> PUBLISHER_DEFAULT_CSS_ENABLED
+      SR2_PUBLISHER_DEFAULT_CSS_DISABLED -> PUBLISHER_DEFAULT_CSS_DISABLED
+    }
   }
 
   private fun fromSR2Size(
@@ -64,8 +80,18 @@ object Reader2Themes {
     return SR2Theme(
       colorScheme = toSR2Color(readerPreferences.colorScheme()),
       font = toSR2Font(readerPreferences.fontFamily()),
-      textSize = toSR2Size(readerPreferences.fontScale())
+      textSize = toSR2Size(readerPreferences.fontScale()),
+      publisherCSS = toSR2PublisherCSS(readerPreferences.publisherCSS())
     )
+  }
+
+  private fun toSR2PublisherCSS(
+    publisherCSS: ReaderPublisherCSS
+  ): SR2PublisherCSS {
+    return when (publisherCSS) {
+      PUBLISHER_DEFAULT_CSS_ENABLED -> SR2_PUBLISHER_DEFAULT_CSS_ENABLED
+      PUBLISHER_DEFAULT_CSS_DISABLED -> SR2_PUBLISHER_DEFAULT_CSS_DISABLED
+    }
   }
 
   private fun toSR2Size(


### PR DESCRIPTION
**What's this do?**
This switches to a version of the R2 Android component that can toggle publisher CSS.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/SMA-229

**How should this be tested? / Do these changes have associated tests?**
Unfortunately, I'm not sure, because I don't know what the original problem that required this was. I suspect testing is going to mean trying out the books that were fixed by this change on iOS, and see if the same thing works on Android.

**Dependencies for merging? Releasing to production?**
We're still pointing at a snapshot version. We should tag a new R2 release before releasing this to the store.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m tested that this turned on/off publisher CSS.