### PR TITLE
SMA-200: Trim whitespace around usernames and passwords in AccountDetailFragment

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -200,16 +200,21 @@
         </c:change>
       </c:changes>
     </c:release>
-    <c:release date="2021-08-31T20:06:44+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+    <c:release date="2021-09-01T17:02:36+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
       <c:changes>
         <c:change date="2021-08-31T00:00:00+00:00" summary="Switch to a global byte-based page numbering">
           <c:tickets>
             <c:ticket id="SIMPLY-3802"/>
           </c:tickets>
         </c:change>
-        <c:change date="2021-08-31T20:06:44+00:00" summary="Handle pinch-and-zoom in fixed layout Epubs">
+        <c:change date="2021-08-31T00:00:00+00:00" summary="Handle pinch-and-zoom in fixed layout Epubs">
           <c:tickets>
             <c:ticket id="SMA-213"/>
+          </c:tickets>
+        </c:change>
+        <c:change date="2021-09-01T17:02:36+00:00" summary="Strip whitespace around usernames and passwords during basic authentication">
+          <c:tickets>
+            <c:ticket id="SMA-200"/>
           </c:tickets>
         </c:change>
       </c:changes>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -159,7 +159,7 @@
         <c:change date="2021-06-16T00:00:00+00:00" summary="Improve R2 behaviour with regards to spaces in filenames inside EPUB files"/>
       </c:changes>
     </c:release>
-    <c:release date="2021-08-25T15:28:04+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.1">
+    <c:release date="2021-08-31T00:00:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="7.0.1">
       <c:changes>
         <c:change date="2021-06-23T00:00:00+00:00" summary="Improve R2 accessibility">
           <c:tickets>
@@ -193,9 +193,23 @@
             <c:ticket id="SMA-205"/>
           </c:tickets>
         </c:change>
-        <c:change date="2021-08-25T15:28:04+00:00" summary="Do not show Holds in SimplyE collection">
+        <c:change date="2021-08-25T00:00:00+00:00" summary="Do not show Holds in SimplyE collection">
           <c:tickets>
             <c:ticket id="SMA-195"/>
+          </c:tickets>
+        </c:change>
+      </c:changes>
+    </c:release>
+    <c:release date="2021-08-31T20:06:44+00:00" is-open="true" ticket-system="org.nypl.jira" version="7.0.2">
+      <c:changes>
+        <c:change date="2021-08-31T00:00:00+00:00" summary="Switch to a global byte-based page numbering">
+          <c:tickets>
+            <c:ticket id="SIMPLY-3802"/>
+          </c:tickets>
+        </c:change>
+        <c:change date="2021-08-31T20:06:44+00:00" summary="Handle pinch-and-zoom in fixed layout Epubs">
+          <c:tickets>
+            <c:ticket id="SMA-213"/>
           </c:tickets>
         </c:change>
       </c:changes>

--- a/build_libraries.gradle
+++ b/build_libraries.gradle
@@ -56,7 +56,7 @@ ext.versions = [
   nypl_overdrive                : '1.0.3',
   nypl_pdf                      : '0.1.0',
   nypl_readium                  : '0.30.0',
-  nypl_readium2                 : '0.0.23',
+  nypl_readium2                 : '0.0.24-SNAPSHOT',
   okhttp3                       : '4.8.1',
   pandora_bottom_navigator      : 'ec834b9',
   picasso                       : '2.71828',

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/NYPL-Simplified/Simplified-Android-C
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/NYPL-Simplified/Simplified-Android-Core
 POM_SCM_URL=http://github.com/NYPL-Simplified/Simplified-Android-Core
 POM_URL=http://github.com/NYPL-Simplified/Simplified-Android-Core
-VERSION_NAME=7.0.1
+VERSION_NAME=7.0.2-SNAPSHOT
 VERSION_CODE_BASE=70000
 
 android.useAndroidX=true

--- a/simplified-books-api/src/main/java/org/nypl/simplified/books/api/Bookmark.kt
+++ b/simplified-books-api/src/main/java/org/nypl/simplified/books/api/Bookmark.kt
@@ -53,7 +53,7 @@ data class Bookmark private constructor(
    */
 
   @Deprecated("Use progress information from the BookLocation")
-  val bookProgress: Double,
+  val bookProgress: Double?,
 
   /**
    * The identifier of the device that created the bookmark, if one is available.
@@ -124,7 +124,7 @@ data class Bookmark private constructor(
       kind: BookmarkKind,
       time: DateTime,
       chapterTitle: String,
-      bookProgress: Double,
+      bookProgress: Double?,
       deviceID: String,
       uri: URI?
     ): Bookmark {

--- a/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/BookmarkAnnotations.kt
+++ b/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/BookmarkAnnotations.kt
@@ -90,7 +90,7 @@ object BookmarkAnnotations {
       kind = BookmarkKind.ofMotivation(annotation.motivation),
       time = time,
       chapterTitle = annotation.body.chapterTitle ?: "",
-      bookProgress = annotation.body.bookProgress?.toDouble() ?: 0.0,
+      bookProgress = annotation.body.bookProgress?.toDouble(),
       uri = if (annotation.id != null) URI.create(annotation.id) else null,
       deviceID = annotation.body.device
     )
@@ -116,7 +116,7 @@ object BookmarkAnnotations {
       if (bookmark.bookProgress == 0.0) {
         null
       } else {
-        bookmark.bookProgress.toFloat()
+        bookmark.bookProgress?.toFloat()
       }
 
     val timestamp =

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountAuthenticationViewBindings.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountAuthenticationViewBindings.kt
@@ -252,11 +252,11 @@ sealed class AccountAuthenticationViewBindings {
     }
 
     fun getPassword(): AccountPassword {
-      return AccountPassword(this.pass.text.toString())
+      return AccountPassword(this.pass.text.toString().trim())
     }
 
     fun getUser(): AccountUsername {
-      return AccountUsername(this.user.text.toString())
+      return AccountUsername(this.user.text.toString().trim())
     }
 
     companion object {

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
@@ -25,7 +25,7 @@ import org.librarysimplified.r2.api.SR2Event.SR2CommandEvent.SR2CommandExecution
 import org.librarysimplified.r2.api.SR2Event.SR2Error.SR2ChapterNonexistent
 import org.librarysimplified.r2.api.SR2Event.SR2Error.SR2WebViewInaccessible
 import org.librarysimplified.r2.api.SR2Event.SR2ExternalLinkSelected
-import org.librarysimplified.r2.api.SR2Locator
+import org.librarysimplified.r2.api.SR2PageNumberingMode
 import org.librarysimplified.r2.api.SR2ScrollingMode.SCROLLING_MODE_CONTINUOUS
 import org.librarysimplified.r2.api.SR2ScrollingMode.SCROLLING_MODE_PAGINATED
 import org.librarysimplified.r2.vanilla.SR2Controllers
@@ -273,7 +273,8 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
         SCROLLING_MODE_CONTINUOUS
       } else {
         SCROLLING_MODE_PAGINATED
-      }
+      },
+      pageNumberingMode = SR2PageNumberingMode.WHOLE_BOOK
     )
   }
 
@@ -317,19 +318,8 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
 
       val lastRead = bookmarks.find { bookmark -> bookmark.type == SR2Bookmark.Type.LAST_READ }
       reference.controller.submitCommand(SR2Command.BookmarksLoad(bookmarks))
-      if (lastRead != null) {
-        reference.controller.submitCommand(SR2Command.OpenChapter(lastRead.locator))
-      } else {
-        val first = reference.controller.bookMetadata.navigationGraph.start()
-        reference.controller.submitCommand(
-          SR2Command.OpenChapter(
-            SR2Locator.SR2LocatorPercent(
-              chapterHref = first.node.navigationPoint.locator.chapterHref,
-              chapterProgress = 0.0
-            )
-          )
-        )
-      }
+      val startLocator = lastRead?.locator ?: reference.controller.bookMetadata.start
+      reference.controller.submitCommand(SR2Command.OpenChapter(startLocator))
     } else {
       // Refresh whatever the controller was looking at previously.
       reference.controller.submitCommand(SR2Command.Refresh)

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Bookmarks.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Bookmarks.kt
@@ -3,7 +3,6 @@ package org.nypl.simplified.viewer.epub.readium2
 import org.librarysimplified.r2.api.SR2BookMetadata
 import org.librarysimplified.r2.api.SR2Bookmark
 import org.librarysimplified.r2.api.SR2Locator
-import org.librarysimplified.r2.api.SR2NavigationNode.SR2NavigationReadingOrderNode
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.books.api.BookChapterProgress
 import org.nypl.simplified.books.api.BookID
@@ -118,42 +117,8 @@ object Reader2Bookmarks {
       is BookLocation.BookLocationR2 ->
         this.r2ToSR2Bookmark(source, location)
       is BookLocation.BookLocationR1 ->
-        this.r1ToSR2Bookmark(bookMetadata, source, location)
+        null // R1 bookmarks are not supported any more.
     }
-  }
-
-  private fun r1ToSR2Bookmark(
-    bookMetadata: SR2BookMetadata,
-    source: Bookmark,
-    location: BookLocation.BookLocationR1
-  ): SR2Bookmark? {
-    val chapter =
-      bookMetadata.navigationGraph.readingOrder.find { chapter -> chapter.title == location.idRef }
-    if (chapter != null) {
-      return toSR2Chapter(chapter, source)
-    }
-    return null
-  }
-
-  private fun toSR2Chapter(
-    chapter: SR2NavigationReadingOrderNode,
-    source: Bookmark
-  ): SR2Bookmark {
-    return SR2Bookmark(
-      date = source.time.toDateTime(),
-      type = when (source.kind) {
-        BookmarkKind.ReaderBookmarkLastReadLocation ->
-          SR2Bookmark.Type.LAST_READ
-        BookmarkKind.ReaderBookmarkExplicit ->
-          SR2Bookmark.Type.EXPLICIT
-      },
-      title = source.chapterTitle,
-      locator = SR2Locator.SR2LocatorPercent(
-        chapterHref = chapter.navigationPoint.locator.chapterHref,
-        chapterProgress = source.chapterProgress
-      ),
-      bookProgress = source.bookProgress
-    )
   }
 
   private fun r2ToSR2Bookmark(


### PR DESCRIPTION
**What's this do?**
Trim whitespace around usernames and passwords in AccountDetailFragment.

**Why are we doing this? (w/ JIRA link if applicable)**
https://jira.nypl.org/browse/SMA-200

**How should this be tested? / Do these changes have associated tests?**
-  Open SimplyE
-   Navigate to the Accounts section
-   Add a library that you are not already logged into for which you have valid credentials (e.g. not SimplyE Collection)
-   Enter your user ID and deliberately add a space at the end
-   Enter your password or PIN
-   Try to log in

**Dependencies for merging? Releasing to production?**
Depends on #928 in order to have an up-to-date changelog.

**Have you updated the changelog?**
Yes, I did.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
Yes, I did.