### PR TITLE
OE-192: Delete book data for books with unsupported DRM systems

### DIFF
--- a/simplified-accounts-database-api/src/main/java/org/nypl/simplified/accounts/database/api/AccountsDatabaseFactoryType.kt
+++ b/simplified-accounts-database-api/src/main/java/org/nypl/simplified/accounts/database/api/AccountsDatabaseFactoryType.kt
@@ -6,6 +6,7 @@ import org.nypl.simplified.accounts.api.AccountAuthenticationCredentialsStoreTyp
 import org.nypl.simplified.accounts.api.AccountEvent
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.books.book_database.api.BookDatabaseFactoryType
+import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import java.io.File
 
 /**
@@ -20,6 +21,7 @@ interface AccountsDatabaseFactoryType {
    * @param accountEvents An observable that will be used to publish account events
    * @param bookDatabases A provider of book databases
    * @param accountProviders The available account providers
+   * @param bookFormatSupport The book format support information
    * @param accountAuthenticationCredentialsStore The credentials store
    * @param directory The directory
    * @return A profile database
@@ -32,6 +34,7 @@ interface AccountsDatabaseFactoryType {
     accountEvents: Subject<AccountEvent>,
     accountProviders: AccountProviderRegistryType,
     bookDatabases: BookDatabaseFactoryType,
+    bookFormatSupport: BookFormatSupportType,
     context: Context,
     directory: File
   ): AccountsDatabaseType
@@ -42,6 +45,7 @@ interface AccountsDatabaseFactoryType {
    * @param accountEvents An observable that will be used to publish account events
    * @param accountProviders The available account providers
    * @param accountAuthenticationCredentialsStore The credentials store
+   * @param bookFormatSupport The book format support information
    * @param directory The directory
    * @return A profile database
    * @throws AccountsDatabaseException If any errors occurred whilst trying to open the database
@@ -52,6 +56,7 @@ interface AccountsDatabaseFactoryType {
     accountAuthenticationCredentialsStore: AccountAuthenticationCredentialsStoreType,
     accountEvents: Subject<AccountEvent>,
     accountProviders: AccountProviderRegistryType,
+    bookFormatSupport: BookFormatSupportType,
     context: Context,
     directory: File
   ): AccountsDatabaseType

--- a/simplified-accounts-database/src/main/java/org/nypl/simplified/accounts/database/AccountsDatabase.kt
+++ b/simplified-accounts-database/src/main/java/org/nypl/simplified/accounts/database/AccountsDatabase.kt
@@ -33,6 +33,7 @@ import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.books.book_database.api.BookDatabaseException
 import org.nypl.simplified.books.book_database.api.BookDatabaseFactoryType
 import org.nypl.simplified.books.book_database.api.BookDatabaseType
+import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import org.nypl.simplified.files.DirectoryUtilities
 import org.nypl.simplified.files.FileLocking
 import org.nypl.simplified.files.FileUtilities
@@ -62,7 +63,8 @@ class AccountsDatabase private constructor(
   @GuardedBy("accountsLock")
   private val accountsByProvider: SortedMap<URI, Account>,
   private val credentials: AccountAuthenticationCredentialsStoreType,
-  private val bookDatabases: BookDatabaseFactoryType
+  private val bookDatabases: BookDatabaseFactoryType,
+  private val bookFormatSupport: BookFormatSupportType,
 ) : AccountsDatabaseType {
 
   private val logger =
@@ -131,7 +133,12 @@ class AccountsDatabase private constructor(
       accountDir.mkdirs()
 
       val bookDatabase =
-        this.bookDatabases.openDatabase(this.context, accountId, booksDir)
+        this.bookDatabases.openDatabase(
+          context = this.context,
+          formats = this.bookFormatSupport,
+          owner = accountId,
+          directory = booksDir
+        )
 
       val preferences =
         AccountPreferences(
@@ -438,6 +445,7 @@ class AccountsDatabase private constructor(
       context: Context,
       accountEvents: Subject<AccountEvent>,
       bookDatabases: BookDatabaseFactoryType,
+      bookFormatSupport: BookFormatSupportType,
       accountCredentials: AccountAuthenticationCredentialsStoreType,
       accountProviders: AccountProviderRegistryType,
       directory: File
@@ -466,6 +474,7 @@ class AccountsDatabase private constructor(
         accounts = accounts,
         accountsByProvider = accountsByProvider,
         bookDatabases = bookDatabases,
+        bookFormatSupport = bookFormatSupport,
         context = context,
         directory = directory,
         errors = errors,
@@ -489,7 +498,8 @@ class AccountsDatabase private constructor(
         accounts = accounts,
         accountsByProvider = accountsByProvider,
         credentials = accountCredentials,
-        bookDatabases = bookDatabases
+        bookDatabases = bookDatabases,
+        bookFormatSupport = bookFormatSupport
       )
     }
 
@@ -522,6 +532,7 @@ class AccountsDatabase private constructor(
       accountCredentials: AccountAuthenticationCredentialsStoreType,
       accountEvents: Subject<AccountEvent>,
       bookDatabases: BookDatabaseFactoryType,
+      bookFormatSupport: BookFormatSupportType,
       context: Context,
       directory: File,
       errors: MutableList<Exception>,
@@ -539,6 +550,7 @@ class AccountsDatabase private constructor(
               accountIdName = accountIdName,
               accountProviderResolver = accountProviderResolver,
               bookDatabases = bookDatabases,
+              bookFormatSupport = bookFormatSupport,
               context = context,
               credentialsStore = accountCredentials,
               directory = directory,
@@ -659,6 +671,7 @@ class AccountsDatabase private constructor(
       accountIdName: String,
       accountProviderResolver: (String) -> AccountProviderType?,
       bookDatabases: BookDatabaseFactoryType,
+      bookFormatSupport: BookFormatSupportType,
       context: Context,
       credentialsStore: AccountAuthenticationCredentialsStoreType,
       directory: File,
@@ -676,7 +689,13 @@ class AccountsDatabase private constructor(
 
       return try {
         val bookDatabase =
-          bookDatabases.openDatabase(context, accountId, booksDir)
+          bookDatabases.openDatabase(
+            context = context,
+            formats = bookFormatSupport,
+            owner = accountId,
+            directory = booksDir
+          )
+
         val accountDescription =
           AccountDescriptionJSON.deserializeFromFile(
             objectMapper,

--- a/simplified-accounts-database/src/main/java/org/nypl/simplified/accounts/database/AccountsDatabases.kt
+++ b/simplified-accounts-database/src/main/java/org/nypl/simplified/accounts/database/AccountsDatabases.kt
@@ -10,6 +10,7 @@ import org.nypl.simplified.accounts.database.api.AccountsDatabaseType
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.books.book_database.BookDatabases
 import org.nypl.simplified.books.book_database.api.BookDatabaseFactoryType
+import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import java.io.File
 
 /**
@@ -24,6 +25,7 @@ object AccountsDatabases : AccountsDatabaseFactoryType {
     accountEvents: Subject<AccountEvent>,
     accountProviders: AccountProviderRegistryType,
     bookDatabases: BookDatabaseFactoryType,
+    bookFormatSupport: BookFormatSupportType,
     context: Context,
     directory: File
   ): AccountsDatabaseType {
@@ -31,6 +33,7 @@ object AccountsDatabases : AccountsDatabaseFactoryType {
       context = context,
       accountEvents = accountEvents,
       bookDatabases = bookDatabases,
+      bookFormatSupport = bookFormatSupport,
       accountCredentials = accountAuthenticationCredentialsStore,
       accountProviders = accountProviders,
       directory = directory
@@ -42,6 +45,7 @@ object AccountsDatabases : AccountsDatabaseFactoryType {
     accountAuthenticationCredentialsStore: AccountAuthenticationCredentialsStoreType,
     accountEvents: Subject<AccountEvent>,
     accountProviders: AccountProviderRegistryType,
+    bookFormatSupport: BookFormatSupportType,
     context: Context,
     directory: File
   ): AccountsDatabaseType {
@@ -49,6 +53,7 @@ object AccountsDatabases : AccountsDatabaseFactoryType {
       context = context,
       accountEvents = accountEvents,
       bookDatabases = BookDatabases,
+      bookFormatSupport = bookFormatSupport,
       accountCredentials = accountAuthenticationCredentialsStore,
       accountProviders = accountProviders,
       directory = directory

--- a/simplified-books-database-api/build.gradle
+++ b/simplified-books-database-api/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   api project(":simplified-accounts-api")
   api project(":simplified-books-api")
+  api project(":simplified-books-formats-api")
   api project(":simplified-opds-core")
 
   api libraries.irradia_mime_api

--- a/simplified-books-database-api/src/main/java/org/nypl/simplified/books/book_database/api/BookDatabaseFactoryType.kt
+++ b/simplified-books-database-api/src/main/java/org/nypl/simplified/books/book_database/api/BookDatabaseFactoryType.kt
@@ -2,6 +2,7 @@ package org.nypl.simplified.books.book_database.api
 
 import android.content.Context
 import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import org.nypl.simplified.opds.core.OPDSJSONParserType
 import org.nypl.simplified.opds.core.OPDSJSONSerializerType
 import java.io.File
@@ -21,6 +22,7 @@ interface BookDatabaseFactoryType {
     context: Context,
     parser: OPDSJSONParserType,
     serializer: OPDSJSONSerializerType,
+    formats: BookFormatSupportType,
     owner: AccountID,
     directory: File
   ): BookDatabaseType
@@ -32,6 +34,7 @@ interface BookDatabaseFactoryType {
   @Throws(BookDatabaseException::class)
   fun openDatabase(
     context: Context,
+    formats: BookFormatSupportType,
     owner: AccountID,
     directory: File
   ): BookDatabaseType

--- a/simplified-books-database/build.gradle
+++ b/simplified-books-database/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   api project(":simplified-accounts-api")
   api project(":simplified-books-database-api")
+  api project(":simplified-books-formats-api")
 
   implementation project(':simplified-files')
   implementation project(':simplified-opds-core')

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/BookDRMInformationHandleACS.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/BookDRMInformationHandleACS.kt
@@ -44,6 +44,9 @@ class BookDRMInformationHandleACS(
         nameACSM(format),
         nameMetaJSON(format)
       )
+
+    fun deleteFiles(directory: File) {
+    }
   }
 
   init {

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/BookDatabases.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/BookDatabases.kt
@@ -5,6 +5,7 @@ import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.books.book_database.api.BookDatabaseException
 import org.nypl.simplified.books.book_database.api.BookDatabaseFactoryType
 import org.nypl.simplified.books.book_database.api.BookDatabaseType
+import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import org.nypl.simplified.opds.core.OPDSJSONParser
 import org.nypl.simplified.opds.core.OPDSJSONParserType
 import org.nypl.simplified.opds.core.OPDSJSONSerializer
@@ -18,6 +19,7 @@ object BookDatabases : BookDatabaseFactoryType {
     context: Context,
     parser: OPDSJSONParserType,
     serializer: OPDSJSONSerializerType,
+    formats: BookFormatSupportType,
     owner: AccountID,
     directory: File
   ): BookDatabaseType {
@@ -25,6 +27,7 @@ object BookDatabases : BookDatabaseFactoryType {
       context = context,
       parser = parser,
       serializer = serializer,
+      formats = formats,
       owner = owner,
       directory = directory
     )
@@ -33,6 +36,7 @@ object BookDatabases : BookDatabaseFactoryType {
   @Throws(BookDatabaseException::class)
   override fun openDatabase(
     context: Context,
+    formats: BookFormatSupportType,
     owner: AccountID,
     directory: File
   ): BookDatabaseType {
@@ -40,6 +44,7 @@ object BookDatabases : BookDatabaseFactoryType {
       context = context,
       parser = OPDSJSONParser.newParser(),
       serializer = OPDSJSONSerializer.newSerializer(),
+      formats = formats,
       owner = owner,
       directory = directory
     )

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
@@ -67,11 +67,7 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
 
     if (drmHandleInitial == null) {
       try {
-        if (this.fileBook.isDirectory) {
-          DirectoryUtilities.directoryDelete(this.fileBook)
-        } else {
-          FileUtilities.fileDelete(this.fileBook)
-        }
+        FileUtilities.fileDelete(this.fileManifest)
       } catch (e: Exception) {
         // Not much we can do about this.
       }

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
@@ -17,7 +17,6 @@ import org.nypl.simplified.books.api.BookDRMKind
 import org.nypl.simplified.books.api.BookFormat
 import org.nypl.simplified.books.book_database.api.BookDRMInformationHandle
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleAudioBook
-import org.nypl.simplified.files.DirectoryUtilities
 import org.nypl.simplified.files.FileUtilities
 import org.nypl.simplified.json.core.JSONParserUtilities
 import org.nypl.simplified.json.core.JSONSerializerUtilities

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
@@ -52,12 +52,33 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
   private val dataLock: Any = Any()
 
   @GuardedBy("dataLock")
-  private var drmHandleRef =
-    BookDRMInformationHandles.open(
-      directory = this.parameters.directory,
-      format = this.formatDefinition,
-      onUpdate = this::onDRMUpdated
-    )
+  private var drmHandleRef: BookDRMInformationHandle
+
+  init {
+    val drmHandleOpt =
+      BookDRMInformationHandles.open(
+        directory = this.parameters.directory,
+        format = this.formatDefinition,
+        bookFormats = this.parameters.bookFormatSupport,
+        onUpdate = this::onDRMUpdated
+      )
+
+    if (drmHandleOpt == null) {
+      try {
+        FileUtilities.fileDelete(this.fileManifest)
+      } catch (e: Exception) {
+        // Not much we can do about this.
+      }
+    }
+
+    this.drmHandleRef =
+      BookDRMInformationHandles.open(
+        directory = this.parameters.directory,
+        format = this.formatDefinition,
+        bookFormats = this.parameters.bookFormatSupport,
+        onUpdate = this::onDRMUpdated
+      )!!
+  }
 
   @GuardedBy("dataLock")
   private var formatRef: BookFormat.BookFormatAudioBook =

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandlePDF.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandlePDF.kt
@@ -7,7 +7,6 @@ import org.nypl.simplified.books.api.BookDRMKind
 import org.nypl.simplified.books.api.BookFormat
 import org.nypl.simplified.books.book_database.api.BookDRMInformationHandle
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandlePDF
-import org.nypl.simplified.files.DirectoryUtilities
 import org.nypl.simplified.files.FileUtilities
 import java.io.File
 import java.io.IOException

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandlePDF.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandlePDF.kt
@@ -44,11 +44,7 @@ internal class DatabaseFormatHandlePDF internal constructor(
 
     if (drmHandleInitial == null) {
       try {
-        if (this.fileBook.isDirectory) {
-          DirectoryUtilities.directoryDelete(this.fileBook)
-        } else {
-          FileUtilities.fileDelete(this.fileBook)
-        }
+        FileUtilities.fileDelete(this.fileBook)
       } catch (e: Exception) {
         // Not much we can do about this.
       }

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandlePDF.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandlePDF.kt
@@ -29,12 +29,33 @@ internal class DatabaseFormatHandlePDF internal constructor(
   private val dataLock: Any = Any()
 
   @GuardedBy("dataLock")
-  private var drmHandleRef =
-    BookDRMInformationHandles.open(
-      directory = this.parameters.directory,
-      format = this.formatDefinition,
-      onUpdate = this::onDRMUpdated
-    )
+  private var drmHandleRef: BookDRMInformationHandle
+
+  init {
+    val drmHandleOpt =
+      BookDRMInformationHandles.open(
+        directory = this.parameters.directory,
+        format = this.formatDefinition,
+        bookFormats = this.parameters.bookFormatSupport,
+        onUpdate = this::onDRMUpdated
+      )
+
+    if (drmHandleOpt == null) {
+      try {
+        FileUtilities.fileDelete(this.fileBook)
+      } catch (e: Exception) {
+        // Not much we can do about this.
+      }
+    }
+
+    this.drmHandleRef =
+      BookDRMInformationHandles.open(
+        directory = this.parameters.directory,
+        format = this.formatDefinition,
+        bookFormats = this.parameters.bookFormatSupport,
+        onUpdate = this::onDRMUpdated
+      )!!
+  }
 
   @GuardedBy("dataLock")
   private var formatRef: BookFormat.BookFormatPDF =

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleParameters.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleParameters.kt
@@ -6,6 +6,7 @@ import one.irradia.mime.api.MIMEType
 import org.nypl.simplified.books.api.BookFormat
 import org.nypl.simplified.books.api.BookID
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryType
+import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import java.io.File
 
 /**
@@ -56,5 +57,11 @@ internal data class DatabaseFormatHandleParameters(
    * A JSON object mapper.
    */
 
-  val objectMapper: ObjectMapper
+  val objectMapper: ObjectMapper,
+
+  /**
+   * The book format support.
+   */
+
+  val bookFormatSupport: BookFormatSupportType
 )

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -351,6 +351,7 @@ internal object MainServices {
     accountProviders: AccountProviderRegistryType,
     accountBundledCredentials: AccountBundledCredentialsType,
     accountCredentialsStore: AccountAuthenticationCredentialsStoreType,
+    bookFormatSupport: BookFormatSupportType,
     directory: File
   ): ProfilesDatabaseType {
     /*
@@ -361,27 +362,29 @@ internal object MainServices {
     if (anonymous) {
       this.logger.debug("opening profile database with anonymous profile")
       return ProfilesDatabases.openWithAnonymousProfileEnabled(
-        context,
-        analytics,
-        accountEvents,
-        accountProviders,
-        accountBundledCredentials,
-        accountCredentialsStore,
-        AccountsDatabases,
-        directory
+        context = context,
+        analytics = analytics,
+        accountEvents = accountEvents,
+        accountProviders = accountProviders,
+        accountBundledCredentials = accountBundledCredentials,
+        accountCredentialsStore = accountCredentialsStore,
+        accountsDatabases = AccountsDatabases,
+        bookFormatSupport = bookFormatSupport,
+        directory = directory
       )
     }
 
     this.logger.debug("opening profile database without anonymous profile")
     return ProfilesDatabases.openWithAnonymousProfileDisabled(
-      context,
-      analytics,
-      accountEvents,
-      accountProviders,
-      accountBundledCredentials,
-      accountCredentialsStore,
-      AccountsDatabases,
-      directory
+      context = context,
+      analytics = analytics,
+      accountEvents = accountEvents,
+      accountProviders = accountProviders,
+      accountBundledCredentials = accountBundledCredentials,
+      accountCredentialsStore = accountCredentialsStore,
+      accountsDatabases = AccountsDatabases,
+      bookFormatSupport = bookFormatSupport,
+      directory = directory
     )
   }
 
@@ -807,40 +810,6 @@ internal object MainServices {
     val accountEvents =
       PublishSubject.create<AccountEvent>()
 
-    val profilesDatabase =
-      addService(
-        message = strings.bootingGeneral("profiles database"),
-        interfaceType = ProfilesDatabaseType::class.java,
-        serviceConstructor = {
-          this.createProfileDatabase(
-            context,
-            context.resources,
-            analytics,
-            accountEvents,
-            accountProviderRegistry,
-            accountBundledCredentials,
-            accountCredentials,
-            directories.directoryStorageProfiles
-          )
-        }
-      )
-
-    val bundledContent =
-      addService(
-        message = strings.bootingGeneral("bundled content"),
-        interfaceType = BundledContentResolverType::class.java,
-        serviceConstructor = { MainBundledContentResolver.create(context.assets) }
-      )
-
-    val opdsFeedParser =
-      addService(
-        message = strings.bootingGeneral("feed parser"),
-        interfaceType = OPDSFeedParserType::class.java,
-        serviceConstructor = {
-          this.createFeedParser()
-        }
-      )
-
     val feedbooksSecretService =
       addServiceOptionally(
         message = strings.bootingGeneral("Feedbook secret service"),
@@ -866,6 +835,41 @@ internal object MainServices {
             feedbooksSecretService = feedbooksSecretService,
             overdriveSecretService = overdriveSecretService
           )
+        }
+      )
+
+    val profilesDatabase =
+      addService(
+        message = strings.bootingGeneral("profiles database"),
+        interfaceType = ProfilesDatabaseType::class.java,
+        serviceConstructor = {
+          this.createProfileDatabase(
+            context,
+            context.resources,
+            analytics,
+            accountEvents,
+            accountProviderRegistry,
+            accountBundledCredentials,
+            accountCredentials,
+            bookFormatService,
+            directories.directoryStorageProfiles
+          )
+        }
+      )
+
+    val bundledContent =
+      addService(
+        message = strings.bootingGeneral("bundled content"),
+        interfaceType = BundledContentResolverType::class.java,
+        serviceConstructor = { MainBundledContentResolver.create(context.assets) }
+      )
+
+    val opdsFeedParser =
+      addService(
+        message = strings.bootingGeneral("feed parser"),
+        interfaceType = OPDSFeedParserType::class.java,
+        serviceConstructor = {
+          this.createFeedParser()
         }
       )
 

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabase.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabase.kt
@@ -15,6 +15,7 @@ import org.nypl.simplified.accounts.database.api.AccountsDatabaseFactoryType
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.analytics.api.AnalyticsEvent
 import org.nypl.simplified.analytics.api.AnalyticsType
+import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import org.nypl.simplified.files.DirectoryUtilities
 import org.nypl.simplified.profiles.api.ProfileAnonymousDisabledException
 import org.nypl.simplified.profiles.api.ProfileAnonymousEnabledException
@@ -47,6 +48,7 @@ internal class ProfilesDatabase internal constructor(
   private val accountProviders: AccountProviderRegistryType,
   private val accountCredentialsStore: AccountAuthenticationCredentialsStoreType,
   private val accountsDatabases: AccountsDatabaseFactoryType,
+  private val bookFormatSupport: BookFormatSupportType,
   private val analytics: AnalyticsType,
   private val anonymousProfileEnabled: ProfilesDatabaseType.AnonymousProfileEnabled,
   private val context: Context,
@@ -135,6 +137,7 @@ internal class ProfilesDatabase internal constructor(
         accountsDatabases = this.accountsDatabases,
         accountCredentialsStore = this.accountCredentialsStore,
         accountProvider = accountProvider,
+        bookFormatSupport = this.bookFormatSupport,
         directory = this.directory,
         displayName = displayName,
         id = next

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
@@ -17,6 +17,7 @@ import org.nypl.simplified.accounts.database.api.AccountsDatabaseOpenException
 import org.nypl.simplified.accounts.database.api.AccountsDatabaseType
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.analytics.api.AnalyticsType
+import org.nypl.simplified.books.formats.api.BookFormatSupportType
 import org.nypl.simplified.files.FileLocking
 import org.nypl.simplified.files.FileUtilities
 import org.nypl.simplified.profiles.api.ProfileAttributes
@@ -69,6 +70,7 @@ object ProfilesDatabases {
     accountBundledCredentials: AccountBundledCredentialsType,
     accountCredentialsStore: AccountAuthenticationCredentialsStoreType,
     accountsDatabases: AccountsDatabaseFactoryType,
+    bookFormatSupport: BookFormatSupportType,
     directory: File
   ): ProfilesDatabaseType {
     this.logger.debug("opening profile database: {}", directory)
@@ -85,6 +87,7 @@ object ProfilesDatabases {
       accountBundledCredentials = accountBundledCredentials,
       accountCredentialsStore = accountCredentialsStore,
       accountsDatabases = accountsDatabases,
+      bookFormatSupport = bookFormatSupport,
       directory = directory,
       profiles = profiles,
       jom = jom,
@@ -111,6 +114,7 @@ object ProfilesDatabases {
       accountCredentialsStore = accountCredentialsStore,
       accountsDatabases = accountsDatabases,
       anonymousProfileEnabled = ProfilesDatabaseType.AnonymousProfileEnabled.ANONYMOUS_PROFILE_DISABLED,
+      bookFormatSupport = bookFormatSupport,
       context = context,
       directory = directory,
       profiles = profiles
@@ -125,6 +129,7 @@ object ProfilesDatabases {
     accountBundledCredentials: AccountBundledCredentialsType,
     accountCredentialsStore: AccountAuthenticationCredentialsStoreType,
     accountsDatabases: AccountsDatabaseFactoryType,
+    bookFormatSupport: BookFormatSupportType,
     directory: File,
     profiles: SortedMap<ProfileID, Profile>,
     jom: ObjectMapper,
@@ -151,6 +156,7 @@ object ProfilesDatabases {
             accountsDatabases = accountsDatabases,
             accountBundledCredentials = accountBundledCredentials,
             accountCredentialsStore = accountCredentialsStore,
+            bookFormatSupport = bookFormatSupport,
             jom = jom,
             directory = directory,
             errors = errors,
@@ -177,6 +183,7 @@ object ProfilesDatabases {
     accountBundledCredentials: AccountBundledCredentialsType,
     accountCredentialsStore: AccountAuthenticationCredentialsStoreType,
     accountsDatabases: AccountsDatabaseFactoryType,
+    bookFormatSupport: BookFormatSupportType,
     directory: File
   ): ProfilesDatabaseType {
     this.logger.debug("opening profile database: {}", directory)
@@ -193,6 +200,7 @@ object ProfilesDatabases {
       accountBundledCredentials = accountBundledCredentials,
       accountCredentialsStore = accountCredentialsStore,
       accountsDatabases = accountsDatabases,
+      bookFormatSupport = bookFormatSupport,
       directory = directory,
       profiles = profiles,
       jom = jom,
@@ -210,6 +218,7 @@ object ProfilesDatabases {
           accountsDatabases = accountsDatabases,
           accountCredentialsStore = accountCredentialsStore,
           accountProvider = accountProviders.defaultProvider,
+          bookFormatSupport = bookFormatSupport,
           directory = directory,
           displayName = "",
           id = this.ANONYMOUS_PROFILE_ID
@@ -232,6 +241,7 @@ object ProfilesDatabases {
         accountCredentialsStore = accountCredentialsStore,
         accountsDatabases = accountsDatabases,
         anonymousProfileEnabled = ANONYMOUS_PROFILE_ENABLED,
+        bookFormatSupport = bookFormatSupport,
         context = context,
         directory = directory,
         profiles = profiles
@@ -329,6 +339,7 @@ object ProfilesDatabases {
     accountsDatabases: AccountsDatabaseFactoryType,
     accountBundledCredentials: AccountBundledCredentialsType,
     accountCredentialsStore: AccountAuthenticationCredentialsStoreType,
+    bookFormatSupport: BookFormatSupportType,
     jom: ObjectMapper,
     directory: File,
     errors: MutableList<Exception>,
@@ -353,6 +364,7 @@ object ProfilesDatabases {
             accountAuthenticationCredentialsStore = accountCredentialsStore,
             accountEvents = accountEvents,
             accountProviders = accountProviders,
+            bookFormatSupport = bookFormatSupport,
             context = context,
             directory = profileAccountsDir
           )
@@ -434,6 +446,7 @@ object ProfilesDatabases {
     accountsDatabases: AccountsDatabaseFactoryType,
     accountCredentialsStore: AccountAuthenticationCredentialsStoreType,
     accountProvider: AccountProviderType,
+    bookFormatSupport: BookFormatSupportType,
     directory: File,
     displayName: String,
     id: ProfileID
@@ -450,6 +463,7 @@ object ProfilesDatabases {
             accountAuthenticationCredentialsStore = accountCredentialsStore,
             accountEvents = accountEvents,
             accountProviders = accountProviders,
+            bookFormatSupport = bookFormatSupport,
             context = context,
             directory = profileAccountsDir
           )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/BookFormatsTesting.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/BookFormatsTesting.kt
@@ -1,0 +1,34 @@
+package org.nypl.simplified.tests.books
+
+import org.nypl.simplified.books.formats.BookFormatAudioSupportParameters
+import org.nypl.simplified.books.formats.BookFormatSupport
+import org.nypl.simplified.books.formats.BookFormatSupportParameters
+
+object BookFormatsTesting {
+
+  val supportsEverything =
+    BookFormatSupport.create(
+      BookFormatSupportParameters(
+        supportsLCP = true,
+        supportsAudioBooks = BookFormatAudioSupportParameters(
+          supportsDPLAAudioBooks = true,
+          supportsFindawayAudioBooks = true,
+          supportsOverdriveAudioBooks = true
+        ),
+        supportsAxisNow = true,
+        supportsPDF = true,
+        supportsAdobeDRM = true
+      )
+    )
+
+  val supportsNothing =
+    BookFormatSupport.create(
+      BookFormatSupportParameters(
+        supportsLCP = false,
+        supportsAudioBooks = null,
+        supportsAxisNow = false,
+        supportsPDF = false,
+        supportsAdobeDRM = false
+      )
+    )
+}

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountsDatabaseContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountsDatabaseContract.kt
@@ -21,6 +21,7 @@ import org.nypl.simplified.books.book_database.BookDatabases
 import org.nypl.simplified.files.DirectoryUtilities
 import org.nypl.simplified.files.FileUtilities
 import org.nypl.simplified.profiles.api.ProfileEvent
+import org.nypl.simplified.tests.books.BookFormatsTesting
 import org.nypl.simplified.tests.mocking.FakeAccountCredentialStorage
 import org.nypl.simplified.tests.mocking.MockAccountProviders
 import org.slf4j.LoggerFactory
@@ -97,6 +98,7 @@ abstract class AccountsDatabaseContract {
         this.context(),
         this.accountEvents,
         this.bookDatabases(),
+        BookFormatsTesting.supportsEverything,
         this.credentialStore,
         this.accountProviders,
         f_acc
@@ -143,6 +145,7 @@ abstract class AccountsDatabaseContract {
         this.context(),
         this.accountEvents,
         this.bookDatabases(),
+        BookFormatsTesting.supportsEverything,
         this.credentialStore,
         this.accountProviders,
         f_acc
@@ -174,6 +177,7 @@ abstract class AccountsDatabaseContract {
         this.context(),
         this.accountEvents,
         this.bookDatabases(),
+        BookFormatsTesting.supportsEverything,
         this.credentialStore,
         this.accountProviders,
         f_acc
@@ -208,6 +212,7 @@ abstract class AccountsDatabaseContract {
         this.context(),
         this.accountEvents,
         this.bookDatabases(),
+        BookFormatsTesting.supportsEverything,
         this.credentialStore,
         this.accountProviders,
         f_acc
@@ -235,6 +240,7 @@ abstract class AccountsDatabaseContract {
       this.context(),
       this.accountEvents,
       this.bookDatabases(),
+      BookFormatsTesting.supportsEverything,
       this.credentialStore,
       this.accountProviders,
       f_acc
@@ -261,6 +267,7 @@ abstract class AccountsDatabaseContract {
       this.context(),
       this.accountEvents,
       this.bookDatabases(),
+      BookFormatsTesting.supportsEverything,
       this.credentialStore,
       this.accountProviders,
       f_acc
@@ -304,6 +311,7 @@ abstract class AccountsDatabaseContract {
         this.context(),
         this.accountEvents,
         this.bookDatabases(),
+        BookFormatsTesting.supportsEverything,
         this.credentialStore,
         this.accountProviders,
         f_acc
@@ -333,6 +341,7 @@ abstract class AccountsDatabaseContract {
       this.context(),
       this.accountEvents,
       this.bookDatabases(),
+      BookFormatsTesting.supportsEverything,
       this.credentialStore,
       this.accountProviders,
       f_acc
@@ -350,6 +359,7 @@ abstract class AccountsDatabaseContract {
       this.context(),
       this.accountEvents,
       this.bookDatabases(),
+      BookFormatsTesting.supportsEverything,
       this.credentialStore,
       this.accountProviders,
       f_acc
@@ -380,6 +390,7 @@ abstract class AccountsDatabaseContract {
       this.context(),
       this.accountEvents,
       this.bookDatabases(),
+      BookFormatsTesting.supportsEverything,
       this.credentialStore,
       this.accountProviders,
       f_acc
@@ -432,6 +443,7 @@ abstract class AccountsDatabaseContract {
       this.context(),
       this.accountEvents,
       this.bookDatabases(),
+      BookFormatsTesting.supportsEverything,
       this.credentialStore,
       this.accountProviders,
       f_acc
@@ -463,6 +475,7 @@ abstract class AccountsDatabaseContract {
       this.context(),
       this.accountEvents,
       this.bookDatabases(),
+      BookFormatsTesting.supportsEverything,
       this.credentialStore,
       this.accountProviders,
       f_acc

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/book_database/BookDatabaseAudioBookContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/book_database/BookDatabaseAudioBookContract.kt
@@ -21,6 +21,7 @@ import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSAvailabilityOpenAccess
 import org.nypl.simplified.opds.core.OPDSJSONParser
 import org.nypl.simplified.opds.core.OPDSJSONSerializer
+import org.nypl.simplified.tests.books.BookFormatsTesting
 import org.slf4j.LoggerFactory
 import java.net.URI
 import java.util.UUID
@@ -45,7 +46,7 @@ abstract class BookDatabaseAudioBookContract {
     val parser = OPDSJSONParser.newParser()
     val serializer = OPDSJSONSerializer.newSerializer()
     val directory = DirectoryUtilities.directoryCreateTemporary()
-    val database0 = BookDatabase.open(context(), parser, serializer, accountID, directory)
+    val database0 = BookDatabase.open(context(), parser, serializer, BookFormatsTesting.supportsEverything, accountID, directory)
 
     val feedEntry: OPDSAcquisitionFeedEntry = this.acquisitionFeedEntryWithAudioBook()
     val bookID = BookIDs.newFromText("abcd")

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/book_database/BookDatabaseEPUBContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/book_database/BookDatabaseEPUBContract.kt
@@ -25,6 +25,7 @@ import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSAvailabilityOpenAccess
 import org.nypl.simplified.opds.core.OPDSJSONParser
 import org.nypl.simplified.opds.core.OPDSJSONSerializer
+import org.nypl.simplified.tests.books.BookFormatsTesting
 import org.slf4j.LoggerFactory
 import java.net.URI
 import java.util.UUID
@@ -50,7 +51,7 @@ abstract class BookDatabaseEPUBContract {
     val parser = OPDSJSONParser.newParser()
     val serializer = OPDSJSONSerializer.newSerializer()
     val directory = DirectoryUtilities.directoryCreateTemporary()
-    val database0 = BookDatabase.open(context(), parser, serializer, accountID, directory)
+    val database0 = BookDatabase.open(context(), parser, serializer, BookFormatsTesting.supportsEverything, accountID, directory)
 
     val feedEntry: OPDSAcquisitionFeedEntry = this.acquisitionFeedEntryWithEPUB()
     val bookID = BookIDs.newFromText("abcd")
@@ -99,7 +100,7 @@ abstract class BookDatabaseEPUBContract {
     val parser = OPDSJSONParser.newParser()
     val serializer = OPDSJSONSerializer.newSerializer()
     val directory = DirectoryUtilities.directoryCreateTemporary()
-    val database0 = BookDatabase.open(context(), parser, serializer, accountID, directory)
+    val database0 = BookDatabase.open(context(), parser, serializer, BookFormatsTesting.supportsEverything, accountID, directory)
 
     val feedEntry: OPDSAcquisitionFeedEntry = this.acquisitionFeedEntryWithEPUB()
     val bookID = BookIDs.newFromText("abcd")
@@ -172,7 +173,7 @@ abstract class BookDatabaseEPUBContract {
     }
 
     val database1 =
-      BookDatabase.open(context(), parser, serializer, accountID, directory)
+      BookDatabase.open(context(), parser, serializer, BookFormatsTesting.supportsEverything, accountID, directory)
     val databaseEntry1 =
       database1.createOrUpdate(bookID, feedEntry)
 
@@ -198,7 +199,7 @@ abstract class BookDatabaseEPUBContract {
     val parser = OPDSJSONParser.newParser()
     val serializer = OPDSJSONSerializer.newSerializer()
     val directory = DirectoryUtilities.directoryCreateTemporary()
-    val database0 = BookDatabase.open(context(), parser, serializer, accountID, directory)
+    val database0 = BookDatabase.open(context(), parser, serializer, BookFormatsTesting.supportsEverything, accountID, directory)
 
     val feedEntry: OPDSAcquisitionFeedEntry = this.acquisitionFeedEntryWithEPUB()
     val bookID = BookIDs.newFromText("abcd")

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/book_database/BookDatabasePDFContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/book_database/BookDatabasePDFContract.kt
@@ -23,6 +23,7 @@ import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSAvailabilityOpenAccess
 import org.nypl.simplified.opds.core.OPDSJSONParser
 import org.nypl.simplified.opds.core.OPDSJSONSerializer
+import org.nypl.simplified.tests.books.BookFormatsTesting
 import org.slf4j.LoggerFactory
 import java.net.URI
 import java.util.UUID
@@ -48,7 +49,7 @@ abstract class BookDatabasePDFContract {
     val parser = OPDSJSONParser.newParser()
     val serializer = OPDSJSONSerializer.newSerializer()
     val directory = DirectoryUtilities.directoryCreateTemporary()
-    val bookDatabase = BookDatabase.open(context(), parser, serializer, accountID, directory)
+    val bookDatabase = BookDatabase.open(context(), parser, serializer, BookFormatsTesting.supportsEverything, accountID, directory)
 
     val feedEntry: OPDSAcquisitionFeedEntry = this.acquisitionFeedEntryWithPDF()
     val bookID = BookIDs.newFromText("abcd")
@@ -85,7 +86,7 @@ abstract class BookDatabasePDFContract {
     val parser = OPDSJSONParser.newParser()
     val serializer = OPDSJSONSerializer.newSerializer()
     val directory = DirectoryUtilities.directoryCreateTemporary()
-    val database0 = BookDatabase.open(context(), parser, serializer, accountID, directory)
+    val database0 = BookDatabase.open(context(), parser, serializer, BookFormatsTesting.supportsEverything, accountID, directory)
 
     val feedEntry: OPDSAcquisitionFeedEntry = this.acquisitionFeedEntryWithPDF()
     val bookID = BookIDs.newFromText("abcd")

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowTaskTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowTaskTest.kt
@@ -73,6 +73,7 @@ import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.nypl.simplified.tests.MutableServiceDirectory
 import org.nypl.simplified.tests.TestDirectories
 import org.nypl.simplified.tests.TestDirectories.temporaryFileOf
+import org.nypl.simplified.tests.books.BookFormatsTesting
 import org.nypl.simplified.tests.books.audio.AudioBookSucceedingParsers.playerManifest
 import org.nypl.simplified.tests.books.borrowing.BorrowTestFeeds.FeedRequirements
 import org.nypl.simplified.tests.books.borrowing.BorrowTestFeeds.PathElement
@@ -217,6 +218,7 @@ class BorrowTaskTest {
         context = androidContext,
         parser = OPDSJSONParser.newParser(),
         serializer = OPDSJSONSerializer.newSerializer(),
+        formats = BookFormatsTesting.supportsEverything,
         owner = this.accountId,
         directory = TestDirectories.temporaryDirectory()
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
@@ -67,6 +67,7 @@ import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.nypl.simplified.tests.EventAssertions
 import org.nypl.simplified.tests.ExtraAssertions.assertInstanceOf
 import org.nypl.simplified.tests.MutableServiceDirectory
+import org.nypl.simplified.tests.books.BookFormatsTesting
 import org.nypl.simplified.tests.books.idle_timer.InoperableIdleTimer
 import org.nypl.simplified.tests.mocking.FakeAccountCredentialStorage
 import org.nypl.simplified.tests.mocking.MockAccountCreationStringResources
@@ -832,14 +833,15 @@ abstract class BooksControllerContract {
     dirProfiles: File
   ): ProfilesDatabaseType {
     return ProfilesDatabases.openWithAnonymousProfileDisabled(
-      context(),
-      this.analytics,
-      accountEvents,
-      MockAccountProviders.fakeAccountProviders(),
-      AccountBundledCredentialsEmpty.getInstance(),
-      this.credentialsStore,
-      AccountsDatabases,
-      dirProfiles
+      context = context(),
+      analytics = this.analytics,
+      accountEvents = accountEvents,
+      accountProviders = MockAccountProviders.fakeAccountProviders(),
+      accountBundledCredentials = AccountBundledCredentialsEmpty.getInstance(),
+      accountCredentialsStore = this.credentialsStore,
+      accountsDatabases = AccountsDatabases,
+      bookFormatSupport = BookFormatsTesting.supportsEverything,
+      directory = dirProfiles
     )
   }
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/ProfilesControllerContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/ProfilesControllerContract.kt
@@ -65,6 +65,7 @@ import org.nypl.simplified.reader.api.ReaderPreferences
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkEvent
 import org.nypl.simplified.tests.EventAssertions
 import org.nypl.simplified.tests.MutableServiceDirectory
+import org.nypl.simplified.tests.books.BookFormatsTesting
 import org.nypl.simplified.tests.books.idle_timer.InoperableIdleTimer
 import org.nypl.simplified.tests.mocking.FakeAccountCredentialStorage
 import org.nypl.simplified.tests.mocking.MockAccountCreationStringResources
@@ -474,6 +475,7 @@ abstract class ProfilesControllerContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialsStore,
       AccountsDatabases,
+      BookFormatsTesting.supportsEverything,
       dir_profiles
     )
   }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfilesDatabaseContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfilesDatabaseContract.kt
@@ -28,6 +28,7 @@ import org.nypl.simplified.profiles.api.ProfileDescription
 import org.nypl.simplified.profiles.api.ProfileEvent
 import org.nypl.simplified.profiles.api.ProfileID
 import org.nypl.simplified.profiles.api.ProfileType
+import org.nypl.simplified.tests.books.BookFormatsTesting
 import org.nypl.simplified.tests.mocking.FakeAccountCredentialStorage
 import org.nypl.simplified.tests.mocking.MockAccountProviderRegistry
 import org.nypl.simplified.tests.mocking.MockAccountProviders
@@ -85,6 +86,7 @@ abstract class ProfilesDatabaseContract {
           AccountBundledCredentialsEmpty.getInstance(),
           this.credentialStore,
           this.accountsDatabases(),
+          BookFormatsTesting.supportsEverything,
           fileProfiles
         )
       }
@@ -118,6 +120,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
   }
@@ -147,6 +150,7 @@ abstract class ProfilesDatabaseContract {
           AccountBundledCredentialsEmpty.getInstance(),
           this.credentialStore,
           this.accountsDatabases(),
+          BookFormatsTesting.supportsEverything,
           fileProfiles
         )
       }
@@ -184,6 +188,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
   }
@@ -215,6 +220,7 @@ abstract class ProfilesDatabaseContract {
           AccountBundledCredentialsEmpty.getInstance(),
           this.credentialStore,
           this.accountsDatabases(),
+          BookFormatsTesting.supportsEverything,
           fileProfiles
         )
       }
@@ -244,6 +250,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -276,6 +283,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         fileProfiles
       )
 
@@ -329,6 +337,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -347,6 +356,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -385,6 +395,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -420,6 +431,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -452,6 +464,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -483,6 +496,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -514,6 +528,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -550,6 +565,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         fileProfiles
       )
 
@@ -582,6 +598,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         fileProfiles
       )
 
@@ -612,6 +629,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         fileProfiles
       )
 
@@ -647,6 +665,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -684,6 +703,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -720,6 +740,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -763,6 +784,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
 
@@ -802,6 +824,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         fileProfiles
       )
 
@@ -821,6 +844,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       fileProfiles
     )
   }
@@ -854,6 +878,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         fileProfiles
       )
 
@@ -869,6 +894,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         fileProfiles
       )
 
@@ -900,6 +926,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         fileProfiles
       )
 
@@ -919,6 +946,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         fileProfiles
       )
 
@@ -952,6 +980,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         fileProfiles
       )
 
@@ -995,6 +1024,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       f_pro
     )
 
@@ -1033,6 +1063,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       f_pro
     )
 
@@ -1052,6 +1083,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       f_pro
     )
 
@@ -1081,6 +1113,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       f_pro
     )
 
@@ -1121,6 +1154,7 @@ abstract class ProfilesDatabaseContract {
       AccountBundledCredentialsEmpty.getInstance(),
       this.credentialStore,
       this.accountsDatabases(),
+      BookFormatsTesting.supportsEverything,
       f_pro
     )
 
@@ -1161,6 +1195,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         f_pro
       )
 
@@ -1196,6 +1231,7 @@ abstract class ProfilesDatabaseContract {
         AccountBundledCredentialsEmpty.getInstance(),
         this.credentialStore,
         this.accountsDatabases(),
+        BookFormatsTesting.supportsEverything,
         f_pro
       )
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/bugs/Simply3635Test.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/bugs/Simply3635Test.kt
@@ -64,6 +64,7 @@ import org.nypl.simplified.profiles.api.ProfilesDatabaseType
 import org.nypl.simplified.profiles.api.idle_timer.ProfileIdleTimer
 import org.nypl.simplified.profiles.api.idle_timer.ProfileIdleTimerType
 import org.nypl.simplified.tests.TestDirectories
+import org.nypl.simplified.tests.books.BookFormatsTesting
 import org.nypl.simplified.tests.mocking.MockAccountProviders
 import org.nypl.simplified.tests.mocking.MockBundledContentResolver
 import org.nypl.simplified.tests.mocking.MockStrings
@@ -182,6 +183,7 @@ class Simply3635Test {
         accountBundledCredentials = this.accountBundledCredentials,
         accountCredentialsStore = this.accountCredentialsStore,
         accountsDatabases = this.accountsDatabases,
+        bookFormatSupport = BookFormatsTesting.supportsEverything,
         directory = this.profilesDirectory
       )
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/migration/from3master/MigrationFrom3MasterContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/migration/from3master/MigrationFrom3MasterContract.kt
@@ -28,6 +28,7 @@ import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSJSONParser
 import org.nypl.simplified.taskrecorder.api.TaskRecorder
 import org.nypl.simplified.taskrecorder.api.TaskResult
+import org.nypl.simplified.tests.books.BookFormatsTesting
 import org.slf4j.Logger
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -425,6 +426,7 @@ abstract class MigrationFrom3MasterContract {
     val bookDatabase =
       BookDatabases.openDatabase(
         context = this.context,
+        formats = BookFormatsTesting.supportsEverything,
         owner = AccountID(UUID.randomUUID()),
         directory = this.tempBookDatabaseDir
       )
@@ -698,6 +700,7 @@ abstract class MigrationFrom3MasterContract {
     val bookDatabase =
       BookDatabases.openDatabase(
         context = this.context,
+        formats = BookFormatsTesting.supportsEverything,
         owner = AccountID(UUID.randomUUID()),
         directory = this.tempBookDatabaseDir
       )


### PR DESCRIPTION
**What's this do?**
This updates the book database to be aware of book and DRM formats. If
an attempt is made to open a book that has an unsupported type of
DRM, the book data and the DRM information is deleted and the book is
reopened. The intention is that this will cause the book to appear
as having been loaned but not downloaded, and the user will then
re-download the book using the correct DRM system.  Bookmarks and
other information are preserved.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://jira.nypl.org/browse/OE-192

**How should this be tested? / Do these changes have associated tests?**
1. Use an old build of the app to download an ACS book.
2. Install this build.
3. Check that your ACS book is no longer downloaded, and that you can download the book again but using Axis DRM.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Wrote unit tests, but I haven't tested the full migration yet.