### PR TITLE
OE-140: Implement an OE QA toggle

### DIFF
--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
@@ -48,6 +48,7 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
   private lateinit var showOnlySupportedBooks: SwitchCompat
   private lateinit var showTesting: SwitchCompat
   private lateinit var syncAccountsButton: Button
+  private lateinit var enableOpenEBooksQA: Button
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
@@ -84,6 +85,8 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       view.findViewById(R.id.settingsVersionDevCustomOPDS)
     this.crashlyticsId =
       view.findViewById(R.id.settingsVersionCrashlyticsID)
+    this.enableOpenEBooksQA =
+      view.findViewById(R.id.settingsVersionDevEnableOpenEBooksQA)
 
     this.drmTable.addView(
       this.createDrmSupportRow("Adobe Acs", this.viewModel.adeptSupported)
@@ -206,6 +209,14 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
 
     this.customOPDS.setOnClickListener {
       this.listener.post(SettingsDebugEvent.OpenCustomOPDS)
+    }
+
+    /*
+     * Configure the Open EBooks QA button.
+     */
+
+    this.enableOpenEBooksQA.setOnClickListener {
+      this.viewModel.openEbooksQAToggle()
     }
   }
 

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
@@ -6,10 +6,13 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.google.common.util.concurrent.MoreExecutors
 import io.reactivex.disposables.CompositeDisposable
+import org.joda.time.DateTime
 import org.joda.time.LocalDateTime
 import org.librarysimplified.services.api.Services
 import org.nypl.drm.core.AdobeAdeptExecutorType
 import org.nypl.drm.core.AxisNowServiceType
+import org.nypl.simplified.accounts.api.AccountProvider
+import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.adobe.extensions.AdobeDRMExtensions
 import org.nypl.simplified.analytics.api.AnalyticsEvent
@@ -25,6 +28,7 @@ import org.nypl.simplified.profiles.api.ProfileUpdated
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.reports.Reports
 import org.slf4j.LoggerFactory
+import java.net.URI
 
 class SettingsDebugViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -225,5 +229,84 @@ class SettingsDebugViewModel(application: Application) : AndroidViewModel(applic
     )
 
     return activationsLive
+  }
+
+  private object OpenEBooksQAHack {
+    val basicAuth =
+      AccountProviderAuthenticationDescription.Basic(
+        description = "First Book - JWT",
+        barcodeFormat = null,
+        keyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+        passwordKeyboard = AccountProviderAuthenticationDescription.KeyboardInput.DEFAULT,
+        passwordMaximumLength = -1,
+        labels = mapOf(),
+        logoURI = URI.create("https://qa-circulation.openebooks.us/images/FirstBookLoginButton280.png")
+      )
+
+    val cleverAuth =
+      AccountProviderAuthenticationDescription.OAuthWithIntermediary(
+        description = "Clever",
+        authenticate = URI.create("https://qa-circulation.openebooks.us/USOEI/oauth_authenticate?provider=Clever"),
+        logoURI = URI.create("https://qa-circulation.openebooks.us/images/CleverLoginButton280.png")
+      )
+
+    val openEbooksQA =
+      AccountProvider(
+        addAutomatically = true,
+        authenticationDocumentURI = URI.create("https://qa-circulation.openebooks.us/USOEI/authentication_document"),
+        authentication = this.basicAuth,
+        authenticationAlternatives = listOf(this.cleverAuth),
+        cardCreatorURI = null,
+        catalogURI = URI.create("https://qa-circulation.openebooks.us/USOEI/groups"),
+        displayName = "Open eBooks (QA)",
+        eula = null,
+        id = URI.create("https://qa-circulation.openebooks.us/USOEI/authentication_document"),
+        idNumeric = -1,
+        isProduction = true,
+        license = URI.create("http://www.librarysimplified.org/iclicenses.html"),
+        loansURI = URI.create("https://qa-circulation.openebooks.us/USOEI/loans/"),
+        logo = null,
+        mainColor = "teal",
+        patronSettingsURI = URI.create("https://qa-circulation.openebooks.us/USOEI/patrons/me/"),
+        privacyPolicy = URI.create("https://openebooks.net/app_privacy.html"),
+        subtitle = "",
+        supportEmail = null,
+        supportsReservations = false,
+        updated = DateTime.parse("2020-05-10T00:00:00Z"),
+        location = null
+      )
+  }
+
+  fun openEbooksQAAccountExists(): Boolean {
+    return this.profilesController.profileCurrent()
+      .accountsByProvider()
+      .containsKey(OpenEBooksQAHack.openEbooksQA.id)
+  }
+
+  fun openEbooksQAToggle() {
+    if (this.openEbooksQAAccountExists()) {
+      this.profilesController.profileAccountDeleteByProvider(OpenEBooksQAHack.openEbooksQA.id)
+    } else {
+      this.accountRegistry.updateProvider(OpenEBooksQAHack.openEbooksQA)
+      this.accountRegistry.updateDescription(OpenEBooksQAHack.openEbooksQA.toDescription())
+
+      val creationFuture =
+        this.profilesController.profileAccountCreate(OpenEBooksQAHack.openEbooksQA.id)
+
+      creationFuture.addListener(
+        {
+          val account =
+            this.profilesController.profileCurrent()
+              .accountsByProvider()[OpenEBooksQAHack.openEbooksQA.id]
+
+          if (account != null) {
+            this.profilesController.profileUpdate { description ->
+              description.copy(preferences = description.preferences.copy(mostRecentAccount = account.id))
+            }
+          }
+        },
+        MoreExecutors.directExecutor()
+      )
+    }
   }
 }

--- a/simplified-ui-settings/src/main/res/layout/settings_debug.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_debug.xml
@@ -206,5 +206,14 @@
       android:layout_height="wrap_content"
       android:layout_marginBottom="16dp"
       android:text="Add Custom OPDS Feed" />
+
+    <Button
+      android:id="@+id/settingsVersionDevEnableOpenEBooksQA"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginBottom="16dp"
+      android:checked="false"
+      android:enabled="true"
+      android:text="Toggle OpenEBooks QA Account" />
   </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
**What's this do?**
This implements a toggle that will add and remove an Open eBooks
QA account in the debug menu. Hardcoding the account information,
unfortunately, appears to be the only way to implement this as
there isn't a registry present in OE that seems to know about the OE
QA server.

**Why are we doing this? (w/ JIRA link if applicable)**
Fix: https://jira.nypl.org/browse/OE-140

**How should this be tested? / Do these changes have associated tests?**
Try pressing the button in the debug menu to add/remove an Open eBooks QA
account.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m tried it.