### PR TITLE
Check snapshot dependencies in non-snapshot builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,36 @@ ext {
         ^ required by 'org.librarysimplified.drm.enabled'\
       """.stripIndent())
   }
+
+  //
+  // Check that non -SNAPSHOT builds don't use -SNAPSHOT dependencies.
+  //
+
+  final String versionName = project.ext["VERSION_NAME"];
+  if (!versionName.endsWith("-SNAPSHOT")) {
+    final Set<String> snapshots = new HashSet<>();
+    ext.libraries.each { name, version ->
+      if (version.toString().endsWith("-SNAPSHOT")) {
+        snapshots.add(version.toString())
+      }
+    }
+
+    if (!snapshots.isEmpty()) {
+      final StringBuilder builder = new StringBuilder();
+      builder.append("The current non-SNAPSHOT build (")
+      builder.append(versionName)
+      builder.append(") depends on the following -SNAPSHOT dependencies:")
+      builder.append("\n")
+      snapshots.each { version ->
+        builder.append("  ")
+        builder.append(version)
+        builder.append("\n")
+      }
+      final String text = builder.toString()
+      logger.error("{}", text)
+      throw new GradleException(text);
+    }
+  }
 }
 
 subprojects {


### PR DESCRIPTION
**What's this do?**
This implements a check in the build system that refuses to allow
non-SNAPSHOT builds of the app to build with -SNAPSHOT dependencies.
Essentially, this enforces reproducibility for release builds.

**Why are we doing this? (w/ JIRA link if applicable)**
Fix: https://jira.nypl.org/browse/SIMPLY-3634

**How should this be tested? / Do these changes have associated tests?**
Try setting the version number to a version that doesn't end in -SNAPSHOT, and then seeing if the app will refuse to build with -SNAPSHOT dependencies.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**

![success](https://user-images.githubusercontent.com/612494/127902600-ad3da692-bb58-4fca-bd3e-b710d7c587d2.png)
