### PR TITLE
OE-149: Disable book returns in OE

### DIFF
--- a/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
+++ b/simplified-app-openebooks/src/main/java/org/nypl/labs/OpenEbooks/app/OEIBuildConfigurationService.kt
@@ -40,4 +40,8 @@ class OEIBuildConfigurationService : BuildConfigurationServiceType {
     false
   override val showAgeGateUi: Boolean
     get() = false
+
+  override fun allowReturns(): Boolean {
+    return false
+  }
 }

--- a/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationCatalogType.kt
+++ b/simplified-buildconfig-api/src/main/java/org/nypl/simplified/buildconfig/api/BuildConfigurationCatalogType.kt
@@ -35,4 +35,11 @@ interface BuildConfigurationCatalogType {
    */
 
   val showBooksFromAllAccounts: Boolean
+
+  /**
+   * Enable/disable returning books.
+   */
+
+  @Deprecated(message = "Intended to solve a temporary issue with Open eBooks")
+  fun allowReturns(): Boolean = true
 }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -25,6 +25,7 @@ import org.nypl.simplified.books.book_database.api.BookFormats
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.covers.BookCoverProviderType
+import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryOPDS
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.listeners.api.fragmentListeners
@@ -84,6 +85,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
   private var thumbnailLoading: FluentFuture<Unit>? = null
 
   private lateinit var authors: TextView
+  private lateinit var buildConfig: BuildConfigurationServiceType
   private lateinit var buttonCreator: CatalogButtons
   private lateinit var buttons: LinearLayout
   private lateinit var cover: ImageView
@@ -136,6 +138,9 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       services.requireService(ScreenSizeInformationType::class.java)
     this.covers =
       services.requireService(BookCoverProviderType::class.java)
+    this.buildConfig =
+      services.requireService(BuildConfigurationServiceType::class.java)
+
     this.buttonCreator =
       CatalogButtons(this.requireContext(), this.screenSize)
   }
@@ -542,7 +547,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
         }
     }
 
-    if (bookStatus.returnable) {
+    if (bookStatus.returnable && this.buildConfig.allowReturns()) {
       this.buttons.addView(this.buttonCreator.createButtonSpace())
       this.buttons.addView(
         this.buttonCreator.createRevokeLoanButton {


### PR DESCRIPTION
**What's this do?**
This adds a (deprecated) method to the catalog build configuration
service that allows for disabling book returns in applications.
This is only used by OE, and probably won't be used for all that long.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/OE-149

**How should this be tested? / Do these changes have associated tests?**
Check that you don't see Return buttons in OE in the book detail pages.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m checked for a lack of buttons.