### PR TITLE
SMA-226: Account identifier disappears

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -222,6 +222,11 @@
             <c:ticket id="SMA-237"/>
           </c:tickets>
         </c:change>
+        <c:change date="2021-09-13T12:27:18+00:00" summary="Account identifier disappears">
+          <c:tickets>
+            <c:ticket id="SMA-226"/>
+          </c:tickets>
+        </c:change>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/BottomNavigators.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/BottomNavigators.kt
@@ -17,6 +17,7 @@ import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.feeds.api.FeedBooksSelection
 import org.nypl.simplified.feeds.api.FeedFacet
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
+import org.nypl.simplified.ui.accounts.AccountListRegistryFragment
 import org.nypl.simplified.ui.catalog.CatalogFeedArguments
 import org.nypl.simplified.ui.catalog.CatalogFeedOwnership
 import org.nypl.simplified.ui.catalog.CatalogFeedFragment
@@ -124,6 +125,7 @@ object BottomNavigators {
         return profile.account(mostRecentId)
       } catch (e: Exception) {
         logger.error("stale account: ", e)
+        throw StaleAccountException("$mostRecentId is a stale account")
       }
     }
 
@@ -197,7 +199,11 @@ object BottomNavigators {
       if (settingsConfiguration.showBooksFromAllAccounts) {
         null
       } else {
-        pickDefaultAccount(profilesController, defaultProvider).id
+        try {
+          pickDefaultAccount(profilesController, defaultProvider).id
+        } catch (e: StaleAccountException) {
+          return AccountListRegistryFragment()
+        }
       }
 
     return CatalogFeedFragment.create(
@@ -229,7 +235,11 @@ object BottomNavigators {
       if (settingsConfiguration.showBooksFromAllAccounts) {
         null
       } else {
-        pickDefaultAccount(profilesController, defaultProvider).id
+        try {
+          pickDefaultAccount(profilesController, defaultProvider).id
+        } catch (e: StaleAccountException) {
+          return AccountListRegistryFragment()
+        }
       }
 
     return CatalogFeedFragment.create(
@@ -252,4 +262,9 @@ object BottomNavigators {
     logger.debug("[{}]: creating catalog fragment", id)
     return CatalogFeedFragment.create(feedArguments)
   }
+
+  /**
+   * Occurs when an profile cannot be accessed for a given ID
+   */
+  class StaleAccountException(message: String) : Exception(message)
 }


### PR DESCRIPTION
**What's this do?**
Here a new custom exception has been added to `BottomNavigators.kt`. When the most recent account is accessed and it is stale for whatever reason, `StaleAccountException` is thrown and as a result the `AccountListRegistryFragment()` is returned so the user has to pick their account again.

**Why are we doing this? (w/ JIRA link if applicable)**
[SMA-226: Account identifier disappears](https://jira.nypl.org/browse/SMA-226)

**How should this be tested? / Do these changes have associated tests?**
This fix can be tested by modifying the SharedPreferences for the app.
1. Navigate to `/data/data/org.nypl.simplified.simplye/files/profiles/*/profile.json`
View > Tool Windows > Device File Explorer or click the Device File Explorer
2. Delete `mostRecentAccount` entry.
3. Restart the app.

Desired Result: Whenever the user gets to a point where the account identifier is blank resulting from the most recent account being null, the user is prompted to select an account

**Dependencies for merging? Releasing to production?**
n/a

**Have you updated the changelog?**
Done.

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
TBD
