### PR TITLE
OE-182: Filter unsupported books locally

### DIFF
--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
@@ -35,6 +35,7 @@ import org.nypl.simplified.books.borrowing.BorrowRequirements
 import org.nypl.simplified.books.borrowing.BorrowTask
 import org.nypl.simplified.books.controller.api.BookRevokeStringResourcesType
 import org.nypl.simplified.books.controller.api.BooksControllerType
+import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
 import org.nypl.simplified.feeds.api.Feed
 import org.nypl.simplified.feeds.api.FeedEntry
@@ -107,6 +108,8 @@ class Controller private constructor(
     this.services.requireService(AuthenticationDocumentParsersType::class.java)
   private val bookRegistry =
     this.services.requireService(BookRegistryType::class.java)
+  private val bookFormatSupport =
+    this.services.requireService(BookFormatSupportType::class.java)
   private val feedLoader =
     this.services.requireService(FeedLoaderType::class.java)
   private val feedParser =
@@ -522,6 +525,7 @@ class Controller private constructor(
   ): FluentFuture<Feed.FeedWithoutGroups> {
     return this.submitTask(
       ProfileFeedTask(
+        bookFormatSupport = this.bookFormatSupport,
         bookRegistry = this.bookRegistry,
         profiles = this,
         request = request

--- a/simplified-books-formats-api/build.gradle
+++ b/simplified-books-formats-api/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+  api project(":simplified-books-api")
+
   api libraries.irradia_mime_api
   api libraries.irradia_mime_vanilla
 

--- a/simplified-books-formats-api/src/main/java/org/nypl/simplified/books/formats/api/BookFormatSupportType.kt
+++ b/simplified-books-formats-api/src/main/java/org/nypl/simplified/books/formats/api/BookFormatSupportType.kt
@@ -1,6 +1,7 @@
 package org.nypl.simplified.books.formats.api
 
 import one.irradia.mime.api.MIMEType
+import org.nypl.simplified.books.api.BookDRMKind
 
 /**
  * Information about the book formats supported by the current application.
@@ -25,4 +26,10 @@ interface BookFormatSupportType {
   fun isSupportedPath(
     typePath: List<MIMEType>
   ): Boolean
+
+  /**
+   * @return `true` if the given DRM kind is supported
+   */
+
+  fun isDRMSupported(drmKind: BookDRMKind): Boolean
 }

--- a/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupport.kt
+++ b/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupport.kt
@@ -1,6 +1,11 @@
 package org.nypl.simplified.books.formats
 
 import one.irradia.mime.api.MIMEType
+import org.nypl.simplified.books.api.BookDRMKind
+import org.nypl.simplified.books.api.BookDRMKind.ACS
+import org.nypl.simplified.books.api.BookDRMKind.AXIS
+import org.nypl.simplified.books.api.BookDRMKind.LCP
+import org.nypl.simplified.books.api.BookDRMKind.NONE
 import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import org.nypl.simplified.books.formats.api.StandardFormatNames
 import org.slf4j.LoggerFactory
@@ -138,5 +143,14 @@ class BookFormatSupport private constructor(
     }
 
     return true
+  }
+
+  override fun isDRMSupported(drmKind: BookDRMKind): Boolean {
+    return when (drmKind) {
+      NONE -> true
+      LCP -> this.parameters.supportsLCP
+      ACS -> this.parameters.supportsAdobeDRM
+      AXIS -> this.parameters.supportsAxisNow
+    }
   }
 }

--- a/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupportParameters.kt
+++ b/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupportParameters.kt
@@ -22,6 +22,7 @@ data class BookFormatSupportParameters(
   /**
    * The application has a working AxisNow service.
    */
+
   val supportsAxisNow: Boolean,
 
   /**
@@ -29,5 +30,11 @@ data class BookFormatSupportParameters(
    * registered that supports audio books.
    */
 
-  val supportsAudioBooks: BookFormatAudioSupportParameters?
+  val supportsAudioBooks: BookFormatAudioSupportParameters?,
+
+  /**
+   * The application has a working LCP service.
+   */
+
+  val supportsLCP: Boolean
 )

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainBookFormatSupport.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainBookFormatSupport.kt
@@ -29,6 +29,7 @@ object MainBookFormatSupport {
         supportsPDF = this.isPDFSupported(),
         supportsAdobeDRM = adobeDRM != null,
         supportsAxisNow = axisNowService != null,
+        supportsLCP = false,
         supportsAudioBooks = BookFormatAudioSupportParameters(
           supportsFindawayAudioBooks = this.isFindawaySupported(),
           supportsOverdriveAudioBooks = overdriveSecretService != null,

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/FeedLoaderTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/FeedLoaderTest.kt
@@ -39,6 +39,7 @@ class FeedLoaderTest : FeedLoaderContract() {
       BookFormatSupport.create(
         BookFormatSupportParameters(
           supportsPDF = false,
+          supportsLCP = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
           supportsAudioBooks = null

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/formats/BookFormatSupportTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/formats/BookFormatSupportTest.kt
@@ -19,6 +19,7 @@ class BookFormatSupportTest {
       BookFormatSupport.create(
         BookFormatSupportParameters(
           supportsPDF = false,
+          supportsLCP = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
           supportsAudioBooks = null
@@ -38,6 +39,7 @@ class BookFormatSupportTest {
       BookFormatSupport.create(
         BookFormatSupportParameters(
           supportsPDF = true,
+          supportsLCP = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
           supportsAudioBooks = null
@@ -47,6 +49,7 @@ class BookFormatSupportTest {
       BookFormatSupport.create(
         BookFormatSupportParameters(
           supportsPDF = false,
+          supportsLCP = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
           supportsAudioBooks = null
@@ -79,6 +82,7 @@ class BookFormatSupportTest {
       BookFormatSupport.create(
         BookFormatSupportParameters(
           supportsPDF = false,
+          supportsLCP = false,
           supportsAdobeDRM = true,
           supportsAxisNow = false,
           supportsAudioBooks = null
@@ -88,6 +92,7 @@ class BookFormatSupportTest {
       BookFormatSupport.create(
         BookFormatSupportParameters(
           supportsPDF = false,
+          supportsLCP = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
           supportsAudioBooks = null
@@ -122,6 +127,7 @@ class BookFormatSupportTest {
       BookFormatSupport.create(
         BookFormatSupportParameters(
           supportsPDF = false,
+          supportsLCP = false,
           supportsAdobeDRM = false,
           supportsAxisNow = true,
           supportsAudioBooks = null
@@ -131,6 +137,7 @@ class BookFormatSupportTest {
       BookFormatSupport.create(
         BookFormatSupportParameters(
           supportsPDF = false,
+          supportsLCP = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
           supportsAudioBooks = null
@@ -164,6 +171,7 @@ class BookFormatSupportTest {
         BookFormatSupportParameters(
           supportsPDF = false,
           supportsAdobeDRM = false,
+          supportsLCP = false,
           supportsAxisNow = false,
           supportsAudioBooks = BookFormatAudioSupportParameters(
             supportsFindawayAudioBooks = false,
@@ -178,6 +186,7 @@ class BookFormatSupportTest {
           supportsPDF = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
+          supportsLCP = false,
           supportsAudioBooks = null
         )
       )
@@ -210,6 +219,7 @@ class BookFormatSupportTest {
           supportsPDF = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
+          supportsLCP = false,
           supportsAudioBooks = BookFormatAudioSupportParameters(
             supportsFindawayAudioBooks = false,
             supportsOverdriveAudioBooks = false,
@@ -222,6 +232,7 @@ class BookFormatSupportTest {
         BookFormatSupportParameters(
           supportsPDF = false,
           supportsAdobeDRM = false,
+          supportsLCP = false,
           supportsAxisNow = false,
           supportsAudioBooks = null
         )
@@ -255,6 +266,7 @@ class BookFormatSupportTest {
           supportsPDF = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
+          supportsLCP = false,
           supportsAudioBooks = BookFormatAudioSupportParameters(
             supportsFindawayAudioBooks = false,
             supportsOverdriveAudioBooks = true,
@@ -268,6 +280,7 @@ class BookFormatSupportTest {
           supportsPDF = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
+          supportsLCP = false,
           supportsAudioBooks = null
         )
       )
@@ -300,6 +313,7 @@ class BookFormatSupportTest {
           supportsPDF = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
+          supportsLCP = false,
           supportsAudioBooks = BookFormatAudioSupportParameters(
             supportsFindawayAudioBooks = true,
             supportsOverdriveAudioBooks = false,
@@ -313,6 +327,7 @@ class BookFormatSupportTest {
           supportsPDF = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
+          supportsLCP = false,
           supportsAudioBooks = null
         )
       )
@@ -345,6 +360,7 @@ class BookFormatSupportTest {
           supportsPDF = false,
           supportsAdobeDRM = false,
           supportsAxisNow = false,
+          supportsLCP = false,
           supportsAudioBooks = null
         )
       )
@@ -379,6 +395,7 @@ class BookFormatSupportTest {
           supportsPDF = true,
           supportsAdobeDRM = true,
           supportsAxisNow = false,
+          supportsLCP = false,
           supportsAudioBooks = null
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/bugs/Simply3635Test.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/bugs/Simply3635Test.kt
@@ -190,6 +190,7 @@ class Simply3635Test {
         BookFormatSupportParameters(
           supportsPDF = false,
           supportsAdobeDRM = false,
+          supportsLCP = false,
           supportsAudioBooks = null,
           supportsAxisNow = false
         )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookFormatSupport.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookFormatSupport.kt
@@ -1,6 +1,7 @@
 package org.nypl.simplified.tests.mocking
 
 import one.irradia.mime.api.MIMEType
+import org.nypl.simplified.books.api.BookDRMKind
 import org.nypl.simplified.books.formats.api.BookFormatSupportType
 
 class MockBookFormatSupport : BookFormatSupportType {
@@ -18,4 +19,8 @@ class MockBookFormatSupport : BookFormatSupportType {
 
   override fun isSupportedPath(typePath: List<MIMEType>): Boolean =
     this.onIsSupportedPath(typePath)
+
+  override fun isDRMSupported(drmKind: BookDRMKind): Boolean {
+    return true
+  }
 }


### PR DESCRIPTION
**What's this do?**
This adds the extra support required to filter out books that
were supported when they were fulfilled, but may be unsupported
now (due to a DRM system becoming unsupported).

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/OE-182

**How should this be tested? / Do these changes have associated tests?**
1. Use an older build of OE that supported Adobe DRM.
2. Borrow/fulfill a few Adobe-encrypted books.
3. Upgrade to this version of OE.
4. Check that those previously-fulfilled Adobe books don't appear in your Books tab.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Checked that Adobe books don't appear.